### PR TITLE
chore: add in go-releaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,17 @@
 name: GoReleaser
 
-# GoReleaser should only run when a new git tag is pushed, which is
-# what release-please does when the Release PR is merged.
+# GoReleaser should run when release-please creates a new release.
+# Note: release-please creates tags via GitHub API, not git push,
+# so we trigger on the release event instead of push to tags.
 on:
-  push:
-    tags:
-      - 'v*' # Run for all tags starting with 'v', which is the default for release-please
+  release:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g., v0.1.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write # Needed for GoReleaser to upload artifacts to the release
@@ -14,25 +20,30 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      # 1. Checkout the code
+      # 1. Checkout the code at the tag
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0 # GoReleaser requires full git history
+          fetch-depth: 0
+          ref: ${{ inputs.tag || github.event.release.tag_name }}
 
       # 2. Setup Go
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25' # Or your required Go version
+          go-version: '1.25'
 
-      # 3. Run GoReleaser
+      # 3. Generate pricing data for embedding
+      - name: Generate pricing data
+        run: make generate-pricing
+
+      # 4. Run GoReleaser
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean # Run the release command
+          args: release --clean
         env:
-          # A token with 'contents: write' is needed
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,6 @@
     ".": {
       "release-type": "go",
       "package-name": "pulumicost-plugin-aws-public",
-      "release-as": "0.0.1",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "changelog-sections": [


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate releases using GoReleaser. The workflow is triggered when a new git tag starting with 'v' is pushed, ensuring that releases are automatically built and published.

Release automation:

* Added a `.github/workflows/release.yml` workflow that runs GoReleaser on new version tags, checks out the repository with full history, sets up Go, and uploads release artifacts using a GitHub token with appropriate permissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated release workflow that runs on release creation and manual dispatch (with tag input), builds artifacts with Go 1.25, and publishes releases via GoReleaser.
  * Removed the explicit root package release version from the release configuration so versioning is no longer fixed in config.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->