### PR TITLE
feat: add support for additional US regions (us-west-1, us-gov-west-1…

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,7 +3,7 @@ version: 2
 before:
   hooks:
     # Generate pricing data for all regions before building
-    - go run ./tools/generate-pricing --regions us-east-1,us-west-2,eu-west-1,ap-southeast-1,ap-southeast-2,ap-northeast-1,ap-south-1,ca-central-1,sa-east-1 --out-dir ./internal/pricing/data
+    - go run ./tools/generate-pricing --regions us-east-1,us-west-1,us-west-2,us-gov-west-1,us-gov-east-1,eu-west-1,ap-southeast-1,ap-southeast-2,ap-northeast-1,ap-south-1,ca-central-1,sa-east-1 --out-dir ./internal/pricing/data
 
 builds:
   # us-east-1 binary
@@ -39,6 +39,60 @@ builds:
       - arm64
     tags:
       - region_usw2
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+
+  # us-west-1 binary
+  - id: us-west-1
+    main: ./cmd/pulumicost-plugin-aws-public
+    binary: pulumicost-plugin-aws-public-us-west-1
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    tags:
+      - region_usw1
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+
+  # us-gov-west-1 binary
+  - id: us-gov-west-1
+    main: ./cmd/pulumicost-plugin-aws-public
+    binary: pulumicost-plugin-aws-public-us-gov-west-1
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    tags:
+      - region_govw1
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+
+  # us-gov-east-1 binary
+  - id: us-gov-east-1
+    main: ./cmd/pulumicost-plugin-aws-public
+    binary: pulumicost-plugin-aws-public-us-gov-east-1
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    tags:
+      - region_gove1
     ldflags:
       - -s -w -X main.version={{.Version}}
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,3 +29,10 @@
 - One resource per RPC call (no batching)
 - Region-specific binaries with build tags
 - Thread-safe pricing lookups for concurrent gRPC calls
+
+## Active Technologies
+- Go 1.25.4 minimum + gRPC (pulumicost.v1), pluginsdk, embedded pricing data (006-add-us-regions)
+- Embedded pricing data (no external storage) (006-add-us-regions)
+
+## Recent Changes
+- 006-add-us-regions: Added Go 1.25.4 minimum + gRPC (pulumicost.v1), pluginsdk, embedded pricing data

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: help lint test build clean ensure develop generate-pricing build-region build-all-regions
 
 # All supported AWS regions
-REGIONS := us-east-1 us-west-2 eu-west-1 ap-southeast-1 ap-southeast-2 ap-northeast-1 ap-south-1 ca-central-1 sa-east-1
+REGIONS := us-east-1 us-west-1 us-west-2 us-gov-west-1 us-gov-east-1 eu-west-1 ap-southeast-1 ap-southeast-2 ap-northeast-1 ap-south-1 ca-central-1 sa-east-1
 
 help: ## Show this help message
 	@echo "Available targets:"

--- a/internal/pricing/embed_fallback.go
+++ b/internal/pricing/embed_fallback.go
@@ -1,4 +1,4 @@
-//go:build !region_use1 && !region_usw2 && !region_euw1 && !region_apse1 && !region_apse2 && !region_apne1 && !region_aps1 && !region_cac1 && !region_sae1
+//go:build !region_use1 && !region_usw1 && !region_usw2 && !region_govw1 && !region_gove1 && !region_euw1 && !region_apse1 && !region_apse2 && !region_apne1 && !region_aps1 && !region_cac1 && !region_sae1
 
 package pricing
 

--- a/internal/pricing/embed_gove1.go
+++ b/internal/pricing/embed_gove1.go
@@ -1,0 +1,8 @@
+//go:build region_gove1
+
+package pricing
+
+import _ "embed"
+
+//go:embed data/aws_pricing_us-gov-east-1.json
+var rawPricingJSON []byte

--- a/internal/pricing/embed_govw1.go
+++ b/internal/pricing/embed_govw1.go
@@ -1,0 +1,8 @@
+//go:build region_govw1
+
+package pricing
+
+import _ "embed"
+
+//go:embed data/aws_pricing_us-gov-west-1.json
+var rawPricingJSON []byte

--- a/internal/pricing/embed_usw1.go
+++ b/internal/pricing/embed_usw1.go
@@ -1,0 +1,8 @@
+//go:build region_usw1
+
+package pricing
+
+import _ "embed"
+
+//go:embed data/aws_pricing_us-west-1.json
+var rawPricingJSON []byte

--- a/scripts/build-region.sh
+++ b/scripts/build-region.sh
@@ -28,7 +28,10 @@ fi
 # Map region to build tag
 declare -A REGION_TAGS=(
     ["us-east-1"]="region_use1"
+    ["us-west-1"]="region_usw1"
     ["us-west-2"]="region_usw2"
+    ["us-gov-west-1"]="region_govw1"
+    ["us-gov-east-1"]="region_gove1"
     ["eu-west-1"]="region_euw1"
     ["ap-southeast-1"]="region_apse1"
     ["ap-southeast-2"]="region_apse2"

--- a/scripts/region-tag.sh
+++ b/scripts/region-tag.sh
@@ -5,7 +5,10 @@
 
 case "$1" in
     us-east-1)      echo "use1" ;;
+    us-west-1)      echo "usw1" ;;
     us-west-2)      echo "usw2" ;;
+    us-gov-west-1)  echo "govw1" ;;
+    us-gov-east-1)  echo "gove1" ;;
     eu-west-1)      echo "euw1" ;;
     ap-southeast-1) echo "apse1" ;;
     ap-southeast-2) echo "apse2" ;;
@@ -16,7 +19,8 @@ case "$1" in
     *)
         echo "Unknown region: $1" >&2
         echo "Supported regions:" >&2
-        echo "  us-east-1, us-west-2, eu-west-1" >&2
+        echo "  us-east-1, us-west-1, us-west-2, us-gov-west-1, us-gov-east-1" >&2
+        echo "  eu-west-1" >&2
         echo "  ap-southeast-1, ap-southeast-2, ap-northeast-1, ap-south-1" >&2
         echo "  ca-central-1, sa-east-1" >&2
         exit 1

--- a/specs/006-add-us-regions/checklists/requirements.md
+++ b/specs/006-add-us-regions/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Add support for additional US regions (us-west-1, us-gov-west-1, us-gov-east-1)
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-11-30
+**Feature**: specs/006-add-us-regions/spec.md
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before /speckit.clarify or /speckit.plan

--- a/specs/006-add-us-regions/contracts/01-name-rpc.md
+++ b/specs/006-add-us-regions/contracts/01-name-rpc.md
@@ -1,0 +1,107 @@
+# Contract: Name() RPC
+
+**Service**: `pulumicost.v1.CostSourceService`
+**Method**: `Name`
+**Purpose**: Returns the plugin identifier for routing and discovery
+
+---
+
+## RPC Signature
+
+```protobuf
+rpc Name(NameRequest) returns (NameResponse);
+```
+
+---
+
+## Request
+
+```protobuf
+message NameRequest {
+  // Empty - no parameters needed
+}
+```
+
+**Validation**: None required (empty message)
+
+---
+
+## Response
+
+```protobuf
+message NameResponse {
+  string name = 1;  // Plugin identifier
+}
+```
+
+**Contract**:
+- `name` MUST be `"aws-public"` for this plugin
+- `name` MUST be consistent across all invocations
+- `name` MUST match the plugin identifier expected by PulumiCost core
+
+---
+
+## Implementation
+
+```go
+func (p *AWSPublicPlugin) Name(
+    ctx context.Context,
+    req *pbc.NameRequest,
+) (*pbc.NameResponse, error) {
+    return &pbc.NameResponse{
+        Name: "aws-public",
+    }, nil
+}
+```
+
+---
+
+## Success Criteria
+
+- Returns `NameResponse{name: "aws-public"}` in < 10ms
+- Never returns an error
+- Response is identical for all region-specific binaries
+
+---
+
+## Error Cases
+
+**None** - this RPC always succeeds.
+
+---
+
+## Testing
+
+```bash
+# grpcurl test
+grpcurl -plaintext localhost:12345 pulumicost.v1.CostSourceService/Name
+
+# Expected response:
+{
+  "name": "aws-public"
+}
+```
+
+**Unit Test**:
+```go
+func TestName(t *testing.T) {
+    p := NewAWSPublicPlugin("us-west-1", &mockPricingClient{})
+
+    resp, err := p.Name(context.Background(), &pbc.NameRequest{})
+
+    require.NoError(t, err)
+    assert.Equal(t, "aws-public", resp.Name)
+}
+```
+
+---
+
+## Usage by PulumiCost Core
+
+1. Core starts the plugin subprocess
+2. Core reads PORT from stdout
+3. Core connects gRPC client
+4. Core calls Name() to verify plugin identity
+5. Core uses the name for logging and routing
+
+**Frequency**: Once per plugin instance (on startup)

--- a/specs/006-add-us-regions/data-model.md
+++ b/specs/006-add-us-regions/data-model.md
@@ -1,0 +1,56 @@
+# Data Model: Add support for additional US regions
+
+## Entities
+
+### Region
+Represents an AWS region with its associated pricing data and configuration.
+
+**Attributes:**
+- `Name`: string - Region identifier (e.g., "us-west-1", "us-gov-west-1")
+- `DisplayName`: string - Human-readable name (e.g., "N. California", "AWS GovCloud US-West")
+- `PricingData`: map[string]PricingData - Service-specific pricing information
+- `BuildTag`: string - Go build tag for region-specific compilation (e.g., "region_usw1")
+
+**Relationships:**
+- Contains multiple PricingData entries
+- Referenced by build configuration
+
+### PricingData
+Contains cost information for AWS services within a specific region.
+
+**Attributes:**
+- `Service`: string - AWS service name (e.g., "EC2", "S3", "EBS")
+- `ResourceType`: string - Specific resource type (e.g., "t3.micro", "gp2")
+- `UnitPrice`: float64 - Cost per unit (e.g., per hour, per GB)
+- `Currency`: string - Currency code (e.g., "USD")
+- `BillingUnit`: string - Unit of measurement (e.g., "Hrs", "GB-Mo")
+
+**Relationships:**
+- Belongs to a Region
+- Used for cost calculations
+
+### BuildConfiguration
+Defines how region-specific binaries are built and deployed.
+
+**Attributes:**
+- `Region`: string - Target region name
+- `BuildTag`: string - Go build tag
+- `BinaryName`: string - Output binary name (e.g., "pulumicost-plugin-aws-public-us-west-1")
+- `EmbedFile`: string - Path to embedded pricing data file
+
+**Relationships:**
+- References a Region
+- Used by GoReleaser configuration
+
+## Validation Rules
+
+- Region names must follow AWS naming conventions
+- Pricing data must be non-negative
+- Build tags must be unique across regions
+- Currency must be supported (currently USD only)
+
+## State Transitions
+
+- Region: Static (no state changes)
+- PricingData: Updated via data generation tools (no runtime changes)
+- BuildConfiguration: Modified during build process

--- a/specs/006-add-us-regions/plan.md
+++ b/specs/006-add-us-regions/plan.md
@@ -1,0 +1,112 @@
+# Implementation Plan: Add support for additional US regions (us-west-1, us-gov-west-1, us-gov-east-1)
+
+**Branch**: `006-add-us-regions` | **Date**: 2025-11-30 | **Spec**: specs/006-add-us-regions/spec.md
+**Input**: Feature specification from `/specs/006-add-us-regions/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+Add pricing data and build configurations for us-west-1, us-gov-west-1, and us-gov-east-1 regions to the PulumiCost AWS plugin. Implement region-specific binaries with embedded pricing data, following the existing pattern of build tags and GoReleaser configuration.
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: Go 1.25.4 minimum
+**Primary Dependencies**: gRPC (pulumicost.v1), pluginsdk, embedded pricing data
+**Storage**: Embedded pricing data (no external storage)
+**Testing**: Go testing framework, integration tests for gRPC methods
+**Target Platform**: Linux (cross-compiled Go binaries)
+**Project Type**: Single project (gRPC plugin service)
+**Performance Goals**: GetProjectedCost() < 100ms, Supports() < 10ms, startup < 500ms
+**Constraints**: Thread-safe concurrent RPC calls, region-specific binaries with build tags, embedded data only
+**Scale/Scope**: Support 3 additional regions, handle 100+ concurrent RPC calls
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+✅ **PASS**: Feature complies with all constitution principles
+
+- **Code Quality & Simplicity**: Adding region support follows existing patterns (build tags, embed files) without introducing complexity
+- **Testing Discipline**: Will add unit and integration tests following existing patterns
+- **Protocol & Interface Consistency**: Uses existing gRPC methods, adds new build tags for regions
+- **Performance & Reliability**: Maintains embedded data approach and performance targets
+- **Build & Release Quality**: Extends existing GoReleaser configuration for new regions
+- **Security**: No changes to security model, maintains embedded data approach
+- **Development Workflow**: Follows established branch naming and commit conventions
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/[###-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
+```text
+# Go project structure (single binary plugin)
+cmd/pulumicost-plugin-aws-public/
+└── main.go                    # Plugin entry point
+
+internal/
+├── plugin/
+│   ├── plugin.go              # gRPC service implementation
+│   ├── supports.go            # Supports() method
+│   ├── estimate.go            # GetProjectedCost() method
+│   ├── actual.go              # GetActualCost() method
+│   ├── supports_test.go       # Unit tests
+│   ├── estimate_test.go       # Unit tests
+│   └── integration_test.go    # Integration tests
+└── pricing/
+    ├── client.go              # Pricing data client
+    ├── types.go               # Pricing data types
+    ├── embed_use1.go          # Existing us-east-1 pricing data
+    ├── embed_usw2.go          # Existing us-west-2 pricing data
+    ├── embed_euw1.go          # Existing eu-west-1 pricing data
+    ├── embed_usw1.go          # NEW: us-west-1 pricing data
+    ├── embed_govw1.go         # NEW: us-gov-west-1 pricing data
+    ├── embed_gove1.go         # NEW: us-gov-east-1 pricing data
+    └── client_test.go         # Unit tests
+
+scripts/
+├── build-region.sh           # Build script for regions
+├── region-tag.sh             # Region tag management
+└── release-region.sh         # Release script for regions
+
+tools/generate-pricing/
+└── main.go                   # Pricing data generator
+
+.goreleaser.yaml              # UPDATED: New region builds
+Makefile                      # Build targets
+```
+
+**Structure Decision**: Single Go project following existing repository structure. New embed files added to internal/pricing/ following the established pattern. Build configuration updated in .goreleaser.yaml to include new region binaries.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/006-add-us-regions/quickstart.md
+++ b/specs/006-add-us-regions/quickstart.md
@@ -1,0 +1,55 @@
+# Quickstart: Add support for additional US regions
+
+## Prerequisites
+
+- Go 1.25.4 or later
+- Make sure `make lint` and `make test` pass on main branch
+
+## Building New Regions
+
+### Build us-west-1 region
+```bash
+make build-region REGION=us-west-1
+```
+
+### Build us-gov-west-1 region
+```bash
+make build-region REGION=us-gov-west-1
+```
+
+### Build us-gov-east-1 region
+```bash
+make build-region REGION=us-gov-east-1
+```
+
+## Testing New Regions
+
+### Run all tests
+```bash
+make test
+```
+
+### Test specific region integration
+```bash
+# Test us-west-1
+go test ./internal/plugin -run TestIntegration_usw1 -v
+
+# Test us-gov-west-1
+go test ./internal/plugin -run TestIntegration_govw1 -v
+
+# Test us-gov-east-1
+go test ./internal/plugin -run TestIntegration_gove1 -v
+```
+
+## Verification
+
+1. Check that binaries are created in `dist/` directory
+2. Verify pricing data is embedded correctly
+3. Test gRPC endpoints with grpcurl
+4. Confirm GovCloud pricing differs from commercial regions
+
+## Troubleshooting
+
+- If build fails, check that pricing data generation completed successfully
+- Ensure build tags are correctly defined in Go files
+- Verify .goreleaser.yaml includes new region configurations

--- a/specs/006-add-us-regions/research.md
+++ b/specs/006-add-us-regions/research.md
@@ -1,0 +1,32 @@
+# Research Findings: Add support for additional US regions (us-west-1, us-gov-west-1, us-gov-east-1)
+
+## GovCloud Pricing Differences
+
+**Decision:** GovCloud regions (us-gov-west-1, us-gov-east-1) require separate pricing data that differs from commercial regions
+
+**Rationale:** AWS GovCloud (US) is physically and logically isolated from standard AWS regions, with pricing that reflects the specialized infrastructure and compliance requirements. Pricing data must be region-specific and embedded at build time, following the existing pattern for commercial regions.
+
+**Alternatives considered:**
+- Using commercial pricing for GovCloud regions (rejected: inaccurate cost estimates)
+- Fetching pricing at runtime (rejected: violates embedded data principle and performance requirements)
+- Single pricing dataset for all regions (rejected: GovCloud isolation and pricing differences)
+
+## Build Tag Strategy
+
+**Decision:** Use build tags `region_usw1`, `region_govw1`, `region_gove1` following existing naming convention
+
+**Rationale:** Maintains consistency with current regions (us-east-1 = use1, us-west-2 = usw2), enables selective compilation of region-specific binaries.
+
+**Alternatives considered:**
+- Different naming scheme (rejected: breaks consistency)
+- No build tags (rejected: would embed all pricing data, violating memory constraints)
+
+## Pricing Data Sources
+
+**Decision:** Generate pricing data using existing tools/generate-pricing/main.go with region-specific API calls
+
+**Rationale:** Leverages existing infrastructure for pricing data generation, ensures data accuracy and consistency with current regions.
+
+**Alternatives considered:**
+- Manual pricing data entry (rejected: error-prone and maintenance intensive)
+- Third-party pricing APIs (rejected: may not be reliable or up-to-date)

--- a/specs/006-add-us-regions/spec.md
+++ b/specs/006-add-us-regions/spec.md
@@ -1,0 +1,120 @@
+# Feature Specification: Add support for additional US regions (us-west-1, us-gov-west-1, us-gov-east-1)
+
+**Feature Branch**: `006-add-us-regions`  
+**Created**: 2025-11-30  
+**Status**: Draft  
+**Input**: User description: "title:	Add support for additional US regions (us-west-1, us-gov-west-1, us-gov-east-1)
+state:	OPEN
+author:	rshade
+labels:	enhancement
+comments:	0
+assignees:	
+projects:	
+milestone:	
+number:	4
+--
+### Description
+Add pricing data and build configurations for:
+
+- **us-west-1** (N. California)
+- **us-gov-west-1** (AWS GovCloud US-West)
+- **us-gov-east-1** (AWS GovCloud US-East)
+
+**Note:** GovCloud regions may have different pricing than commercial regions.
+
+### Implementation Tasks
+- [ ] Add build tags: `region_usw1`, `region_govw1`, `region_gove1`
+- [ ] Create embed files
+- [ ] Update `.goreleaser.yaml`
+- [ ] Research GovCloud pricing differences
+- [ ] Update pricing generator
+- [ ] Add tests
+- [ ] Update documentation
+
+### Acceptance Criteria
+- All US region binaries build successfully
+- GovCloud pricing is accurate
+- Tests pass"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Get pricing for us-west-1 region (Priority: P1)
+
+As a user estimating AWS costs, I want to get accurate pricing data for the us-west-1 (N. California) region so I can plan my infrastructure costs effectively.
+
+**Why this priority**: This is a core commercial region that users frequently deploy to, enabling immediate value for cost estimation.
+
+**Independent Test**: Can be fully tested by requesting projected costs for resources in us-west-1 and verifying accurate pricing data is returned.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource configuration in us-west-1, **When** requesting projected costs, **Then** accurate pricing data for us-west-1 is returned
+2. **Given** an invalid region request, **When** requesting projected costs, **Then** appropriate error is returned
+
+---
+
+### User Story 2 - Get pricing for us-gov-west-1 region (Priority: P1)
+
+As a user in government or regulated industries, I want to get accurate pricing data for the us-gov-west-1 (AWS GovCloud US-West) region so I can estimate costs for compliant infrastructure.
+
+**Why this priority**: GovCloud regions serve specialized users with compliance requirements, providing essential functionality for this user segment.
+
+**Independent Test**: Can be fully tested by requesting projected costs for resources in us-gov-west-1 and verifying GovCloud-specific pricing data is returned.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource configuration in us-gov-west-1, **When** requesting projected costs, **Then** accurate GovCloud pricing data for us-gov-west-1 is returned
+2. **Given** a request for GovCloud pricing, **When** the pricing differs from commercial regions, **Then** the correct GovCloud rates are applied
+
+---
+
+### User Story 3 - Get pricing for us-gov-east-1 region (Priority: P1)
+
+As a user in government or regulated industries, I want to get accurate pricing data for the us-gov-east-1 (AWS GovCloud US-East) region so I can estimate costs for compliant infrastructure.
+
+**Why this priority**: GovCloud regions serve specialized users with compliance requirements, providing essential functionality for this user segment.
+
+**Independent Test**: Can be fully tested by requesting projected costs for resources in us-gov-east-1 and verifying GovCloud-specific pricing data is returned.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource configuration in us-gov-east-1, **When** requesting projected costs, **Then** accurate GovCloud pricing data for us-gov-east-1 is returned
+2. **Given** a request for GovCloud pricing, **When** the pricing differs from commercial regions, **Then** the correct GovCloud rates are applied
+
+### Edge Cases
+
+- What happens when GovCloud pricing data is unavailable or outdated?
+- How does the system handle requests for regions not yet supported?
+- What if commercial and GovCloud pricing structures differ significantly?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide accurate pricing data for us-west-1 region
+- **FR-002**: System MUST provide accurate pricing data for us-gov-west-1 region  
+- **FR-003**: System MUST provide accurate pricing data for us-gov-east-1 region
+- **FR-004**: System MUST use GovCloud-specific pricing for GovCloud regions when it differs from commercial pricing
+- **FR-005**: System MUST build successfully for all new US region configurations
+- **FR-006**: System MUST pass all tests for the new regions
+
+### Key Entities *(include if feature involves data)*
+
+- **Region**: Represents an AWS region with its pricing data and configuration
+- **Pricing Data**: Contains cost information for AWS services within a specific region
+- **Build Configuration**: Defines how binaries are built for specific regions
+
+## Assumptions
+
+- GovCloud pricing data is available and can be obtained from AWS pricing APIs
+- The pricing structure for GovCloud regions follows similar patterns to commercial regions
+- Build configurations can be extended to support additional regions without major architectural changes
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All US region binaries build successfully without errors
+- **SC-002**: GovCloud pricing data is accurate and reflects actual AWS pricing
+- **SC-003**: All automated tests pass for the new regions
+- **SC-004**: Users can successfully request and receive projected costs for all three new regions

--- a/specs/006-add-us-regions/tasks.md
+++ b/specs/006-add-us-regions/tasks.md
@@ -1,0 +1,205 @@
+# Tasks: Add support for additional US regions (us-west-1, us-gov-west-1, us-gov-east-1)
+
+**Input**: Design documents from `/specs/006-add-us-regions/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/
+
+**Tests**: Included as requested in feature specification (integration tests for each region)
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Go project**: `cmd/`, `internal/`, `scripts/`, `.goreleaser.yaml` at repository root
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Update tools and scripts to support new regions
+
+- [ ] T001 Update pricing generator to support us-west-1, us-gov-west-1, us-gov-east-1 regions in tools/generate-pricing/main.go
+- [ ] T002 [P] Add region mappings for new regions in scripts/region-tag.sh
+- [ ] T003 [P] Update build scripts for new regions in scripts/build-region.sh
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core build configuration that MUST be complete before ANY region can be implemented
+
+**⚠️ CRITICAL**: No region work can begin until this phase is complete
+
+- [ ] T004 Add build tags region_usw1, region_govw1, region_gove1 to relevant Go files
+- [ ] T005 Update .goreleaser.yaml with new region configurations for us-west-1, us-gov-west-1, us-gov-east-1
+- [ ] T006 Verify build system works with new region configurations
+
+**Checkpoint**: Foundation ready - region implementation can now begin in parallel
+
+---
+
+## Phase 3: User Story 1 - Get pricing for us-west-1 region (Priority: P1) 🎯 MVP
+
+**Goal**: Enable accurate cost estimation for AWS resources in us-west-1 (N. California) region
+
+**Independent Test**: Request projected costs for resources in us-west-1 and verify pricing data is returned without errors
+
+### Tests for User Story 1 ⚠️
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T007 [P] [US1] Integration test for us-west-1 region in internal/plugin/integration_usw1_test.go
+
+### Implementation for User Story 1
+
+- [ ] T008 [US1] Generate pricing data for us-west-1 region using tools/generate-pricing/
+- [ ] T009 [US1] Create embed_usw1.go with us-west-1 pricing data in internal/pricing/embed_usw1.go
+- [ ] T010 [US1] Update pricing client to support us-west-1 region in internal/pricing/client.go
+
+**Checkpoint**: At this point, User Story 1 should be fully functional and testable independently
+
+---
+
+## Phase 4: User Story 2 - Get pricing for us-gov-west-1 region (Priority: P1)
+
+**Goal**: Enable accurate cost estimation for AWS resources in us-gov-west-1 (AWS GovCloud US-West) region
+
+**Independent Test**: Request projected costs for resources in us-gov-west-1 and verify GovCloud-specific pricing data is returned
+
+### Tests for User Story 2 ⚠️
+
+- [ ] T011 [P] [US2] Integration test for us-gov-west-1 region in internal/plugin/integration_govw1_test.go
+
+### Implementation for User Story 2
+
+- [ ] T012 [US2] Generate pricing data for us-gov-west-1 region using tools/generate-pricing/
+- [ ] T013 [US2] Create embed_govw1.go with us-gov-west-1 pricing data in internal/pricing/embed_govw1.go
+- [ ] T014 [US2] Update pricing client to support us-gov-west-1 region in internal/pricing/client.go
+
+**Checkpoint**: At this point, User Stories 1 AND 2 should both work independently
+
+---
+
+## Phase 5: User Story 3 - Get pricing for us-gov-east-1 region (Priority: P1)
+
+**Goal**: Enable accurate cost estimation for AWS resources in us-gov-east-1 (AWS GovCloud US-East) region
+
+**Independent Test**: Request projected costs for resources in us-gov-east-1 and verify GovCloud-specific pricing data is returned
+
+### Tests for User Story 3 ⚠️
+
+- [ ] T015 [P] [US3] Integration test for us-gov-east-1 region in internal/plugin/integration_gove1_test.go
+
+### Implementation for User Story 3
+
+- [ ] T016 [US3] Generate pricing data for us-gov-east-1 region using tools/generate-pricing/
+- [ ] T017 [US3] Create embed_gove1.go with us-gov-east-1 pricing data in internal/pricing/embed_gove1.go
+- [ ] T018 [US3] Update pricing client to support us-gov-east-1 region in internal/pricing/client.go
+
+**Checkpoint**: All user stories should now be independently functional
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final improvements and validation
+
+- [ ] T019 [P] Update README.md with new supported regions
+- [ ] T020 Run make test to ensure all tests pass
+- [ ] T021 Run make build-region for all new regions to verify builds
+- [ ] T022 Update CHANGELOG.md with new region support
+- [ ] T023 Validate quickstart.md instructions work correctly
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories (Phase 3-5)**: All depend on Foundational phase completion
+  - User stories can proceed in parallel (if staffed)
+  - Or sequentially in priority order (P1 → P2 → P3)
+- **Polish (Phase 6)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational (Phase 2) - No dependencies on other stories
+- **User Story 2 (P1)**: Can start after Foundational (Phase 2) - No dependencies on other stories
+- **User Story 3 (P1)**: Can start after Foundational (Phase 2) - No dependencies on other stories
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation
+- Pricing data generation before embed file creation
+- Embed file before client updates
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+- All Setup tasks marked [P] can run in parallel
+- All Foundational tasks marked [P] can run in parallel (within Phase 2)
+- Once Foundational phase completes, all user stories can start in parallel (if team capacity allows)
+- All tests for a user story marked [P] can run in parallel
+- Different user stories can be worked on in parallel by different team members
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch test for User Story 1:
+Task: "Integration test for us-west-1 region in internal/plugin/integration_usw1_test.go"
+
+# Launch implementation for User Story 1:
+Task: "Generate pricing data for us-west-1 region using tools/generate-pricing/"
+Task: "Create embed_usw1.go with us-west-1 pricing data in internal/pricing/embed_usw1.go"
+Task: "Update pricing client to support us-west-1 region in internal/pricing/client.go"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (CRITICAL - blocks all stories)
+3. Complete Phase 3: User Story 1
+4. **STOP and VALIDATE**: Test User Story 1 independently
+5. Deploy/demo if ready
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational → Foundation ready
+2. Add User Story 1 → Test independently → Deploy/Demo (MVP!)
+3. Add User Story 2 → Test independently → Deploy/Demo
+4. Add User Story 3 → Test independently → Deploy/Demo
+5. Each story adds value without breaking previous stories
+
+### Parallel Team Strategy
+
+With multiple developers:
+
+1. Team completes Setup + Foundational together
+2. Once Foundational is done:
+   - Developer A: User Story 1 (us-west-1)
+   - Developer B: User Story 2 (us-gov-west-1)
+   - Developer C: User Story 3 (us-gov-east-1)
+3. Stories complete and integrate independently
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Verify tests fail before implementing
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- Avoid: vague tasks, same file conflicts, cross-story dependencies that break independence


### PR DESCRIPTION
…, us-gov-east-1)

Add pricing data and build configurations for three additional US AWS regions:

- us-west-1 (N. California) - commercial region
- us-gov-west-1 (AWS GovCloud US-West) - government region
- us-gov-east-1 (AWS GovCloud US-East) - government region

## Changes

- **Pricing Data**: Generated actual AWS pricing data for all three regions using the pricing API
- **Build Configuration**: Added region-specific build tags and GoReleaser configurations
- **Embed Files**: Created region-specific pricing data embed files with proper build constraints
- **Scripts**: Updated build and region mapping scripts to support new regions
- **Documentation**: Updated plan and spec files for the new regions

## Technical Details

- GovCloud regions use separate pricing data that differs from commercial regions
- All pricing data is fetched from official AWS APIs and embedded at build time
- Region-specific binaries are built with appropriate build tags to include only relevant pricing data
- Follows existing patterns for region support (us-east-1, us-west-2, eu-west-1, etc.)

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded regional support: added us-west-1, us-gov-west-1, and us-gov-east-1 with per-region builds and embedded pricing assets.

* **Documentation**
  * Added Active Technologies and Recent Changes entries noting Go requirement and embedded pricing.

* **Chores**
  * Updated build tags and build/tagging scripts to recognize, validate, and produce per-region artifacts for the new regions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->