### PR TITLE
feat(rds): add RDS cost estimation support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -442,7 +442,6 @@ This allows the user to review and make the commit themselves, and ensures
 the commit message follows conventional commits format.
 
 ## Active Technologies
-
 - **Go 1.25+** with gRPC via pulumicost-spec/sdk/go/pluginsdk
 - **pulumicost-spec** protos for CostSourceService API
 - **zerolog** for structured JSON logging (stderr only)

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -19,21 +19,27 @@ import (
 
 // mockPricingClient is a test double for pricing.PricingClient.
 type mockPricingClient struct {
-	region            string
-	currency          string
-	ec2Prices         map[string]float64 // key: "instanceType/os/tenancy"
-	ebsPrices         map[string]float64 // key: "volumeType"
-	ec2OnDemandCalled int
-	ebsPriceCalled    int
+	region               string
+	currency             string
+	ec2Prices            map[string]float64 // key: "instanceType/os/tenancy"
+	ebsPrices            map[string]float64 // key: "volumeType"
+	rdsInstancePrices    map[string]float64 // key: "instanceType/engine"
+	rdsStoragePrices     map[string]float64 // key: "volumeType"
+	ec2OnDemandCalled    int
+	ebsPriceCalled       int
+	rdsOnDemandCalled    int
+	rdsStoragePriceCalled int
 }
 
 // newMockPricingClient creates a new mockPricingClient with default values.
 func newMockPricingClient(region, currency string) *mockPricingClient {
 	return &mockPricingClient{
-		region:    region,
-		currency:  currency,
-		ec2Prices: make(map[string]float64),
-		ebsPrices: make(map[string]float64),
+		region:            region,
+		currency:          currency,
+		ec2Prices:         make(map[string]float64),
+		ebsPrices:         make(map[string]float64),
+		rdsInstancePrices: make(map[string]float64),
+		rdsStoragePrices:  make(map[string]float64),
 	}
 }
 
@@ -55,6 +61,19 @@ func (m *mockPricingClient) EC2OnDemandPricePerHour(instanceType, os, tenancy st
 func (m *mockPricingClient) EBSPricePerGBMonth(volumeType string) (float64, bool) {
 	m.ebsPriceCalled++
 	price, found := m.ebsPrices[volumeType]
+	return price, found
+}
+
+func (m *mockPricingClient) RDSOnDemandPricePerHour(instanceType, engine string) (float64, bool) {
+	m.rdsOnDemandCalled++
+	key := instanceType + "/" + engine
+	price, found := m.rdsInstancePrices[key]
+	return price, found
+}
+
+func (m *mockPricingClient) RDSStoragePricePerGBMonth(volumeType string) (float64, bool) {
+	m.rdsStoragePriceCalled++
+	price, found := m.rdsStoragePrices[volumeType]
 	return price, found
 }
 

--- a/internal/plugin/supports.go
+++ b/internal/plugin/supports.go
@@ -66,7 +66,7 @@ func (p *AWSPublicPlugin) Supports(ctx context.Context, req *pbc.SupportsRequest
 
 	// Check resource type
 	switch resource.ResourceType {
-	case "ec2", "ebs":
+	case "ec2", "ebs", "rds":
 		// Fully supported
 		p.logger.Info().
 			Str(pluginsdk.FieldTraceID, traceID).
@@ -82,7 +82,7 @@ func (p *AWSPublicPlugin) Supports(ctx context.Context, req *pbc.SupportsRequest
 			Reason:    "",
 		}, nil
 
-	case "s3", "lambda", "rds", "dynamodb":
+	case "s3", "lambda", "dynamodb":
 		// Stub support - returns $0 estimates
 		p.logger.Info().
 			Str(pluginsdk.FieldTraceID, traceID).

--- a/internal/plugin/supports_test.go
+++ b/internal/plugin/supports_test.go
@@ -74,7 +74,7 @@ func TestSupports(t *testing.T) {
 			wantReasonSubstr: "Limited support",
 		},
 		{
-			name: "RDS with limited support",
+			name: "RDS fully supported",
 			req: &pbc.SupportsRequest{
 				Resource: &pbc.ResourceDescriptor{
 					Provider:     "aws",
@@ -83,7 +83,7 @@ func TestSupports(t *testing.T) {
 				},
 			},
 			wantSupported:    true,
-			wantReasonSubstr: "Limited support",
+			wantReasonSubstr: "",
 		},
 		{
 			name: "DynamoDB with limited support",

--- a/internal/pricing/types.go
+++ b/internal/pricing/types.go
@@ -46,3 +46,17 @@ type ebsPrice struct {
 	RatePerGBMonth float64
 	Currency       string
 }
+
+// rdsInstancePrice represents the hourly compute cost for RDS instances
+type rdsInstancePrice struct {
+	Unit       string
+	HourlyRate float64
+	Currency   string
+}
+
+// rdsStoragePrice represents the per-GB-month cost for RDS storage
+type rdsStoragePrice struct {
+	Unit           string
+	RatePerGBMonth float64
+	Currency       string
+}

--- a/specs/009-rds-cost-estimation/checklists/requirements.md
+++ b/specs/009-rds-cost-estimation/checklists/requirements.md
@@ -1,0 +1,48 @@
+# Specification Quality Checklist: RDS Instance Cost Estimation
+
+**Purpose**: Validate specification completeness and quality before planning
+**Created**: 2025-12-02
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Validation Summary
+
+| Category           | Status | Notes                                   |
+| ------------------ | ------ | --------------------------------------- |
+| Content Quality    | PASS   | All items verified                      |
+| Requirements       | PASS   | 14 functional requirements, all testable|
+| Success Criteria   | PASS   | 6 measurable outcomes defined           |
+| Scope              | PASS   | Clear in/out scope boundaries           |
+
+## Notes
+
+- Specification derived from GitHub Issue #52 with comprehensive technical context
+- All pricing dimensions (instance + storage) addressed
+- Default values specified for optional parameters (engine, storage_type, storage_size)
+- Thread-safety requirement explicitly stated
+- All 9 regional binaries requirement captured
+- Clear scope boundaries exclude Multi-AZ, replicas, reserved pricing, Aurora

--- a/specs/009-rds-cost-estimation/data-model.md
+++ b/specs/009-rds-cost-estimation/data-model.md
@@ -1,0 +1,164 @@
+# Data Model: RDS Instance Cost Estimation
+
+**Feature**: 009-rds-cost-estimation
+**Date**: 2025-12-02
+
+## Entity Definitions
+
+### RDS Instance Price
+
+Represents the hourly compute cost for a specific RDS instance type and database engine.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Unit | string | Billing unit, always "Hrs" |
+| HourlyRate | float64 | Cost per hour in USD |
+| Currency | string | Currency code, always "USD" |
+
+**Lookup Key**: `{instanceType}/{engine}` (e.g., `db.t3.medium/MySQL`)
+
+**Cardinality**: ~500-1000 entries per region (varies by engine availability)
+
+### RDS Storage Price
+
+Represents the per-GB-month cost for a specific storage volume type.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| Unit | string | Billing unit, always "GB-Mo" |
+| RatePerGBMonth | float64 | Cost per GB per month in USD |
+| Currency | string | Currency code, always "USD" |
+
+**Lookup Key**: `{volumeType}` (e.g., `gp2`, `gp3`, `io1`)
+
+**Cardinality**: 4-5 entries per region (gp2, gp3, io1, io2, standard)
+
+## Index Structures
+
+### Client Struct Extensions
+
+```go
+type Client struct {
+    // Existing fields
+    region   string
+    currency string
+    once     sync.Once
+    err      error
+    ec2Index map[string]ec2Price
+    ebsIndex map[string]ebsPrice
+
+    // New RDS fields
+    rdsInstanceIndex map[string]rdsInstancePrice  // key: "instanceType/engine"
+    rdsStorageIndex  map[string]rdsStoragePrice   // key: "volumeType"
+}
+```
+
+### Index Key Examples
+
+**Instance Index**:
+
+| Key | Value (HourlyRate) |
+|-----|-------------------|
+| `db.t3.micro/MySQL` | 0.017 |
+| `db.t3.medium/MySQL` | 0.068 |
+| `db.t3.medium/PostgreSQL` | 0.068 |
+| `db.m5.large/MySQL` | 0.171 |
+| `db.m5.large/Oracle` | 0.350 |
+
+**Storage Index**:
+
+| Key | Value (RatePerGBMonth) |
+|-----|------------------------|
+| `gp2` | 0.115 |
+| `gp3` | 0.10 |
+| `io1` | 0.125 |
+| `standard` | 0.10 |
+
+## Input/Output Mapping
+
+### ResourceDescriptor (Input)
+
+```go
+ResourceDescriptor{
+    Provider:     "aws",
+    ResourceType: "rds",
+    Sku:          "db.t3.medium",     // Instance type
+    Region:       "us-east-1",
+    Tags: map[string]string{
+        "engine":       "mysql",      // Database engine (optional, default: mysql)
+        "storage_type": "gp3",        // Volume type (optional, default: gp2)
+        "storage_size": "100",        // GB (optional, default: 20)
+    },
+}
+```
+
+### GetProjectedCostResponse (Output)
+
+```go
+GetProjectedCostResponse{
+    UnitPrice:     0.068,             // Hourly instance rate
+    Currency:      "USD",
+    CostPerMonth:  59.64,             // Instance (49.64) + Storage (10.00)
+    BillingDetail: "RDS db.t3.medium MySQL, 730 hrs/month + 100GB gp3 storage",
+}
+```
+
+## Validation Rules
+
+### Instance Type
+
+- Must start with `db.` prefix (e.g., `db.t3.medium`, `db.m5.large`)
+- Unknown types return $0 with explanatory message
+
+### Engine
+
+- Valid values: `mysql`, `postgres`, `mariadb`, `oracle-se2`, `sqlserver-ex`
+- Unknown engines default to `mysql` with note in billing_detail
+
+### Storage Type
+
+- Valid values: `gp2`, `gp3`, `io1`, `io2`, `standard` (magnetic)
+- Unknown types default to `gp2` with note in billing_detail
+
+### Storage Size
+
+- Must be positive integer
+- Invalid values (non-numeric, negative, zero) default to 20 GB
+- No maximum enforced (AWS limits vary by instance type)
+
+## Engine Normalization Map
+
+```go
+var engineNormalization = map[string]string{
+    "mysql":        "MySQL",
+    "postgres":     "PostgreSQL",
+    "postgresql":   "PostgreSQL",  // Alias
+    "mariadb":      "MariaDB",
+    "oracle":       "Oracle",
+    "oracle-se2":   "Oracle",      // Standard Edition 2 (license-included)
+    "sqlserver":    "SQL Server",
+    "sqlserver-ex": "SQL Server",  // Express Edition
+    "sql-server":   "SQL Server",  // Alias
+}
+```
+
+## State Transitions
+
+N/A - Pricing data is immutable at runtime (embedded at build time).
+
+## Relationships
+
+```text
+ResourceDescriptor
+    │
+    ├── Sku (instance type) ──────┐
+    │                             ├──► rdsInstanceIndex ──► rdsInstancePrice
+    └── Tags["engine"] ───────────┘
+
+    └── Tags["storage_type"] ─────────► rdsStorageIndex ──► rdsStoragePrice
+```
+
+## Thread Safety
+
+All index maps are populated once during `init()` via `sync.Once`. After initialization,
+maps are read-only, making concurrent access safe without additional locking.

--- a/specs/009-rds-cost-estimation/plan.md
+++ b/specs/009-rds-cost-estimation/plan.md
@@ -1,0 +1,79 @@
+# Implementation Plan: RDS Instance Cost Estimation
+
+**Branch**: `009-rds-cost-estimation` | **Date**: 2025-12-02 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/009-rds-cost-estimation/spec.md`
+
+## Summary
+
+Implement RDS database instance cost estimation using AWS Public Pricing data. This extends
+the existing EC2/EBS pricing pattern to support RDS instance hours (hourly rate × 730) and
+storage costs (per GB-month). Supports MySQL, PostgreSQL, MariaDB, Oracle SE2, and SQL
+Server Express engines with Single-AZ deployment pricing only.
+
+## Technical Context
+
+**Language/Version**: Go 1.25+
+**Primary Dependencies**: gRPC via pulumicost-spec/sdk/go/pluginsdk, zerolog for logging
+**Storage**: Embedded JSON pricing data via `//go:embed`
+**Testing**: Go testing with table-driven tests, mock pricing client
+**Target Platform**: Linux server (9 regional binaries)
+**Project Type**: Single project (gRPC plugin)
+**Performance Goals**: < 100ms per GetProjectedCost() call, < 10ms for Supports()
+**Constraints**: < 50MB memory per binary, thread-safe concurrent access
+**Scale/Scope**: 100 concurrent RPC calls without errors
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| I. Code Quality & Simplicity | PASS | Follows existing EC2/EBS pattern; no new abstractions |
+| II. Testing Discipline | PASS | Table-driven unit tests planned; mock pricing client exists |
+| III. Protocol & Interface Consistency | PASS | Uses proto-defined types; no stdout except PORT |
+| IV. Performance & Reliability | PASS | sync.Once + indexed maps; thread-safe lookups |
+| V. Build & Release Quality | PASS | GoReleaser builds for 9 regions; make lint/test |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/009-rds-cost-estimation/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (N/A - gRPC proto already defined)
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+internal/
+├── plugin/
+│   ├── plugin.go           # Plugin struct (no changes needed)
+│   ├── projected.go        # Add estimateRDS() function, update router
+│   ├── projected_test.go   # Add RDS test cases
+│   └── supports.go         # Move RDS from stub to fully-supported
+├── pricing/
+│   ├── client.go           # Add RDS interface methods, indexes, init logic
+│   ├── types.go            # Add rdsInstancePrice, rdsStoragePrice structs
+│   ├── embed_*.go          # No changes (RDS data embedded in same files)
+│   └── client_test.go      # Add RDS lookup tests
+tools/
+└── generate-pricing/
+    └── main.go             # Add AmazonRDS service code support
+```
+
+**Structure Decision**: Single project structure, extending existing internal packages.
+No new directories needed; RDS support integrates into existing pricing and plugin packages.
+
+## Complexity Tracking
+
+> No constitution violations. All changes follow established patterns.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| N/A | N/A | N/A |

--- a/specs/009-rds-cost-estimation/quickstart.md
+++ b/specs/009-rds-cost-estimation/quickstart.md
@@ -1,0 +1,160 @@
+# Quickstart: RDS Instance Cost Estimation
+
+**Feature**: 009-rds-cost-estimation
+**Date**: 2025-12-02
+
+## Overview
+
+This feature adds RDS database instance cost estimation to the aws-public plugin. After
+implementation, the plugin will return accurate cost estimates for RDS instances including
+compute (instance hours) and storage costs.
+
+## Prerequisites
+
+- Go 1.25+
+- make, golangci-lint
+- grpcurl (for manual testing)
+
+## Build & Test
+
+```bash
+# Run linting
+make lint
+
+# Run all tests
+make test
+
+# Build specific region binary (e.g., us-east-1)
+go build -tags region_use1 -o pulumicost-plugin-aws-public-us-east-1 \
+    ./cmd/pulumicost-plugin-aws-public
+
+# Generate pricing data (includes RDS)
+go run ./tools/generate-pricing \
+    --regions us-east-1 \
+    --service AmazonEC2,AmazonRDS \
+    --out-dir ./data
+```
+
+## Usage Examples
+
+### Basic RDS Query (MySQL)
+
+```bash
+# Start the plugin
+./pulumicost-plugin-aws-public-us-east-1 &
+# Capture: PORT=12345
+
+# Query RDS cost
+grpcurl -plaintext -d '{
+  "resource": {
+    "provider": "aws",
+    "resource_type": "rds",
+    "sku": "db.t3.medium",
+    "region": "us-east-1",
+    "tags": {
+      "engine": "mysql",
+      "storage_type": "gp3",
+      "storage_size": "100"
+    }
+  }
+}' localhost:12345 pulumicost.v1.CostSourceService/GetProjectedCost
+```
+
+**Expected Response**:
+
+```json
+{
+  "unitPrice": 0.068,
+  "currency": "USD",
+  "costPerMonth": 59.64,
+  "billingDetail": "RDS db.t3.medium MySQL, 730 hrs/month + 100GB gp3 storage"
+}
+```
+
+### PostgreSQL with Defaults
+
+```bash
+grpcurl -plaintext -d '{
+  "resource": {
+    "provider": "aws",
+    "resource_type": "rds",
+    "sku": "db.m5.large",
+    "region": "us-east-1",
+    "tags": {
+      "engine": "postgres"
+    }
+  }
+}' localhost:12345 pulumicost.v1.CostSourceService/GetProjectedCost
+```
+
+**Expected Response** (with defaults: gp2, 20GB):
+
+```json
+{
+  "unitPrice": 0.171,
+  "currency": "USD",
+  "costPerMonth": 127.13,
+  "billingDetail": "RDS db.m5.large PostgreSQL, 730 hrs/month + 20GB gp2 storage (defaulted)"
+}
+```
+
+### Supports Query
+
+```bash
+grpcurl -plaintext -d '{
+  "resource": {
+    "provider": "aws",
+    "resource_type": "rds",
+    "sku": "db.t3.medium",
+    "region": "us-east-1"
+  }
+}' localhost:12345 pulumicost.v1.CostSourceService/Supports
+```
+
+**Expected Response**:
+
+```json
+{
+  "supported": true,
+  "reason": "RDS instances supported with instance and storage cost estimation"
+}
+```
+
+## Testing Checklist
+
+- [ ] `make lint` passes
+- [ ] `make test` passes (all existing + new RDS tests)
+- [ ] Manual grpcurl test for MySQL returns expected cost
+- [ ] Manual grpcurl test for PostgreSQL returns expected cost
+- [ ] Supports() returns `supported=true` without "Limited support"
+- [ ] Unknown instance type returns $0 with explanation
+- [ ] Missing engine tag defaults to MySQL
+- [ ] Missing storage tags default to gp2/20GB
+
+## Key Files Modified
+
+| File | Changes |
+|------|---------|
+| `internal/pricing/client.go` | Add RDS interface methods, indexes |
+| `internal/pricing/types.go` | Add `rdsInstancePrice`, `rdsStoragePrice` |
+| `internal/plugin/projected.go` | Add `estimateRDS()`, update router |
+| `internal/plugin/supports.go` | Move RDS to fully-supported |
+| `tools/generate-pricing/main.go` | Support AmazonRDS service |
+
+## Troubleshooting
+
+### "RDS instance type not found in pricing data"
+
+- Verify the instance type starts with `db.` prefix
+- Check the region binary matches the resource region
+- Ensure pricing data was regenerated with `--service AmazonEC2,AmazonRDS`
+
+### "Resource region does not match plugin region"
+
+- Use the correct region-specific binary (e.g., `pulumicost-plugin-aws-public-us-east-1`)
+- Ensure `resource.region` matches the binary's embedded region
+
+### Storage cost seems wrong
+
+- Verify `storage_size` is a valid positive integer string
+- Check `storage_type` is one of: gp2, gp3, io1, io2, standard

--- a/specs/009-rds-cost-estimation/research.md
+++ b/specs/009-rds-cost-estimation/research.md
@@ -1,0 +1,150 @@
+# Research: RDS Instance Cost Estimation
+
+**Feature**: 009-rds-cost-estimation
+**Date**: 2025-12-02
+
+## Research Summary
+
+No critical unknowns requiring clarification. Technical context is well-defined based on
+existing EC2/EBS implementation patterns and AWS Pricing API documentation.
+
+## Decision Log
+
+### 1. AWS Pricing API Structure for RDS
+
+**Decision**: Use AWS Price List API with service code `AmazonRDS`
+
+**Rationale**: The existing `tools/generate-pricing/main.go` already supports parameterized
+service codes. RDS pricing follows the same JSON structure as EC2 with `products` and
+`terms.OnDemand` sections.
+
+**Alternatives Considered**:
+
+- AWS Cost Explorer API: Rejected - requires credentials and provides historical data, not
+  public pricing
+- Web scraping AWS pricing page: Rejected - fragile, against ToS
+
+**URL Pattern**:
+
+```text
+https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonRDS/current/{region}/index.json
+```
+
+### 2. RDS Product Family Filters
+
+**Decision**: Filter by `ProductFamily` values for instance and storage pricing
+
+**Rationale**: AWS Price List JSON uses consistent product family naming. Testing against
+actual API responses confirms these values.
+
+**Filters**:
+
+| Component | ProductFamily | Key Attributes |
+|-----------|---------------|----------------|
+| Instances | `Database Instance` | `dbInstanceClass`, `databaseEngine`, `deploymentOption` |
+| Storage | `Database Storage` | `volumeType`, `storageMedia` |
+
+**Additional Filters for Single-AZ**:
+
+- `deploymentOption == "Single-AZ"` (excludes Multi-AZ pricing)
+- Exclude `Reserved` term types (use only `OnDemand`)
+
+### 3. Database Engine Mapping
+
+**Decision**: Map AWS API engine names to user-friendly tag values
+
+**Rationale**: AWS uses capitalized engine names in the API, but users typically pass
+lowercase values. Normalize input to match AWS naming.
+
+| AWS API Value | User Tag Value | Notes |
+|---------------|----------------|-------|
+| `MySQL` | `mysql` | Community Edition |
+| `PostgreSQL` | `postgres` | Standard PostgreSQL |
+| `MariaDB` | `mariadb` | MariaDB Community |
+| `Oracle` | `oracle-se2` | Standard Edition 2 (license-included) |
+| `SQL Server` | `sqlserver-ex` | Express Edition (license-included) |
+
+**Engine Normalization**: Convert user input to title case for lookup, with special handling
+for Oracle and SQL Server editions.
+
+### 4. Pricing Index Key Structure
+
+**Decision**: Use composite key `{instanceType}/{engine}` for instance pricing
+
+**Rationale**: RDS pricing varies by both instance type AND database engine (unlike EC2
+which varies by OS). The composite key ensures accurate lookups.
+
+**Index Keys**:
+
+- **Instance**: `db.t3.medium/MySQL` → hourly rate
+- **Storage**: `gp2` → rate per GB-month (storage pricing is engine-agnostic for most types)
+
+### 5. Default Values
+
+**Decision**: Use sensible defaults matching typical RDS configurations
+
+| Parameter | Default | Rationale |
+|-----------|---------|-----------|
+| engine | `mysql` | Most popular RDS engine |
+| storage_type | `gp2` | Default RDS storage type |
+| storage_size | `20` GB | AWS minimum for most engines |
+
+### 6. Cost Calculation Formula
+
+**Decision**: Combine instance and storage costs
+
+```text
+monthly_cost = (hourly_rate × 730) + (storage_rate × storage_gb)
+unit_price = hourly_rate (primary cost driver)
+```
+
+**Rationale**: Follows EC2/EBS pattern where `unit_price` represents the atomic billing
+unit (hourly for compute) and `cost_per_month` is the total projected cost.
+
+### 7. Billing Detail Format
+
+**Decision**: Include all assumptions in human-readable format
+
+**Format**:
+
+```text
+RDS {instance_type} {engine}, 730 hrs/month + {size}GB {storage_type} storage
+```
+
+**Examples**:
+
+- `RDS db.t3.medium MySQL, 730 hrs/month + 100GB gp3 storage`
+- `RDS db.m5.large PostgreSQL, 730 hrs/month + 20GB gp2 storage (defaulted)`
+
+### 8. Generate-Pricing Tool Update
+
+**Decision**: Extend existing tool to support multiple services
+
+**Approach**: The tool already accepts `--service` flag. Need to:
+
+1. Call tool twice in GoReleaser (once for AmazonEC2, once for AmazonRDS)
+2. OR modify to accept comma-separated services
+3. Combine both EC2 and RDS data into single embedded JSON per region
+
+**Chosen**: Option 3 - Combine data into single JSON file per region for simpler embedding.
+
+## Best Practices Applied
+
+### From Existing Codebase
+
+1. **Thread-safe initialization**: Use `sync.Once` for parsing embedded data
+2. **Indexed lookups**: Build maps during init, O(1) lookups at runtime
+3. **Performance logging**: Log warning if lookup exceeds 50ms
+4. **Graceful degradation**: Return $0 with explanation for unknown types
+5. **Trace ID propagation**: Pass traceID through all method calls
+
+### From Constitution
+
+1. **KISS**: No new abstractions; extend existing `PricingClient` interface
+2. **Single Responsibility**: `estimateRDS()` handles only RDS, delegates to pricing client
+3. **Proto-defined types**: Use existing `GetProjectedCostResponse` structure
+4. **Table-driven tests**: Test multiple engines/instance types in single test function
+
+## Open Items
+
+None. All technical decisions resolved.

--- a/specs/009-rds-cost-estimation/spec.md
+++ b/specs/009-rds-cost-estimation/spec.md
@@ -1,0 +1,152 @@
+# Feature Specification: RDS Instance Cost Estimation
+
+**Feature Branch**: `009-rds-cost-estimation`
+**Created**: 2025-12-02
+**Status**: Draft
+**Input**: GitHub Issue #52 - feat(rds): implement RDS instance cost estimation
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Basic RDS Instance Cost Query (Priority: P1)
+
+As a cloud cost analyst, I want to get accurate cost estimates for RDS database instances based on instance type and database engine, so that I can understand the compute cost component of my database infrastructure.
+
+**Why this priority**: Instance compute costs represent the primary cost driver for RDS. Without accurate instance pricing, cost estimates are fundamentally incomplete. This is the core value proposition.
+
+**Independent Test**: Can be fully tested by sending a cost query for a db.t3.medium MySQL instance and verifying a non-zero hourly rate is returned with correct monthly calculation (hourly × 730 hours).
+
+**Acceptance Scenarios**:
+
+1. **Given** an RDS resource with instance type "db.t3.medium" and engine "mysql", **When** GetProjectedCost is called, **Then** return accurate hourly rate and monthly cost (hourly × 730)
+2. **Given** an RDS resource with instance type "db.m5.large" and engine "postgres", **When** GetProjectedCost is called, **Then** return accurate hourly rate specific to PostgreSQL engine pricing
+3. **Given** an RDS resource with no engine specified, **When** GetProjectedCost is called, **Then** default to MySQL engine pricing
+
+---
+
+### User Story 2 - RDS Storage Cost Estimation (Priority: P2)
+
+As a cloud cost analyst, I want storage costs included in RDS estimates based on volume type and size, so that I can see the complete database infrastructure cost.
+
+**Why this priority**: Storage is the second major cost component for RDS. Combined with instance costs, this provides a complete basic cost picture.
+
+**Independent Test**: Can be tested by sending a cost query with storage_type and storage_size tags, verifying storage cost is calculated and added to the total monthly cost.
+
+**Acceptance Scenarios**:
+
+1. **Given** an RDS resource with storage_type "gp3" and storage_size "100", **When** GetProjectedCost is called, **Then** include storage cost (100 GB × per-GB rate) in total monthly cost
+2. **Given** an RDS resource with no storage_type specified, **When** GetProjectedCost is called, **Then** default to gp2 storage type
+3. **Given** an RDS resource with no storage_size specified, **When** GetProjectedCost is called, **Then** default to 20 GB storage
+
+---
+
+### User Story 3 - Multi-Engine Support (Priority: P3)
+
+As a cloud cost analyst, I want cost estimates for different database engines (MySQL, PostgreSQL, MariaDB, Oracle, SQL Server), so that I can estimate costs across my diverse database portfolio.
+
+**Why this priority**: Enterprise environments often use multiple database engines. Supporting all major engines ensures broad applicability.
+
+**Independent Test**: Can be tested by querying costs for each supported engine type and verifying engine-specific pricing is returned.
+
+**Acceptance Scenarios**:
+
+1. **Given** an RDS resource with engine "postgres", **When** GetProjectedCost is called, **Then** return PostgreSQL-specific pricing
+2. **Given** an RDS resource with engine "mariadb", **When** GetProjectedCost is called, **Then** return MariaDB-specific pricing
+3. **Given** an RDS resource with engine "oracle-se2", **When** GetProjectedCost is called, **Then** return Oracle Standard Edition 2 pricing
+4. **Given** an RDS resource with engine "sqlserver-ex", **When** GetProjectedCost is called, **Then** return SQL Server Express pricing
+
+---
+
+### User Story 4 - Supports Query for RDS (Priority: P1)
+
+As a PulumiCost core system, I need to query whether this plugin supports RDS resources, so that I can route cost requests to the appropriate plugin.
+
+**Why this priority**: Equal priority to P1 as Supports() is prerequisite for any cost estimation to occur.
+
+**Independent Test**: Can be tested by calling Supports() with resource_type "rds" and verifying supported=true without "Limited support" caveat.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource descriptor with resource_type "rds" and matching region, **When** Supports is called, **Then** return supported=true with reason indicating full support
+2. **Given** a resource descriptor with resource_type "rds" and non-matching region, **When** Supports is called, **Then** return supported=false with region mismatch reason
+
+---
+
+### Edge Cases
+
+- What happens when an unknown instance type is provided?
+  - Return $0 cost with explanatory billing_detail message
+- What happens when an unsupported database engine is specified?
+  - Default to MySQL pricing with note in billing_detail
+- How does system handle invalid storage_size values (non-numeric, negative)?
+  - Default to 20 GB with note in billing_detail
+- What happens when storage_type is not recognized?
+  - Default to gp2 with note in billing_detail
+- How does system handle concurrent RDS pricing lookups?
+  - Thread-safe access to pricing indexes ensures correct results
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST return accurate hourly rates for RDS instance types (db.t3.*, db.m5.*, db.r5.*, etc.)
+- **FR-002**: System MUST support MySQL, PostgreSQL, MariaDB, Oracle Standard Edition 2, and SQL Server Express engines
+- **FR-003**: System MUST calculate monthly instance cost as hourly_rate × 730 hours
+- **FR-004**: System MUST calculate storage cost based on volume type (gp2, gp3, io1, magnetic) and size in GB
+- **FR-005**: System MUST combine instance cost and storage cost for total monthly estimate
+- **FR-006**: System MUST default to MySQL engine when engine tag is not provided
+- **FR-007**: System MUST default to gp2 storage type when storage_type tag is not provided
+- **FR-008**: System MUST default to 20 GB storage when storage_size tag is not provided or invalid
+- **FR-009**: System MUST return $0 with explanatory message for unknown instance types
+- **FR-010**: System MUST provide thread-safe pricing lookups for concurrent requests
+- **FR-011**: Supports() MUST return supported=true without "Limited support" reason for RDS resources
+- **FR-012**: System MUST include RDS pricing data in all 9 regional binaries
+- **FR-013**: System MUST use Single-AZ deployment pricing only (Multi-AZ is out of scope)
+- **FR-014**: System MUST return billing_detail describing all assumptions (instance type, engine, hours, storage)
+
+### Key Entities
+
+- **RDS Instance Price**: Represents hourly compute cost for a specific instance type and engine combination
+- **RDS Storage Price**: Represents per-GB-month cost for a specific storage volume type
+- **Resource Descriptor**: Input containing instance type (Sku), region, and tags (engine, storage_type, storage_size)
+- **Projected Cost Response**: Output containing unit_price (hourly), currency, cost_per_month (total), and billing_detail
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Cost queries for common instance types (db.t3.micro, db.t3.medium, db.m5.large) return non-zero results within 100ms
+- **SC-002**: Cost estimates are within 5% accuracy compared to AWS Pricing Calculator for the same configuration
+- **SC-003**: All 9 regional binaries return accurate region-specific RDS pricing
+- **SC-004**: System handles 100 concurrent RDS cost queries without errors or data corruption
+- **SC-005**: 100% of unit tests pass covering instance types, engines, storage types, and default value scenarios
+- **SC-006**: billing_detail message clearly communicates all pricing assumptions to users
+
+## Scope Boundaries
+
+### In Scope
+
+- Single-AZ RDS instance pricing
+- Instance compute hours (on-demand)
+- General purpose and provisioned IOPS storage (per GB)
+- MySQL, PostgreSQL, MariaDB, Oracle SE2, SQL Server Express engines
+- All 9 supported AWS regions
+
+### Out of Scope
+
+- Multi-AZ deployment pricing
+- Read replica pricing
+- Reserved instance pricing
+- Aurora and Aurora Serverless
+- Provisioned IOPS (per IOPS) pricing
+- Backup storage costs
+- Data transfer costs
+- License-included vs BYOL pricing variations beyond defaults
+
+## Assumptions
+
+- AWS public pricing API provides accurate, up-to-date RDS pricing data
+- 730 hours per month is an acceptable standard for cost projection
+- Default engine (MySQL) is the most common use case when unspecified
+- Default storage type (gp2) and size (20 GB) represent typical minimum configurations
+- Single-AZ deployment is sufficient for v1 cost estimation
+- License-included pricing is used for Oracle and SQL Server (standard default)

--- a/specs/009-rds-cost-estimation/tasks.md
+++ b/specs/009-rds-cost-estimation/tasks.md
@@ -1,0 +1,263 @@
+# Tasks: RDS Instance Cost Estimation
+
+**Input**: Design documents from `/specs/009-rds-cost-estimation/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md
+
+**Tests**: Included per spec requirement (SC-005: 100% unit tests pass)
+
+**Organization**: Tasks grouped by user story for independent implementation.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: User story (US1, US2, US3, US4)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+Based on plan.md structure:
+
+- `internal/pricing/` - Pricing client and data types
+- `internal/plugin/` - Plugin implementation
+- `tools/generate-pricing/` - Pricing data generation tool
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Extend existing project structure for RDS support
+
+- [ ] T001 Add RDS price types to internal/pricing/types.go
+- [ ] T002 [P] Add RDS interface methods to PricingClient in internal/pricing/client.go
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core RDS pricing infrastructure that ALL user stories depend on
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T003 Add rdsInstanceIndex and rdsStorageIndex maps to Client struct in internal/pricing/client.go
+- [ ] T004 Implement RDS instance parsing in init() function in internal/pricing/client.go
+- [ ] T005 Implement RDS storage parsing in init() function in internal/pricing/client.go (after T004)
+- [ ] T006 Implement RDSOnDemandPricePerHour() lookup method in internal/pricing/client.go
+- [ ] T007 Implement RDSStoragePricePerGBMonth() lookup method in internal/pricing/client.go
+- [ ] T008 Update tools/generate-pricing/main.go to support AmazonRDS service code
+
+**Checkpoint**: Foundation ready - RDS pricing lookups functional
+
+---
+
+## Phase 3: User Story 1 - Basic RDS Instance Cost Query (Priority: P1)
+
+**Goal**: Return accurate cost estimates for RDS instances based on type and engine
+
+**Independent Test**: Query db.t3.medium MySQL, verify non-zero hourly rate and monthly cost
+
+### Tests for User Story 1
+
+- [ ] T009 [P] [US1] Add unit test for RDSOnDemandPricePerHour() in internal/pricing/client_test.go
+- [ ] T010 [P] [US1] Add unit test for estimateRDS() with MySQL in internal/plugin/projected_test.go
+
+### Implementation for User Story 1
+
+- [ ] T011 [US1] Create estimateRDS() function skeleton in internal/plugin/projected.go
+- [ ] T012 [US1] Implement instance type extraction from resource.Sku in internal/plugin/projected.go
+- [ ] T013 [US1] Implement engine extraction with mysql default in internal/plugin/projected.go
+- [ ] T014 [US1] Implement engine normalization map in internal/plugin/projected.go
+- [ ] T015 [US1] Implement hourly rate lookup via pricing client in internal/plugin/projected.go
+- [ ] T016 [US1] Implement monthly cost calculation (rate × 730) in internal/plugin/projected.go
+- [ ] T017 [US1] Implement billing_detail message for instance-only in internal/plugin/projected.go
+- [ ] T018 [US1] Update router switch case for "rds" in internal/plugin/projected.go
+- [ ] T019 [US1] Handle unknown instance type ($0 with explanation) in internal/plugin/projected.go
+
+**Checkpoint**: User Story 1 complete - RDS instance cost queries return accurate results
+
+---
+
+## Phase 4: User Story 4 - Supports Query for RDS (Priority: P1)
+
+**Goal**: Supports() returns supported=true for RDS without "Limited support" caveat
+
+**Independent Test**: Call Supports() with resource_type "rds", verify supported=true
+
+### Tests for User Story 4
+
+- [ ] T020 [P] [US4] Add unit test for Supports() with RDS in internal/plugin/supports_test.go
+
+### Implementation for User Story 4
+
+- [ ] T021 [US4] Move "rds" from stub case to fully-supported in internal/plugin/supports.go
+- [ ] T022 [US4] Update Supports() reason message for RDS in internal/plugin/supports.go
+
+**Checkpoint**: User Story 4 complete - plugin correctly reports RDS support
+
+---
+
+## Phase 5: User Story 2 - RDS Storage Cost Estimation (Priority: P2)
+
+**Goal**: Include storage costs (per GB-month) in RDS estimates
+
+**Independent Test**: Query with storage_type and storage_size, verify storage added to total
+
+### Tests for User Story 2
+
+- [ ] T023 [P] [US2] Add unit test for RDSStoragePricePerGBMonth() in internal/pricing/client_test.go
+- [ ] T024 [P] [US2] Add unit test for estimateRDS() with storage in internal/plugin/projected_test.go
+
+### Implementation for User Story 2
+
+- [ ] T025 [US2] Extract storage_type from tags with gp2 default in internal/plugin/projected.go
+- [ ] T026 [US2] Extract storage_size from tags with 20GB default in internal/plugin/projected.go
+- [ ] T027 [US2] Implement storage rate lookup via pricing client in internal/plugin/projected.go
+- [ ] T028 [US2] Combine instance + storage costs in cost_per_month in internal/plugin/projected.go
+- [ ] T029 [US2] Update billing_detail to include storage info in internal/plugin/projected.go
+- [ ] T030 [US2] Handle invalid storage_size (default to 20GB) in internal/plugin/projected.go
+- [ ] T031 [US2] Handle unknown storage_type (default to gp2) in internal/plugin/projected.go
+
+**Checkpoint**: User Story 2 complete - RDS estimates include storage costs
+
+---
+
+## Phase 6: User Story 3 - Multi-Engine Support (Priority: P3)
+
+**Goal**: Support all major database engines with engine-specific pricing
+
+**Independent Test**: Query each engine type, verify engine-specific pricing returned
+
+### Tests for User Story 3
+
+- [ ] T032 [P] [US3] Add table-driven test for all engines in internal/plugin/projected_test.go
+- [ ] T033 [P] [US3] Add test for unknown engine defaulting to MySQL in internal/plugin/projected_test.go
+
+### Implementation for User Story 3
+
+- [ ] T034 [US3] Add PostgreSQL to engine normalization map in internal/plugin/projected.go
+- [ ] T035 [US3] Add MariaDB to engine normalization map in internal/plugin/projected.go
+- [ ] T036 [US3] Add Oracle SE2 to engine normalization map in internal/plugin/projected.go
+- [ ] T037 [US3] Add SQL Server Express to engine normalization map in internal/plugin/projected.go
+- [ ] T038 [US3] Handle unknown engine (default to mysql with note) in internal/plugin/projected.go
+- [ ] T039 [US3] Update billing_detail to show actual engine used in internal/plugin/projected.go
+
+**Checkpoint**: User Story 3 complete - all engines supported with accurate pricing
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Improvements affecting multiple user stories
+
+- [ ] T040 [P] Add debug logging for RDS pricing lookups in internal/plugin/projected.go
+- [ ] T041 [P] Add performance warning logging (>50ms) in internal/pricing/client.go
+- [ ] T042 Run make lint and fix any issues
+- [ ] T043 Run make test and verify all tests pass
+- [ ] T044 Validate against quickstart.md scenarios manually with grpcurl
+- [ ] T045 Update mock pricing client for test coverage in internal/plugin/plugin_test.go
+- [ ] T046 Build and validate RDS pricing in all 9 regional binaries (goreleaser build --snapshot)
+- [ ] T047 Spot-check db.t3.medium MySQL price against AWS Calculator for us-east-1, eu-west-1
+- [ ] T048 [P] Add concurrent access test for RDS pricing lookups in internal/pricing/client_test.go
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup - BLOCKS all user stories
+- **User Stories (Phases 3-6)**: All depend on Foundational completion
+- **Polish (Phase 7)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Can start after Foundational - No dependencies on other stories
+- **US4 (P1)**: Can start after Foundational - No dependencies on other stories
+- **US2 (P2)**: Depends on US1 (uses estimateRDS() function created in US1)
+- **US3 (P3)**: Depends on US1 (extends engine normalization from US1)
+
+### Within Each User Story
+
+- Tests written first (TDD approach)
+- Core implementation before edge cases
+- Commit after each logical group
+
+### Parallel Opportunities
+
+**Phase 1 (Setup)**:
+
+- T001 and T002 can run in parallel (different areas of types.go and client.go interface)
+
+**Phase 2 (Foundational)**:
+
+- T004 then T005 sequentially (same init() function to avoid conflicts)
+- T006 and T007 can run in parallel (different lookup methods)
+
+**Phase 3 (US1) + Phase 4 (US4)**:
+
+- US1 and US4 can proceed in parallel (different files: projected.go vs supports.go)
+- T009 and T010 can run in parallel (different test files)
+
+**Phase 5-6 (US2, US3)**:
+
+- US2 and US3 tests can run in parallel
+- After US1, implementation of US2 and US3 can partially overlap
+
+---
+
+## Parallel Example: Foundational Phase
+
+```bash
+# Launch instance and storage parsing together:
+Task: "Implement RDS instance parsing in init() function in internal/pricing/client.go"
+Task: "Implement RDS storage parsing in init() function in internal/pricing/client.go"
+
+# Launch lookup methods together:
+Task: "Implement RDSOnDemandPricePerHour() lookup method in internal/pricing/client.go"
+Task: "Implement RDSStoragePricePerGBMonth() lookup method in internal/pricing/client.go"
+```
+
+## Parallel Example: User Story 1 & 4
+
+```bash
+# US1 and US4 can proceed in parallel after Foundational:
+# Developer A (US1):
+Task: "Create estimateRDS() function skeleton in internal/plugin/projected.go"
+Task: "Implement instance type extraction from resource.Sku in internal/plugin/projected.go"
+
+# Developer B (US4):
+Task: "Move 'rds' from stub case to fully-supported in internal/plugin/supports.go"
+Task: "Update Supports() reason message for RDS in internal/plugin/supports.go"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1 & 4 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1 (instance cost)
+4. Complete Phase 4: User Story 4 (Supports)
+5. **STOP and VALIDATE**: Test RDS instance queries work with grpcurl
+6. Deploy/demo if ready - basic RDS support functional
+
+### Incremental Delivery
+
+1. Setup + Foundational → Foundation ready
+2. Add US1 + US4 → Test independently → MVP ready
+3. Add US2 → Storage costs included → Enhanced MVP
+4. Add US3 → All engines supported → Full feature
+5. Polish → Production ready
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to user story
+- Each user story independently testable after Foundational
+- Verify tests fail before implementing
+- Commit after each task or logical group
+- Follow existing EC2/EBS patterns for consistency


### PR DESCRIPTION
This PR implements RDS (Relational Database Service) cost estimation, extending the existing EC2/EBS pricing pattern to support database instance costs. It fulfills the requirements of issue #69.

## Summary

- Add RDS instance hourly pricing lookup with multi-engine support
- Add RDS storage cost calculation (per GB-month)
- Support engine normalization for user-friendly input
- Update Supports() to mark RDS as fully supported
- Extend generate-pricing tool to fetch AmazonRDS pricing data

## Implementation Details

### Modified Files

- `internal/pricing/types.go` - Added `rdsInstancePrice` and `rdsStoragePrice`
- `internal/pricing/client.go` - Added RDS lookup methods and indexes
- `internal/plugin/projected.go` - Implemented `estimateRDS()` function
- `internal/plugin/supports.go` - Moved RDS to fully-supported case
- `internal/plugin/plugin_test.go` - Extended mock with RDS methods
- `internal/plugin/projected_test.go` - Added comprehensive RDS tests
- `internal/plugin/supports_test.go` - Updated RDS test expectation
- `internal/plugin/actual_test.go` - Extended mock and removed RDS from stubs
- `tools/generate-pricing/main.go` - Multi-service pricing fetch support

### Key Functions

| Function | Purpose |
|----------|---------|
| `RDSOnDemandPricePerHour()` | Lookup hourly rate for instance type + engine | | `RDSStoragePricePerGBMonth()` | Lookup storage rate for volume type | | `estimateRDS()` | Calculate total RDS monthly cost | | `generateCombinedPricingData()` | Fetch and merge multiple AWS services |

### Engine Normalization

| User Input | AWS API Name |
|------------|--------------|
| mysql | MySQL |
| postgres, postgresql | PostgreSQL |
| mariadb | MariaDB |
| oracle, oracle-se2 | Oracle |
| sqlserver, sqlserver-ex, sql-server | SQL Server |

### Cost Calculation

```text
monthly_cost = (hourly_rate × 730) + (storage_rate × storage_gb)
```

Default values when tags not specified:

- Engine: MySQL
- Storage type: gp2
- Storage size: 20GB

## Test Plan

- [x] `make lint` passes (0 issues)
- [x] `make test` passes (all tests)
- [x] RDS unit tests cover all engines
- [x] RDS unit tests cover default values
- [x] RDS unit tests cover unknown instance/engine
- [x] RDS unit tests cover invalid storage sizes
- [x] Supports() returns fully supported for RDS
- [x] Mock clients updated in all test files

## Supported Configurations

- **Resource Type:** rds
- **Instance Types:** db.t3.*, db.m5.*, db.r5.*, etc.
- **Engines:** MySQL, PostgreSQL, MariaDB, Oracle, SQL Server
- **Storage Types:** gp2, gp3, io1, io2, standard

## Known Limitations

- Single-AZ deployment pricing only (Multi-AZ not implemented)
- License-included pricing only (BYOL not supported)
- IOPS costs for io1/io2 not included in estimate
- Reserved instance pricing not supported

## Breaking Changes

None. This is a purely additive change. Existing EC2/EBS functionality is unchanged.

Closes #69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full RDS support for projected and actual cost estimates: on‑demand instance and per‑GB storage pricing, engine normalization, storage defaults, and detailed billing details.

* **Tests**
  * Expanded RDS unit tests and updated mocks to exercise instance and storage pricing paths; adjusted stub-service expectations.

* **Documentation**
  * Minor formatting tweak in active technologies note.

* **Chores**
  * Pricing data generator now aggregates multiple services into combined region files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->