### PR TITLE
feat(eks): add EKS pricing validation and missing pricing test coverage

### DIFF
--- a/internal/pricing/client.go
+++ b/internal/pricing/client.go
@@ -301,6 +301,18 @@ func (c *Client) init() error {
 				}
 			}
 		}
+
+		// Validate EKS pricing data was loaded successfully
+		if c.eksPricing == nil || c.eksPricing.StandardHourlyRate == 0 {
+			c.logger.Warn().
+				Str("region", c.region).
+				Msg("EKS standard pricing not found in embedded data")
+		}
+		if c.eksPricing != nil && c.eksPricing.ExtendedHourlyRate == 0 {
+			c.logger.Warn().
+				Str("region", c.region).
+				Msg("EKS extended support pricing not found in embedded data")
+		}
 	})
 	return c.err
 }


### PR DESCRIPTION
## Summary

- Add initialization-time warnings when EKS pricing data is missing
  from embedded pricing files
- Add test coverage for EKS missing pricing scenario, mirroring
  existing tests for EC2 and RDS unknown instance types

## Test plan

- [x] `make lint` passes with zero issues
- [x] `make test` passes
- [x] New test `TestGetProjectedCost_EKS_MissingPricing` validates $0
      cost returned when pricing data unavailable
- [x] Test verifies billing_detail explains why cost is $0

## Changes

### Modified files

- `internal/pricing/client.go` - Add post-init validation warnings for
  missing EKS standard and extended support pricing
- `internal/plugin/projected_test.go` - Add missing pricing test case
  for EKS that mirrors EC2/RDS patterns

Closes #90