### PR TITLE
fix(eks): resolve pricing parser zero-value bug and case-sensitive su…

### DIFF
--- a/internal/plugin/projected.go
+++ b/internal/plugin/projected.go
@@ -521,9 +521,9 @@ func detectService(resourceType string) string {
 func (p *AWSPublicPlugin) estimateEKS(traceID string, resource *pbc.ResourceDescriptor) (*pbc.GetProjectedCostResponse, error) {
 	// Determine support type from resource.Sku or tags
 	// resource.Sku = "cluster" (standard) or "cluster-extended" (extended support)
-	// OR use tags: tags["support_type"] == "extended"
+	// OR use tags: tags["support_type"] == "extended" (case-insensitive)
 	extendedSupport := resource.Sku == "cluster-extended" ||
-		(resource.Tags != nil && resource.Tags["support_type"] == "extended")
+		(resource.Tags != nil && strings.EqualFold(resource.Tags["support_type"], "extended"))
 
 	// Look up EKS pricing based on support type
 	hourlyRate, found := p.pricing.EKSClusterPricePerHour(extendedSupport)

--- a/internal/pricing/client.go
+++ b/internal/pricing/client.go
@@ -287,16 +287,14 @@ func (c *Client) init() error {
 				rate, unit, found := getOnDemandPrice(sku)
 				if found && unit == "Hrs" && rate > 0 {
 					// Extended support: ExtendedSupport operation or extendedSupport in usagetype
+					// Always update with valid non-zero rates. This handles cases where AWS pricing
+					// data may contain multiple entries or change order in future API responses.
 					if operation == "ExtendedSupport" || strings.Contains(usageType, "extendedSupport") {
-						if c.eksPricing.ExtendedHourlyRate == 0 {
-							c.eksPricing.ExtendedHourlyRate = rate
-						}
+						c.eksPricing.ExtendedHourlyRate = rate
 					} else {
 						// Standard support: CreateOperation with perCluster, or any non-extended EKS pricing
 						// This includes legacy data that doesn't have specific operation/usagetype
-						if c.eksPricing.StandardHourlyRate == 0 {
-							c.eksPricing.StandardHourlyRate = rate
-						}
+						c.eksPricing.StandardHourlyRate = rate
 					}
 				}
 			}


### PR DESCRIPTION
…pport_type

## Summary

- Fix EKS pricing parser to always update with valid non-zero rates instead of only setting when zero, preventing issues if AWS API response order changes
- Fix case-sensitive `support_type` tag comparison to use `strings.EqualFold` so users can use "Extended", "EXTENDED", or any case variation
- Add regression test for case-insensitive `support_type` tag validation

## Test plan

- [x] `make lint` passes with 0 issues
- [x] `make test` passes (all existing tests + new test)
- [x] New `TestGetProjectedCost_EKS_SupportTypeCaseInsensitive` test verifies all case variations (Extended, EXTENDED, ExTeNdEd, extended)

## Changes

### Modified files

- `internal/pricing/client.go` - Remove zero-check condition in EKS pricing parser to always update with last valid non-zero rate
- `internal/plugin/projected.go` - Use `strings.EqualFold` for case-insensitive `support_type` tag comparison
- `internal/plugin/projected_test.go` - Add regression test for case variations

Closes #89