### PR TITLE
# fix(main): refactor to use run() error pattern to ensure defer exec…

### DIFF
--- a/cmd/pulumicost-plugin-aws-public/main.go
+++ b/cmd/pulumicost-plugin-aws-public/main.go
@@ -15,13 +15,21 @@ import (
 // version is the plugin version, set at build time via ldflags.
 var version = "0.0.3"
 
-// main starts the aws-public plugin process, configures logging, initializes the pricing
-// client and plugin instance, and runs the plugin server until a shutdown signal is received.
+// main is the entry point that delegates to run() and handles exit codes.
+// This pattern ensures all defer statements execute properly before process exit.
+func main() {
+	if err := run(); err != nil {
+		os.Exit(1)
+	}
+}
+
+// run contains the main application logic, returning an error on failure.
+// This function configures logging, initializes the pricing client and plugin instance,
+// and runs the plugin server until a shutdown signal is received.
 // It reads LOG_LEVEL and PORT from the environment, validates test-mode configuration,
 // logs the AWS region returned by the pricing client, and performs a graceful shutdown on
-// os.Interrupt or syscall.SIGTERM. On initialization or server errors the process exits with
-// a non-zero status.
-func main() {
+// os.Interrupt or syscall.SIGTERM.
+func run() error {
 	// Parse log level from environment (default: info)
 	level := zerolog.InfoLevel
 	if lvl := os.Getenv("LOG_LEVEL"); lvl != "" {
@@ -40,7 +48,7 @@ func main() {
 	pricingClient, err := pricing.NewClient(logger)
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to initialize pricing client")
-		os.Exit(1)
+		return err
 	}
 	region := pricingClient.Region()
 
@@ -77,6 +85,8 @@ func main() {
 	}
 	if err := pluginsdk.Serve(ctx, config); err != nil {
 		logger.Error().Err(err).Msg("server error")
-		os.Exit(1)
+		return err
 	}
+
+	return nil
 }


### PR DESCRIPTION
…ution

## Summary

- Refactored `main.go` to use the `run() error` pattern instead of calling `os.Exit(1)` directly
- This ensures all `defer` statements execute properly before the process exits

## Implementation Details

### Modified Files

- `cmd/pulumicost-plugin-aws-public/main.go`: Extracted main logic into a `run() error` function

### Changes

The previous implementation called `os.Exit(1)` directly in two places:

1. After pricing client initialization failure
2. After server error

This prevented `defer cancel()` from executing, which could leave resources in an inconsistent state.

The new implementation:

- `main()` simply calls `run()` and exits with code 1 if an error is returned
- `run()` contains all the application logic and returns errors instead of calling `os.Exit()`
- All `defer` statements now execute properly before process exit

## Test Plan

- [x] `make lint` passes with 0 issues
- [x] `make test` passes all tests
- [x] Code review for defer statement handling

## Known Limitations

None.

## Breaking Changes

None. This is a pure refactor with no behavior changes.

Closes #85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization and error handling flow in the application entrypoint. No functional changes to end-user behavior or features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->