### PR TITLE
fix(resource): Support Pulumi resource type format

### DIFF
--- a/internal/plugin/actual.go
+++ b/internal/plugin/actual.go
@@ -66,8 +66,11 @@ func (p *AWSPublicPlugin) getProjectedForResource(traceID string, resource *pbc.
 		return nil, stWithDetails.Err()
 	}
 
-	// Route to appropriate estimator based on resource type
-	switch resource.ResourceType {
+	// Normalize resource type (handles Pulumi formats like aws:ec2/instance:Instance)
+	serviceType := detectService(resource.ResourceType)
+
+	// Route to appropriate estimator based on normalized resource type
+	switch serviceType {
 	case "ec2":
 		return p.estimateEC2(traceID, resource)
 	case "ebs":

--- a/internal/plugin/pricingspec.go
+++ b/internal/plugin/pricingspec.go
@@ -48,9 +48,12 @@ func (p *AWSPublicPlugin) GetPricingSpec(ctx context.Context, req *pbc.GetPricin
 		return nil, err
 	}
 
+	// Normalize resource type (handles Pulumi formats like aws:ec2/instance:Instance)
+	serviceType := detectService(resource.ResourceType)
+
 	var spec *pbc.PricingSpec
 
-	switch resource.ResourceType {
+	switch serviceType {
 	case "ec2":
 		spec = p.ec2PricingSpec(resource)
 	case "ebs":

--- a/internal/plugin/supports_test.go
+++ b/internal/plugin/supports_test.go
@@ -200,6 +200,44 @@ func TestSupports(t *testing.T) {
 			wantReasonSubstr: "not supported",
 		},
 
+		// Pulumi resource type format support
+		{
+			name: "EC2 with Pulumi format",
+			req: &pbc.SupportsRequest{
+				Resource: &pbc.ResourceDescriptor{
+					Provider:     "aws",
+					ResourceType: "aws:ec2/instance:Instance",
+					Region:       "us-east-1",
+				},
+			},
+			wantSupported:    true,
+			wantReasonSubstr: "",
+		},
+		{
+			name: "EBS with Pulumi format",
+			req: &pbc.SupportsRequest{
+				Resource: &pbc.ResourceDescriptor{
+					Provider:     "aws",
+					ResourceType: "aws:ebs/volume:Volume",
+					Region:       "us-east-1",
+				},
+			},
+			wantSupported:    true,
+			wantReasonSubstr: "",
+		},
+		{
+			name: "S3 with Pulumi format",
+			req: &pbc.SupportsRequest{
+				Resource: &pbc.ResourceDescriptor{
+					Provider:     "aws",
+					ResourceType: "aws:s3/bucket:Bucket",
+					Region:       "us-east-1",
+				},
+			},
+			wantSupported:    true,
+			wantReasonSubstr: "Limited support",
+		},
+
 		// Invalid requests
 		{
 			name:             "Nil request",


### PR DESCRIPTION
This pull request adds support for handling Pulumi-style AWS resource type formats (e.g., `aws:ec2/instance:Instance`) throughout the pricing and cost estimation plugin. The changes ensure that the plugin can correctly recognize and process both standard and Pulumi-formatted resource types for EC2, EBS, and S3 resources. Comprehensive tests are added to verify this behavior.

**Core logic improvements:**

* Updated resource type handling in `getProjectedForResource` and `GetPricingSpec` to normalize Pulumi-style resource types using the new `detectService` function, ensuring correct routing for cost estimation and pricing specification. [[1]](diffhunk://#diff-da87d25bab1e96b8d88572a0d91a75192844452ec1305ce5b2061bbb10074daeL69-R73) [[2]](diffhunk://#diff-19f653e22621a8aa580a01f090b7684b6f535784fda7669cd3a4373500f899c1R51-R56)

**Testing enhancements:**

* Added tests to `actual_test.go` for EC2 and EBS resources using Pulumi resource type formats to verify accurate cost calculation and correct handling of resource IDs and tags.
* Added tests to `pricingspec_test.go` for EC2 and EBS resources with Pulumi resource type formats to confirm correct pricing spec generation and preservation of original resource type strings. [[1]](diffhunk://#diff-423303a664c8317b0009158ed190d4ab7eb6bf3501804043f17c3e08295716beR50-R81) [[2]](diffhunk://#diff-423303a664c8317b0009158ed190d4ab7eb6bf3501804043f17c3e08295716beR136-R166)
* Extended `supports_test.go` to verify that EC2, EBS, and S3 Pulumi-formatted resource types are recognized as supported, with appropriate support reasons.
fixes #82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended support for Pulumi-formatted resource type descriptors in cost calculations and pricing specifications.

* **Tests**
  * Added test coverage validating cost and pricing calculations work correctly with Pulumi resource formats across EC2, EBS, and support detection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->