### PR TITLE
feat(finops): implement GetRecommendations RPC for cost optimization

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
 
 language: en-US
-tone_instructions: "Focus on Go 1.25.4 best practices and modern Go idioms"
+tone_instructions: "Focus on Go 1.25.5 best practices and modern Go idioms"
 early_access: false
 enable_free_tier: true
 reviews:
@@ -42,20 +42,20 @@ reviews:
   path_instructions:
     - path: "**/*.go"
       instructions: |
-        Please ensure this Go code is compatible with Go 1.25.4.
+        Please ensure this Go code is compatible with Go 1.25.5.
         Consider using the latest Go features and best practices.
         Pay special attention to:
         - Error handling with proper error wrapping
         - Use of generics where appropriate
         - Modern Go idioms and patterns
-        - Performance optimizations available in Go 1.25.4
+        - Performance optimizations available in Go 1.25.5
         - Proper documentation for exported functions and types
         - Security vulnerabilities and best practices
     - path: "**/*_test.go"
       instructions: |
         Please ensure adequate test coverage for new functionality.
         Consider adding integration tests for complex logic.
-        Use Go 1.25.4 testing features where appropriate.
+        Use Go 1.25.5 testing features where appropriate.
         - Ensure tests cover edge cases and error conditions
         - Check for proper use of testing utilities and patterns
         - Verify test isolation and cleanup
@@ -75,7 +75,7 @@ reviews:
       instructions: |
         Please review Go module dependencies for:
         - Security vulnerabilities
-        - Compatibility with Go 1.25.4
+        - Compatibility with Go 1.25.5
         - Latest stable versions
         - Proper module structure
   abort_on_close: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@
 
 ### Go Standards
 
-- **Version**: Go 1.25.4 minimum
+- **Version**: Go 1.25.5 minimum
 - **Formatting**: Standard gofmt/gofmt -w
 - **Imports**: Group by standard library, third-party, local packages
 - **Naming**: PascalCase for exported, camelCase for unexported
@@ -36,16 +36,16 @@
 - Thread-safe pricing lookups for concurrent gRPC calls
 
 ## Active Technologies
-- Embedded JSON files in Go binaries (no runtime storage) (011-s3-cost-estimation)
 
-- Go 1.25.4 + gRPC, zerolog, embedded JSON pricing data (010-eks-cost-estimation)
+- Embedded JSON files in Go binaries (no runtime storage) (011-s3-cost-estimation)
+- Go 1.25.5 + gRPC, zerolog, embedded JSON pricing data (010-eks-cost-estimation)
 - Embedded JSON pricing data (no runtime storage) (010-eks-cost-estimation)
-- Go 1.25.4 + GoReleaser, gRPC, build tags (006-region-build-matrix)
+- Go 1.25.5 + GoReleaser, gRPC, build tags (006-region-build-matrix)
 - Embedded JSON files in Go binaries (006-region-build-matrix)
 
 ## Recent Changes
 
-- 006-region-build-matrix: Added Go 1.25.4 + GoReleaser, gRPC, build tags
+- 006-region-build-matrix: Added Go 1.25.5 + GoReleaser, gRPC, build tags
 
 ## Custom Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -531,6 +531,7 @@ This allows the user to review and make the commit themselves, and ensures
 the commit message follows conventional commits format.
 
 ## Active Technologies
+
 - **Go 1.25+** with gRPC via pulumicost-spec/sdk/go/pluginsdk
 - **pulumicost-spec** protos for CostSourceService API
 - **zerolog** for structured JSON logging (stderr only)

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/rshade/pulumicost-plugin-aws-public
 
-go 1.25.4
+go 1.25.5
 
 require (
 	github.com/google/uuid v1.6.0
 	github.com/rs/zerolog v1.34.0
-	github.com/rshade/pulumicost-spec v0.4.7
+	github.com/rshade/pulumicost-spec v0.4.8
 	github.com/stretchr/testify v1.11.1
 	google.golang.org/grpc v1.77.0
 	google.golang.org/protobuf v1.36.11

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncj
 github.com/rs/xid v1.6.0/go.mod h1:7XoLgs4eV+QndskICGsho+ADou8ySMSjJKDIan90Nz0=
 github.com/rs/zerolog v1.34.0 h1:k43nTLIwcTVQAncfCw4KZ2VY6ukYoZaBPNOE8txlOeY=
 github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6wYQ=
-github.com/rshade/pulumicost-spec v0.4.3 h1:rujQNyl3rLpdsvhUWuWM0MIcZwzUYaqeLhJKbm9Yx1g=
-github.com/rshade/pulumicost-spec v0.4.3/go.mod h1:Jl712isQd4YR6CW9WkUXJJbldQKA1vZv72GDLe7NjOQ=
+github.com/rshade/pulumicost-spec v0.4.8 h1:VG9+KV5SpqI/tZJ1d75RTcUQfK9NWddRQusHeLazR+M=
+github.com/rshade/pulumicost-spec v0.4.8/go.mod h1:mJ+LSqeFM0dRv4auB63R9NpPbS5YKS/10mDeosdVNJ4=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
@@ -86,8 +86,6 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20251022142026-3a174f9686a8 h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20251022142026-3a174f9686a8/go.mod h1:7i2o+ce6H/6BluujYR+kqX3GKH+dChPTQU19wjRPiGk=
 google.golang.org/grpc v1.77.0 h1:wVVY6/8cGA6vvffn+wWK5ToddbgdU3d8MNENr4evgXM=
 google.golang.org/grpc v1.77.0/go.mod h1:z0BY1iVj0q8E1uSQCjL9cppRj+gnZjzDnzV0dHhrNig=
-google.golang.org/protobuf v1.36.10 h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aOOE=
-google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/plugin/instance_type.go
+++ b/internal/plugin/instance_type.go
@@ -1,0 +1,89 @@
+package plugin
+
+import "strings"
+
+// parseInstanceType splits an EC2 instance type into family and size.
+// Example: "t2.medium" → ("t2", "medium")
+// Returns empty strings if the format is invalid.
+func parseInstanceType(instanceType string) (family, size string) {
+	parts := strings.SplitN(instanceType, ".", 2)
+	if len(parts) != 2 {
+		return "", ""
+	}
+	// Validate both parts are non-empty (handles edge case like "." input)
+	if parts[0] == "" || parts[1] == "" {
+		return "", ""
+	}
+	return parts[0], parts[1]
+}
+
+// generationUpgradeMap maps old instance families to newer generations.
+// Only includes mappings where the newer generation is typically the same price
+// or cheaper with better performance.
+var generationUpgradeMap = map[string]string{
+	// T-series (burstable general purpose)
+	"t2": "t3",  // 2014 → 2018
+	"t3": "t3a", // Intel → AMD (often cheaper)
+
+	// M-series (general purpose)
+	"m4":  "m5",  // 2015 → 2017
+	"m5":  "m6i", // 2017 → 2021
+	"m5a": "m6a", // AMD 2018 → AMD 2022
+	"m6i": "m7i", // 2021 → 2023
+	"m6a": "m7a", // AMD 2022 → AMD 2023
+
+	// C-series (compute optimized)
+	"c4":  "c5",  // 2015 → 2017
+	"c5":  "c6i", // 2017 → 2021
+	"c5a": "c6a", // AMD 2020 → AMD 2022
+	"c6i": "c7i", // 2021 → 2023
+	"c6a": "c7a", // AMD 2022 → AMD 2023
+
+	// R-series (memory optimized)
+	"r4":  "r5",  // 2016 → 2018
+	"r5":  "r6i", // 2018 → 2021
+	"r5a": "r6a", // AMD 2019 → AMD 2022
+	"r6i": "r7i", // 2021 → 2023
+	"r6a": "r7a", // AMD 2022 → AMD 2023
+
+	// I-series (storage optimized)
+	"i3": "i3en", // 2017 → 2019
+
+	// D-series (dense storage)
+	"d2": "d3", // 2015 → 2020
+}
+
+// gravitonMap maps x86 instance families to Graviton (ARM) equivalents.
+// Graviton instances typically offer ~20% cost savings with comparable performance.
+var gravitonMap = map[string]string{
+	// M-series → M6g/M7g
+	"m5":  "m6g",
+	"m5a": "m6g",
+	"m5n": "m6g",
+	"m6i": "m6g",
+	"m6a": "m6g",
+	"m7i": "m7g", // 7th gen Intel → Graviton3
+	"m7a": "m7g", // 7th gen AMD → Graviton3
+
+	// C-series → C6g/C6gn/C7g
+	"c5":  "c6g",
+	"c5a": "c6g",
+	"c5n": "c6gn",
+	"c6i": "c6g",
+	"c6a": "c6g",
+	"c7i": "c7g", // 7th gen Intel → Graviton3
+	"c7a": "c7g", // 7th gen AMD → Graviton3
+
+	// R-series → R6g/R7g
+	"r5":  "r6g",
+	"r5a": "r6g",
+	"r5n": "r6g",
+	"r6i": "r6g",
+	"r6a": "r6g",
+	"r7i": "r7g", // 7th gen Intel → Graviton3
+	"r7a": "r7g", // 7th gen AMD → Graviton3
+
+	// T-series → T4g
+	"t3":  "t4g",
+	"t3a": "t4g",
+}

--- a/internal/plugin/instance_type_test.go
+++ b/internal/plugin/instance_type_test.go
@@ -1,0 +1,151 @@
+package plugin
+
+import "testing"
+
+// TestParseInstanceType validates the parseInstanceType function handles various
+// EC2 instance type formats correctly.
+//
+// This test covers:
+//   - Standard instance types (t2.medium, m5.xlarge)
+//   - Multi-digit sizes (c6i.2xlarge)
+//   - Metal instances (i3.metal)
+//   - Invalid formats (no dot, empty string)
+func TestParseInstanceType(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantFamily string
+		wantSize   string
+	}{
+		{
+			name:       "t2.medium",
+			input:      "t2.medium",
+			wantFamily: "t2",
+			wantSize:   "medium",
+		},
+		{
+			name:       "m5.xlarge",
+			input:      "m5.xlarge",
+			wantFamily: "m5",
+			wantSize:   "xlarge",
+		},
+		{
+			name:       "c6i.2xlarge",
+			input:      "c6i.2xlarge",
+			wantFamily: "c6i",
+			wantSize:   "2xlarge",
+		},
+		{
+			name:       "r6g.metal",
+			input:      "r6g.metal",
+			wantFamily: "r6g",
+			wantSize:   "metal",
+		},
+		{
+			name:       "invalid - no dot",
+			input:      "t2medium",
+			wantFamily: "",
+			wantSize:   "",
+		},
+		{
+			name:       "empty string",
+			input:      "",
+			wantFamily: "",
+			wantSize:   "",
+		},
+		{
+			name:       "just a dot",
+			input:      ".",
+			wantFamily: "",
+			wantSize:   "",
+		},
+		{
+			name:       "multiple dots - only first split",
+			input:      "a.b.c",
+			wantFamily: "a",
+			wantSize:   "b.c",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			family, size := parseInstanceType(tt.input)
+			if family != tt.wantFamily {
+				t.Errorf("parseInstanceType(%q) family = %q, want %q", tt.input, family, tt.wantFamily)
+			}
+			if size != tt.wantSize {
+				t.Errorf("parseInstanceType(%q) size = %q, want %q", tt.input, size, tt.wantSize)
+			}
+		})
+	}
+}
+
+// TestGenerationUpgradeMapEntries verifies the generation upgrade map contains
+// expected mappings for common instance families.
+func TestGenerationUpgradeMapEntries(t *testing.T) {
+	expected := map[string]string{
+		"t2":  "t3",
+		"t3":  "t3a",
+		"m4":  "m5",
+		"m5":  "m6i",
+		"c4":  "c5",
+		"c5":  "c6i",
+		"r4":  "r5",
+		"r5":  "r6i",
+		"i3":  "i3en",
+		"d2":  "d3",
+	}
+
+	for old, expectedNew := range expected {
+		actual, exists := generationUpgradeMap[old]
+		if !exists {
+			t.Errorf("generationUpgradeMap missing key %q", old)
+			continue
+		}
+		if actual != expectedNew {
+			t.Errorf("generationUpgradeMap[%q] = %q, want %q", old, actual, expectedNew)
+		}
+	}
+}
+
+// TestGravitonMapEntries verifies the Graviton map contains expected mappings
+// for x86 to ARM instance family migrations.
+func TestGravitonMapEntries(t *testing.T) {
+	expected := map[string]string{
+		"m5":  "m6g",
+		"m6i": "m6g",
+		"c5":  "c6g",
+		"c6i": "c6g",
+		"r5":  "r6g",
+		"r6i": "r6g",
+		"t3":  "t4g",
+		"t3a": "t4g",
+	}
+
+	for x86, expectedGraviton := range expected {
+		actual, exists := gravitonMap[x86]
+		if !exists {
+			t.Errorf("gravitonMap missing key %q", x86)
+			continue
+		}
+		if actual != expectedGraviton {
+			t.Errorf("gravitonMap[%q] = %q, want %q", x86, actual, expectedGraviton)
+		}
+	}
+}
+
+// TestNoSelfReferencesInMaps verifies that maps don't map a family to itself
+// which would result in useless recommendations.
+func TestNoSelfReferencesInMaps(t *testing.T) {
+	for old, new := range generationUpgradeMap {
+		if old == new {
+			t.Errorf("generationUpgradeMap has self-reference: %q -> %q", old, new)
+		}
+	}
+
+	for old, new := range gravitonMap {
+		if old == new {
+			t.Errorf("gravitonMap has self-reference: %q -> %q", old, new)
+		}
+	}
+}

--- a/internal/plugin/recommendations.go
+++ b/internal/plugin/recommendations.go
@@ -1,0 +1,366 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+	pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+	"google.golang.org/grpc/codes"
+)
+
+const (
+	// confidenceHigh is used for generation upgrades and EBS changes (FR-006).
+	confidenceHigh = 0.9
+	// confidenceMedium is used for Graviton recommendations (FR-007).
+	confidenceMedium = 0.7
+	// sourceAWSPublic identifies recommendations from this plugin.
+	sourceAWSPublic = "aws-public"
+	// modTypeGenUpgrade is the modification type for generation upgrades.
+	modTypeGenUpgrade = "generation_upgrade"
+	// modTypeGraviton is the modification type for Graviton migrations.
+	modTypeGraviton = "graviton_migration"
+	// modTypeVolumeUpgrade is the modification type for EBS volume upgrades.
+	modTypeVolumeUpgrade = "volume_type_upgrade"
+	// defaultEBSVolumeGB is the default volume size when not specified in tags.
+	defaultEBSVolumeGB = 100
+)
+
+// Ensure AWSPublicPlugin implements RecommendationsProvider.
+var _ pluginsdk.RecommendationsProvider = (*AWSPublicPlugin)(nil)
+
+// GetRecommendations returns cost optimization recommendations.
+// Implements FR-001 from spec.md.
+func (p *AWSPublicPlugin) GetRecommendations(
+	ctx context.Context,
+	req *pbc.GetRecommendationsRequest,
+) (*pbc.GetRecommendationsResponse, error) {
+	start := time.Now()
+	traceID := p.getTraceID(ctx)
+
+	// FR-009: Return ERROR_CODE_INVALID_RESOURCE when request is nil
+	if req == nil {
+		err := p.newErrorWithID(traceID, codes.InvalidArgument,
+			"missing request", pbc.ErrorCode_ERROR_CODE_INVALID_RESOURCE)
+		p.logErrorWithID(traceID, "GetRecommendations", err, pbc.ErrorCode_ERROR_CODE_INVALID_RESOURCE)
+		return nil, err
+	}
+
+	// Generate recommendations based on filter (pulumicost-spec v0.4.8+)
+	// FR-008: Return empty list when no filter context provided
+	var recommendations []*pbc.Recommendation
+
+	if req.Filter != nil && req.Filter.Sku != "" {
+		// Determine resource type from filter
+		resourceType := req.Filter.ResourceType
+		region := req.Filter.Region
+		if region == "" {
+			region = p.region // Default to plugin's region
+		}
+
+		// Normalize resource type using detectService
+		service := detectService(resourceType)
+
+		switch service {
+		case "ec2":
+			// FR-002, FR-003: Generate EC2 generation upgrade and Graviton recommendations
+			recommendations = append(recommendations, p.generateEC2Recommendations(req.Filter.Sku, region)...)
+		case "ebs":
+			// FR-004: Generate EBS volume type recommendations
+			recommendations = append(recommendations, p.getEBSRecommendations(req.Filter.Sku, region, req.Filter.Tags)...)
+		}
+	}
+
+	// FR-010: Include trace_id in all log entries
+	p.logger.Info().
+		Str(pluginsdk.FieldTraceID, traceID).
+		Str(pluginsdk.FieldOperation, "GetRecommendations").
+		Int("recommendation_count", len(recommendations)).
+		Int64(pluginsdk.FieldDurationMs, time.Since(start).Milliseconds()).
+		Msg("recommendations generated")
+
+	return &pbc.GetRecommendationsResponse{
+		Recommendations: recommendations,
+		Summary:         pluginsdk.CalculateRecommendationSummary(recommendations, "monthly"),
+	}, nil
+}
+
+// generateEC2Recommendations creates recommendations for an EC2 instance.
+// Returns up to 2 recommendations: generation upgrade and/or Graviton migration.
+func (p *AWSPublicPlugin) generateEC2Recommendations(
+	instanceType, region string,
+) []*pbc.Recommendation {
+	var recommendations []*pbc.Recommendation
+
+	// Generation upgrade (FR-002)
+	if rec := p.getGenerationUpgradeRecommendation(instanceType, region); rec != nil {
+		recommendations = append(recommendations, rec)
+	}
+
+	// Graviton migration (FR-003)
+	if rec := p.getGravitonRecommendation(instanceType, region); rec != nil {
+		recommendations = append(recommendations, rec)
+	}
+
+	return recommendations
+}
+
+// getGenerationUpgradeRecommendation returns a recommendation to upgrade to a newer
+// EC2 instance generation if available and cost-effective.
+// Implements FR-002, FR-005, FR-006, FR-011 from spec.md.
+func (p *AWSPublicPlugin) getGenerationUpgradeRecommendation(
+	instanceType, region string,
+) *pbc.Recommendation {
+	family, size := parseInstanceType(instanceType)
+	if family == "" {
+		return nil
+	}
+
+	newFamily, exists := generationUpgradeMap[family]
+	if !exists {
+		return nil
+	}
+
+	newType := newFamily + "." + size
+
+	currentPrice, found := p.pricing.EC2OnDemandPricePerHour(instanceType, "Linux", "Shared")
+	if !found {
+		return nil
+	}
+
+	newPrice, found := p.pricing.EC2OnDemandPricePerHour(newType, "Linux", "Shared")
+	// FR-011: Only recommend when new price <= current price
+	if !found || newPrice > currentPrice {
+		return nil
+	}
+
+	// FR-005: Calculate monthly savings based on 730 hours/month
+	currentMonthly := currentPrice * hoursPerMonth
+	newMonthly := newPrice * hoursPerMonth
+	savings := currentMonthly - newMonthly
+	savingsPercent := 0.0
+	if currentMonthly > 0 {
+		savingsPercent = (savings / currentMonthly) * 100
+	}
+
+	// FR-006: Set confidence level to 0.9 (high) for generation upgrades
+	confidence := confidenceHigh
+
+	// Build reasoning with optional Graviton alternative note
+	reasoning := []string{
+		fmt.Sprintf("Newer %s instances offer better performance", newFamily),
+		"Drop-in replacement with no architecture changes required",
+	}
+
+	// Check if there's a Graviton alternative for the recommended family
+	if gravitonFamily, hasGraviton := gravitonMap[newFamily]; hasGraviton {
+		gravitonType := gravitonFamily + "." + size
+		reasoning = append(reasoning,
+			fmt.Sprintf("Alternative: consider %s for ARM compatibility (~20%% additional savings)", gravitonType))
+	}
+
+	return &pbc.Recommendation{
+		Id:         uuid.New().String(),
+		Category:   pbc.RecommendationCategory_RECOMMENDATION_CATEGORY_COST,
+		ActionType: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MODIFY,
+		Resource: &pbc.ResourceRecommendationInfo{
+			Provider:     "aws",
+			ResourceType: "ec2",
+			Region:       region,
+			Sku:          instanceType,
+		},
+		ActionDetail: &pbc.Recommendation_Modify{
+			Modify: &pbc.ModifyAction{
+				ModificationType:  modTypeGenUpgrade,
+				CurrentConfig:     map[string]string{"instance_type": instanceType},
+				RecommendedConfig: map[string]string{"instance_type": newType},
+			},
+		},
+		Impact: &pbc.RecommendationImpact{
+			EstimatedSavings:  savings,
+			Currency:          "USD",
+			ProjectionPeriod:  "monthly",
+			CurrentCost:       currentMonthly,
+			ProjectedCost:     newMonthly,
+			SavingsPercentage: savingsPercent,
+		},
+		Priority:        pbc.RecommendationPriority_RECOMMENDATION_PRIORITY_MEDIUM,
+		ConfidenceScore: &confidence,
+		Description: fmt.Sprintf("Upgrade from %s to %s for better performance at same or lower cost",
+			instanceType, newType),
+		Reasoning: reasoning,
+		Source:    sourceAWSPublic,
+	}
+}
+
+// getGravitonRecommendation returns a recommendation to migrate to ARM-based
+// Graviton instances if available and cost-effective.
+// Implements FR-003, FR-007, FR-012 from spec.md.
+func (p *AWSPublicPlugin) getGravitonRecommendation(
+	instanceType, region string,
+) *pbc.Recommendation {
+	family, size := parseInstanceType(instanceType)
+	if family == "" {
+		return nil
+	}
+
+	gravitonFamily, exists := gravitonMap[family]
+	if !exists {
+		return nil
+	}
+
+	gravitonType := gravitonFamily + "." + size
+
+	currentPrice, found := p.pricing.EC2OnDemandPricePerHour(instanceType, "Linux", "Shared")
+	if !found {
+		return nil
+	}
+
+	gravitonPrice, found := p.pricing.EC2OnDemandPricePerHour(gravitonType, "Linux", "Shared")
+	// FR-011: Only recommend when new price <= current price
+	if !found || gravitonPrice > currentPrice {
+		return nil
+	}
+
+	// FR-005: Calculate monthly savings based on 730 hours/month
+	currentMonthly := currentPrice * hoursPerMonth
+	gravitonMonthly := gravitonPrice * hoursPerMonth
+	savings := currentMonthly - gravitonMonthly
+	savingsPercent := 0.0
+	if currentMonthly > 0 {
+		savingsPercent = (savings / currentMonthly) * 100
+	}
+
+	// FR-007: Set confidence level to 0.7 (medium) for Graviton recommendations
+	confidence := confidenceMedium
+	return &pbc.Recommendation{
+		Id:         uuid.New().String(),
+		Category:   pbc.RecommendationCategory_RECOMMENDATION_CATEGORY_COST,
+		ActionType: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MODIFY,
+		Resource: &pbc.ResourceRecommendationInfo{
+			Provider:     "aws",
+			ResourceType: "ec2",
+			Region:       region,
+			Sku:          instanceType,
+		},
+		ActionDetail: &pbc.Recommendation_Modify{
+			Modify: &pbc.ModifyAction{
+				ModificationType:  modTypeGraviton,
+				CurrentConfig:     map[string]string{"instance_type": instanceType, "architecture": "x86_64"},
+				RecommendedConfig: map[string]string{"instance_type": gravitonType, "architecture": "arm64"},
+			},
+		},
+		Impact: &pbc.RecommendationImpact{
+			EstimatedSavings:  savings,
+			Currency:          "USD",
+			ProjectionPeriod:  "monthly",
+			CurrentCost:       currentMonthly,
+			ProjectedCost:     gravitonMonthly,
+			SavingsPercentage: savingsPercent,
+		},
+		Priority:        pbc.RecommendationPriority_RECOMMENDATION_PRIORITY_LOW,
+		ConfidenceScore: &confidence,
+		Description: fmt.Sprintf("Migrate from %s to %s (Graviton) for ~%.0f%% cost savings",
+			instanceType, gravitonType, savingsPercent),
+		Reasoning: []string{
+			"Graviton instances are typically ~20% cheaper with comparable performance",
+			"Requires validation that application supports ARM architecture",
+		},
+		// FR-012: Include relevant metadata (architecture warnings)
+		Metadata: map[string]string{
+			"architecture_change":  "x86_64 -> arm64",
+			"requires_validation": "Application must support ARM architecture",
+		},
+		Source: sourceAWSPublic,
+	}
+}
+
+// getEBSRecommendations returns recommendations for EBS volume optimization.
+// Currently supports gp2 to gp3 migration.
+// Implements FR-004, FR-006 from spec.md.
+func (p *AWSPublicPlugin) getEBSRecommendations(
+	volumeType, region string,
+	tags map[string]string,
+) []*pbc.Recommendation {
+	// Only recommend for gp2 volumes
+	if volumeType != "gp2" {
+		return nil
+	}
+
+	// Extract size from tags, default to defaultEBSVolumeGB per edge case spec
+	sizeGB := defaultEBSVolumeGB
+	if sizeStr, ok := tags["size"]; ok {
+		if parsed, err := strconv.Atoi(sizeStr); err == nil && parsed > 0 {
+			sizeGB = parsed
+		}
+	} else if sizeStr, ok := tags["volume_size"]; ok {
+		if parsed, err := strconv.Atoi(sizeStr); err == nil && parsed > 0 {
+			sizeGB = parsed
+		}
+	}
+
+	gp2Price, found := p.pricing.EBSPricePerGBMonth("gp2")
+	if !found {
+		return nil
+	}
+
+	gp3Price, found := p.pricing.EBSPricePerGBMonth("gp3")
+	// FR-011: Only recommend when new price <= current price
+	if !found || gp3Price > gp2Price {
+		return nil
+	}
+
+	currentMonthly := gp2Price * float64(sizeGB)
+	gp3Monthly := gp3Price * float64(sizeGB)
+	savings := currentMonthly - gp3Monthly
+	savingsPercent := 0.0
+	if currentMonthly > 0 {
+		savingsPercent = (savings / currentMonthly) * 100
+	}
+
+	// FR-006: Set confidence level to 0.9 (high) for EBS volume changes
+	confidence := confidenceHigh
+	return []*pbc.Recommendation{{
+		Id:         uuid.New().String(),
+		Category:   pbc.RecommendationCategory_RECOMMENDATION_CATEGORY_COST,
+		ActionType: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MODIFY,
+		Resource: &pbc.ResourceRecommendationInfo{
+			Provider:     "aws",
+			ResourceType: "ebs",
+			Region:       region,
+			Sku:          volumeType,
+		},
+		ActionDetail: &pbc.Recommendation_Modify{
+			Modify: &pbc.ModifyAction{
+				ModificationType:  modTypeVolumeUpgrade,
+				CurrentConfig:     map[string]string{"volume_type": "gp2", "size_gb": strconv.Itoa(sizeGB)},
+				RecommendedConfig: map[string]string{"volume_type": "gp3", "size_gb": strconv.Itoa(sizeGB)},
+			},
+		},
+		Impact: &pbc.RecommendationImpact{
+			EstimatedSavings:  savings,
+			Currency:          "USD",
+			ProjectionPeriod:  "monthly",
+			CurrentCost:       currentMonthly,
+			ProjectedCost:     gp3Monthly,
+			SavingsPercentage: savingsPercent,
+		},
+		Priority:        pbc.RecommendationPriority_RECOMMENDATION_PRIORITY_MEDIUM,
+		ConfidenceScore: &confidence,
+		Description:     fmt.Sprintf("Upgrade %dGB gp2 volume to gp3 for ~%.0f%% cost savings", sizeGB, savingsPercent),
+		Reasoning: []string{
+			"gp3 volumes are ~20% cheaper than gp2",
+			"gp3 provides better baseline performance (3000 IOPS, 125 MB/s)",
+			"API-compatible change with no data migration required",
+		},
+		// FR-012: Include relevant metadata (performance info)
+		Metadata: map[string]string{
+			"baseline_iops":       "gp2: 100 IOPS/GB, gp3: 3000 IOPS (included)",
+			"baseline_throughput": "gp2: 128-250 MB/s, gp3: 125 MB/s (included)",
+		},
+		Source: sourceAWSPublic,
+	}}
+}

--- a/internal/plugin/recommendations_test.go
+++ b/internal/plugin/recommendations_test.go
@@ -1,0 +1,822 @@
+package plugin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+	pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// parseLastLogEntry parses the last non-empty JSON line from a log buffer.
+// This handles cases where the logger emits multiple entries during a test.
+// Returns the parsed map and any error encountered.
+func parseLastLogEntry(buf *bytes.Buffer) (map[string]interface{}, error) {
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) == 0 || lines[len(lines)-1] == "" {
+		return nil, nil
+	}
+	var logEntry map[string]interface{}
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &logEntry); err != nil {
+		return nil, err
+	}
+	return logEntry, nil
+}
+
+// TestGetRecommendations_NilRequest verifies FR-009: Return ERROR_CODE_INVALID_RESOURCE
+// when request is nil.
+func TestGetRecommendations_NilRequest(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	plugin := NewAWSPublicPlugin("us-east-1", mock, logger)
+
+	_, err := plugin.GetRecommendations(context.Background(), nil)
+	if err == nil {
+		t.Fatal("Expected error for nil request")
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatal("Expected gRPC status error")
+	}
+
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("Code = %v, want %v", st.Code(), codes.InvalidArgument)
+	}
+
+	// Check for ErrorCode in details
+	var foundErrorCode bool
+	for _, detail := range st.Details() {
+		if errDetail, ok := detail.(*pbc.ErrorDetail); ok {
+			if errDetail.Code == pbc.ErrorCode_ERROR_CODE_INVALID_RESOURCE {
+				foundErrorCode = true
+			}
+		}
+	}
+
+	if !foundErrorCode {
+		t.Error("Expected ERROR_CODE_INVALID_RESOURCE in error details")
+	}
+}
+
+// TestGetRecommendations_EmptyRequest verifies FR-008: Return empty recommendations
+// list (not error) when request is valid but has no filter context.
+func TestGetRecommendations_EmptyRequest(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	plugin := NewAWSPublicPlugin("us-east-1", mock, logger)
+
+	req := &pbc.GetRecommendationsRequest{}
+	resp, err := plugin.GetRecommendations(context.Background(), req)
+	if err != nil {
+		t.Fatalf("GetRecommendations() error: %v", err)
+	}
+
+	if resp == nil {
+		t.Fatal("Expected non-nil response")
+	}
+
+	if len(resp.Recommendations) != 0 {
+		t.Errorf("Expected empty recommendations list, got %d", len(resp.Recommendations))
+	}
+
+	if resp.Summary == nil {
+		t.Error("Expected non-nil summary")
+	}
+}
+
+// TestGetRecommendations_TraceIDInLogs verifies FR-010: Include trace_id in all log entries.
+func TestGetRecommendations_TraceIDInLogs(t *testing.T) {
+	var logBuf bytes.Buffer
+	mock := newMockPricingClient("us-east-1", "USD")
+	logger := zerolog.New(&logBuf).Level(zerolog.InfoLevel)
+	plugin := NewAWSPublicPlugin("us-east-1", mock, logger)
+
+	expectedTraceID := "test-recommendations-trace-12345"
+	md := metadata.New(map[string]string{
+		pluginsdk.TraceIDMetadataKey: expectedTraceID,
+	})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	req := &pbc.GetRecommendationsRequest{}
+	_, err := plugin.GetRecommendations(ctx, req)
+	if err != nil {
+		t.Fatalf("GetRecommendations() error: %v", err)
+	}
+
+	// Verify trace_id in log output
+	logEntry, err := parseLastLogEntry(&logBuf)
+	if err != nil {
+		t.Fatalf("Failed to parse log output as JSON: %v\nRaw: %s", err, logBuf.String())
+	}
+
+	traceID, ok := logEntry["trace_id"].(string)
+	if !ok {
+		t.Fatal("trace_id not found in log entry")
+	}
+
+	if traceID != expectedTraceID {
+		t.Errorf("trace_id = %q, want %q", traceID, expectedTraceID)
+	}
+
+	// Verify operation field
+	operation, ok := logEntry["operation"].(string)
+	if !ok || operation != "GetRecommendations" {
+		t.Errorf("operation = %q, want %q", operation, "GetRecommendations")
+	}
+}
+
+// TestGetRecommendations_EC2WithFilter verifies that GetRecommendations returns
+// EC2 recommendations when provided with a proper filter containing SKU and resource type.
+func TestGetRecommendations_EC2WithFilter(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	// t2.medium is older, t3.medium is newer and cheaper
+	mock.ec2Prices["t2.medium/Linux/Shared"] = 0.0464
+	mock.ec2Prices["t3.medium/Linux/Shared"] = 0.0416
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	plugin := NewAWSPublicPlugin("us-east-1", mock, logger)
+
+	req := &pbc.GetRecommendationsRequest{
+		Filter: &pbc.RecommendationFilter{
+			ResourceType: "ec2",
+			Sku:          "t2.medium",
+			Region:       "us-east-1",
+		},
+	}
+
+	resp, err := plugin.GetRecommendations(context.Background(), req)
+	if err != nil {
+		t.Fatalf("GetRecommendations() error: %v", err)
+	}
+
+	if resp == nil {
+		t.Fatal("Expected non-nil response")
+	}
+
+	// Should have at least one recommendation (generation upgrade t2->t3)
+	if len(resp.Recommendations) == 0 {
+		t.Error("Expected at least one recommendation for t2.medium")
+	}
+
+	// Verify a generation upgrade recommendation exists
+	var foundGenUpgrade bool
+	for _, rec := range resp.Recommendations {
+		if rec.GetModify() != nil && rec.GetModify().ModificationType == modTypeGenUpgrade {
+			foundGenUpgrade = true
+			// Verify the recommended config
+			if rec.GetModify().RecommendedConfig["instance_type"] != "t3.medium" {
+				t.Errorf("Expected recommended instance_type t3.medium, got %s",
+					rec.GetModify().RecommendedConfig["instance_type"])
+			}
+		}
+	}
+
+	if !foundGenUpgrade {
+		t.Error("Expected generation upgrade recommendation")
+	}
+
+	// Summary should reflect the recommendations
+	if resp.Summary == nil {
+		t.Error("Expected non-nil summary")
+	}
+}
+
+// TestGetRecommendations_EBSWithFilter verifies that GetRecommendations returns
+// EBS recommendations when provided with a proper filter for gp2 volumes.
+func TestGetRecommendations_EBSWithFilter(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	mock.ebsPrices["gp2"] = 0.10
+	mock.ebsPrices["gp3"] = 0.08
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	plugin := NewAWSPublicPlugin("us-east-1", mock, logger)
+
+	req := &pbc.GetRecommendationsRequest{
+		Filter: &pbc.RecommendationFilter{
+			ResourceType: "ebs",
+			Sku:          "gp2",
+			Region:       "us-east-1",
+			Tags:         map[string]string{"size": "100"},
+		},
+	}
+
+	resp, err := plugin.GetRecommendations(context.Background(), req)
+	if err != nil {
+		t.Fatalf("GetRecommendations() error: %v", err)
+	}
+
+	if resp == nil {
+		t.Fatal("Expected non-nil response")
+	}
+
+	// Should have exactly one recommendation (gp2->gp3)
+	if len(resp.Recommendations) != 1 {
+		t.Errorf("Expected 1 recommendation for gp2 volume, got %d", len(resp.Recommendations))
+	}
+
+	if len(resp.Recommendations) > 0 {
+		rec := resp.Recommendations[0]
+		if rec.GetModify() == nil {
+			t.Fatal("Expected modify action")
+		}
+		if rec.GetModify().ModificationType != modTypeVolumeUpgrade {
+			t.Errorf("Expected modification type %s, got %s", modTypeVolumeUpgrade, rec.GetModify().ModificationType)
+		}
+		if rec.GetModify().RecommendedConfig["volume_type"] != "gp3" {
+			t.Errorf("Expected recommended volume_type gp3, got %s",
+				rec.GetModify().RecommendedConfig["volume_type"])
+		}
+	}
+}
+
+// TestGetRecommendations_DefaultRegion verifies that when filter.Region is empty,
+// the plugin uses its own region for recommendations.
+func TestGetRecommendations_DefaultRegion(t *testing.T) {
+	mock := newMockPricingClient("us-west-2", "USD")
+	mock.ec2Prices["m5.large/Linux/Shared"] = 0.096
+	mock.ec2Prices["m6i.large/Linux/Shared"] = 0.096
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	plugin := NewAWSPublicPlugin("us-west-2", mock, logger)
+
+	req := &pbc.GetRecommendationsRequest{
+		Filter: &pbc.RecommendationFilter{
+			ResourceType: "ec2",
+			Sku:          "m5.large",
+			// Region intentionally empty - should use plugin's region
+		},
+	}
+
+	resp, err := plugin.GetRecommendations(context.Background(), req)
+	if err != nil {
+		t.Fatalf("GetRecommendations() error: %v", err)
+	}
+
+	if resp == nil {
+		t.Fatal("Expected non-nil response")
+	}
+
+	// Should have recommendations (m5->m6i generation upgrade)
+	if len(resp.Recommendations) == 0 {
+		t.Error("Expected recommendations when region defaults to plugin region")
+	}
+
+	// Verify recommendations use the plugin's region
+	for _, rec := range resp.Recommendations {
+		if rec.Resource != nil && rec.Resource.Region != "us-west-2" {
+			t.Errorf("Expected region us-west-2, got %s", rec.Resource.Region)
+		}
+	}
+}
+
+// TestGetRecommendations_PulumiResourceType verifies that Pulumi-format resource types
+// (e.g., "aws:ec2/instance:Instance") are correctly handled.
+func TestGetRecommendations_PulumiResourceType(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	mock.ec2Prices["c5.xlarge/Linux/Shared"] = 0.17
+	mock.ec2Prices["c6i.xlarge/Linux/Shared"] = 0.17
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	plugin := NewAWSPublicPlugin("us-east-1", mock, logger)
+
+	req := &pbc.GetRecommendationsRequest{
+		Filter: &pbc.RecommendationFilter{
+			ResourceType: "aws:ec2/instance:Instance", // Pulumi format
+			Sku:          "c5.xlarge",
+			Region:       "us-east-1",
+		},
+	}
+
+	resp, err := plugin.GetRecommendations(context.Background(), req)
+	if err != nil {
+		t.Fatalf("GetRecommendations() error: %v", err)
+	}
+
+	// Should have at least one recommendation
+	if len(resp.Recommendations) == 0 {
+		t.Error("Expected recommendations for Pulumi-format resource type")
+	}
+}
+
+// TestGenerateEC2Recommendations_GenerationUpgrade verifies FR-002: Return generation
+// upgrade recommendations for EC2 instances when newer generations offer same or lower price.
+func TestGenerateEC2Recommendations_GenerationUpgrade(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	// t2.medium is older, t3.medium is newer and cheaper
+	mock.ec2Prices["t2.medium/Linux/Shared"] = 0.0464
+	mock.ec2Prices["t3.medium/Linux/Shared"] = 0.0416
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	plugin := NewAWSPublicPlugin("us-east-1", mock, logger)
+
+	recs := plugin.generateEC2Recommendations("t2.medium", "us-east-1")
+
+	// Should have at least one recommendation (generation upgrade)
+	var genUpgradeRec *pbc.Recommendation
+	for _, rec := range recs {
+		if rec.GetModify() != nil && rec.GetModify().ModificationType == modTypeGenUpgrade {
+			genUpgradeRec = rec
+			break
+		}
+	}
+
+	if genUpgradeRec == nil {
+		t.Fatal("Expected generation upgrade recommendation")
+	}
+
+	// Verify recommendation details
+	if genUpgradeRec.Category != pbc.RecommendationCategory_RECOMMENDATION_CATEGORY_COST {
+		t.Errorf("Category = %v, want COST", genUpgradeRec.Category)
+	}
+
+	if genUpgradeRec.ActionType != pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MODIFY {
+		t.Errorf("ActionType = %v, want MODIFY", genUpgradeRec.ActionType)
+	}
+
+	// Verify resource info
+	if genUpgradeRec.Resource == nil {
+		t.Fatal("Expected Resource to be set")
+	}
+	if genUpgradeRec.Resource.Provider != "aws" {
+		t.Errorf("Provider = %q, want %q", genUpgradeRec.Resource.Provider, "aws")
+	}
+	if genUpgradeRec.Resource.ResourceType != "ec2" {
+		t.Errorf("ResourceType = %q, want %q", genUpgradeRec.Resource.ResourceType, "ec2")
+	}
+
+	// Verify modify action
+	modify := genUpgradeRec.GetModify()
+	if modify == nil {
+		t.Fatal("Expected Modify action")
+	}
+	if modify.CurrentConfig["instance_type"] != "t2.medium" {
+		t.Errorf("CurrentConfig[instance_type] = %q, want %q", modify.CurrentConfig["instance_type"], "t2.medium")
+	}
+	if modify.RecommendedConfig["instance_type"] != "t3.medium" {
+		t.Errorf("RecommendedConfig[instance_type] = %q, want %q", modify.RecommendedConfig["instance_type"], "t3.medium")
+	}
+
+	// FR-006: Verify confidence level is 0.9 (high) for generation upgrades
+	if genUpgradeRec.ConfidenceScore == nil || *genUpgradeRec.ConfidenceScore != confidenceHigh {
+		t.Errorf("ConfidenceScore = %v, want %v", genUpgradeRec.ConfidenceScore, confidenceHigh)
+	}
+
+	// Verify impact calculations (FR-005: 730 hours/month)
+	if genUpgradeRec.Impact == nil {
+		t.Fatal("Expected Impact to be set")
+	}
+	expectedCurrentMonthly := 0.0464 * hoursPerMonth  // ~33.87
+	expectedNewMonthly := 0.0416 * hoursPerMonth      // ~30.37
+	expectedSavings := expectedCurrentMonthly - expectedNewMonthly
+
+	if genUpgradeRec.Impact.CurrentCost != expectedCurrentMonthly {
+		t.Errorf("CurrentCost = %v, want %v", genUpgradeRec.Impact.CurrentCost, expectedCurrentMonthly)
+	}
+	if genUpgradeRec.Impact.ProjectedCost != expectedNewMonthly {
+		t.Errorf("ProjectedCost = %v, want %v", genUpgradeRec.Impact.ProjectedCost, expectedNewMonthly)
+	}
+	if genUpgradeRec.Impact.EstimatedSavings != expectedSavings {
+		t.Errorf("EstimatedSavings = %v, want %v", genUpgradeRec.Impact.EstimatedSavings, expectedSavings)
+	}
+
+	// Verify source
+	if genUpgradeRec.Source != sourceAWSPublic {
+		t.Errorf("Source = %q, want %q", genUpgradeRec.Source, sourceAWSPublic)
+	}
+}
+
+// TestGenerateEC2Recommendations_NoUpgradeWhenNewIsExpensive verifies FR-011:
+// Only recommend when new price <= current price.
+func TestGenerateEC2Recommendations_NoUpgradeWhenNewIsExpensive(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	// Make the newer generation MORE expensive (edge case)
+	mock.ec2Prices["t2.medium/Linux/Shared"] = 0.0400
+	mock.ec2Prices["t3.medium/Linux/Shared"] = 0.0500 // More expensive
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	plugin := NewAWSPublicPlugin("us-east-1", mock, logger)
+
+	recs := plugin.generateEC2Recommendations("t2.medium", "us-east-1")
+
+	// Should NOT have generation upgrade recommendation
+	for _, rec := range recs {
+		if rec.GetModify() != nil && rec.GetModify().ModificationType == modTypeGenUpgrade {
+			t.Error("Should not recommend upgrade when new generation is more expensive")
+		}
+	}
+}
+
+// TestGenerateEC2Recommendations_NoUpgradeWhenPricingMissing verifies that we don't
+// recommend when pricing data is unavailable.
+func TestGenerateEC2Recommendations_NoUpgradeWhenPricingMissing(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	// Only set current price, not the new generation price
+	mock.ec2Prices["t2.medium/Linux/Shared"] = 0.0464
+	// t3.medium price NOT set
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	plugin := NewAWSPublicPlugin("us-east-1", mock, logger)
+
+	recs := plugin.generateEC2Recommendations("t2.medium", "us-east-1")
+
+	// Should NOT have generation upgrade recommendation
+	for _, rec := range recs {
+		if rec.GetModify() != nil && rec.GetModify().ModificationType == modTypeGenUpgrade {
+			t.Error("Should not recommend upgrade when new generation pricing is missing")
+		}
+	}
+}
+
+// TestGenerateEC2Recommendations_LatestGeneration verifies no recommendation when
+// instance is already the latest generation.
+func TestGenerateEC2Recommendations_LatestGeneration(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	// t3a is end of upgrade chain, no recommendation expected
+	mock.ec2Prices["t3a.micro/Linux/Shared"] = 0.0094
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	plugin := NewAWSPublicPlugin("us-east-1", mock, logger)
+
+	rec := plugin.getGenerationUpgradeRecommendation("t3a.micro", "us-east-1")
+
+	if rec != nil {
+		t.Error("Expected no recommendation for latest generation instance")
+	}
+}
+
+// TestGenerateEC2Recommendations_GravitonMigration verifies FR-003: Return Graviton/ARM
+// migration recommendations for compatible x86 instance families.
+func TestGenerateEC2Recommendations_GravitonMigration(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	mock.ec2Prices["m5.large/Linux/Shared"] = 0.096
+	mock.ec2Prices["m6g.large/Linux/Shared"] = 0.077 // ~20% cheaper
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	plugin := NewAWSPublicPlugin("us-east-1", mock, logger)
+
+	recs := plugin.generateEC2Recommendations("m5.large", "us-east-1")
+
+	// Should have Graviton recommendation
+	var gravitonRec *pbc.Recommendation
+	for _, rec := range recs {
+		if rec.GetModify() != nil && rec.GetModify().ModificationType == modTypeGraviton {
+			gravitonRec = rec
+			break
+		}
+	}
+
+	if gravitonRec == nil {
+		t.Fatal("Expected Graviton migration recommendation")
+	}
+
+	// FR-007: Verify confidence level is 0.7 (medium) for Graviton recommendations
+	if gravitonRec.ConfidenceScore == nil || *gravitonRec.ConfidenceScore != confidenceMedium {
+		t.Errorf("ConfidenceScore = %v, want %v", gravitonRec.ConfidenceScore, confidenceMedium)
+	}
+
+	// Verify architecture change in config
+	modify := gravitonRec.GetModify()
+	if modify.CurrentConfig["architecture"] != "x86_64" {
+		t.Errorf("CurrentConfig[architecture] = %q, want %q", modify.CurrentConfig["architecture"], "x86_64")
+	}
+	if modify.RecommendedConfig["architecture"] != "arm64" {
+		t.Errorf("RecommendedConfig[architecture] = %q, want %q", modify.RecommendedConfig["architecture"], "arm64")
+	}
+
+	// FR-012: Verify metadata includes architecture warning
+	if gravitonRec.Metadata == nil {
+		t.Fatal("Expected Metadata to be set")
+	}
+	if _, ok := gravitonRec.Metadata["architecture_change"]; !ok {
+		t.Error("Expected architecture_change in metadata")
+	}
+	if _, ok := gravitonRec.Metadata["requires_validation"]; !ok {
+		t.Error("Expected requires_validation in metadata")
+	}
+
+	// Verify priority is LOW (Graviton requires validation)
+	if gravitonRec.Priority != pbc.RecommendationPriority_RECOMMENDATION_PRIORITY_LOW {
+		t.Errorf("Priority = %v, want LOW", gravitonRec.Priority)
+	}
+}
+
+// TestGenerateEC2Recommendations_BothUpgrades verifies that both generation upgrade
+// AND Graviton recommendations can be returned when applicable.
+func TestGenerateEC2Recommendations_BothUpgrades(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	// m5.large can upgrade to m6i and also migrate to m6g
+	mock.ec2Prices["m5.large/Linux/Shared"] = 0.096
+	mock.ec2Prices["m6i.large/Linux/Shared"] = 0.096 // Same price
+	mock.ec2Prices["m6g.large/Linux/Shared"] = 0.077  // Cheaper (Graviton)
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	plugin := NewAWSPublicPlugin("us-east-1", mock, logger)
+
+	recs := plugin.generateEC2Recommendations("m5.large", "us-east-1")
+
+	var hasGenUpgrade, hasGraviton bool
+	for _, rec := range recs {
+		if rec.GetModify() == nil {
+			continue
+		}
+		switch rec.GetModify().ModificationType {
+		case modTypeGenUpgrade:
+			hasGenUpgrade = true
+		case modTypeGraviton:
+			hasGraviton = true
+		}
+	}
+
+	if !hasGenUpgrade {
+		t.Error("Expected generation upgrade recommendation")
+	}
+	if !hasGraviton {
+		t.Error("Expected Graviton recommendation")
+	}
+}
+
+// TestGetEBSRecommendations_Gp2ToGp3 verifies FR-004: Return gp2→gp3 volume type
+// upgrade recommendations for EBS volumes.
+func TestGetEBSRecommendations_Gp2ToGp3(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	mock.ebsPrices["gp2"] = 0.10 // per GB-month
+	mock.ebsPrices["gp3"] = 0.08 // 20% cheaper
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	plugin := NewAWSPublicPlugin("us-east-1", mock, logger)
+
+	tags := map[string]string{"size": "500"}
+	recs := plugin.getEBSRecommendations("gp2", "us-east-1", tags)
+
+	if len(recs) == 0 {
+		t.Fatal("Expected EBS recommendation")
+	}
+
+	rec := recs[0]
+
+	// Verify category
+	if rec.Category != pbc.RecommendationCategory_RECOMMENDATION_CATEGORY_COST {
+		t.Errorf("Category = %v, want COST", rec.Category)
+	}
+
+	// Verify resource type
+	if rec.Resource == nil || rec.Resource.ResourceType != "ebs" {
+		t.Error("Expected ResourceType = 'ebs'")
+	}
+
+	// FR-006: Verify confidence level is 0.9 (high) for EBS volume changes
+	if rec.ConfidenceScore == nil || *rec.ConfidenceScore != confidenceHigh {
+		t.Errorf("ConfidenceScore = %v, want %v", rec.ConfidenceScore, confidenceHigh)
+	}
+
+	// Verify modify action
+	modify := rec.GetModify()
+	if modify == nil {
+		t.Fatal("Expected Modify action")
+	}
+	if modify.ModificationType != modTypeVolumeUpgrade {
+		t.Errorf("ModificationType = %q, want %q", modify.ModificationType, modTypeVolumeUpgrade)
+	}
+	if modify.CurrentConfig["volume_type"] != "gp2" {
+		t.Errorf("CurrentConfig[volume_type] = %q, want %q", modify.CurrentConfig["volume_type"], "gp2")
+	}
+	if modify.RecommendedConfig["volume_type"] != "gp3" {
+		t.Errorf("RecommendedConfig[volume_type] = %q, want %q", modify.RecommendedConfig["volume_type"], "gp3")
+	}
+
+	// Verify impact calculations
+	expectedCurrentMonthly := 0.10 * 500 // $50
+	expectedGp3Monthly := 0.08 * 500     // $40
+	expectedSavings := 10.0              // $10
+
+	if rec.Impact.CurrentCost != expectedCurrentMonthly {
+		t.Errorf("CurrentCost = %v, want %v", rec.Impact.CurrentCost, expectedCurrentMonthly)
+	}
+	if rec.Impact.ProjectedCost != expectedGp3Monthly {
+		t.Errorf("ProjectedCost = %v, want %v", rec.Impact.ProjectedCost, expectedGp3Monthly)
+	}
+	if rec.Impact.EstimatedSavings != expectedSavings {
+		t.Errorf("EstimatedSavings = %v, want %v", rec.Impact.EstimatedSavings, expectedSavings)
+	}
+
+	// FR-012: Verify metadata includes performance info
+	if rec.Metadata == nil {
+		t.Fatal("Expected Metadata to be set")
+	}
+	if _, ok := rec.Metadata["baseline_iops"]; !ok {
+		t.Error("Expected baseline_iops in metadata")
+	}
+	if _, ok := rec.Metadata["baseline_throughput"]; !ok {
+		t.Error("Expected baseline_throughput in metadata")
+	}
+}
+
+// TestGetEBSRecommendations_DefaultSize verifies default size of 100GB is used
+// when size is not specified in tags (edge case from spec.md).
+func TestGetEBSRecommendations_DefaultSize(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	mock.ebsPrices["gp2"] = 0.10
+	mock.ebsPrices["gp3"] = 0.08
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	plugin := NewAWSPublicPlugin("us-east-1", mock, logger)
+
+	// No size tag
+	tags := map[string]string{}
+	recs := plugin.getEBSRecommendations("gp2", "us-east-1", tags)
+
+	if len(recs) == 0 {
+		t.Fatal("Expected EBS recommendation")
+	}
+
+	rec := recs[0]
+	modify := rec.GetModify()
+	if modify.CurrentConfig["size_gb"] != "100" {
+		t.Errorf("CurrentConfig[size_gb] = %q, want %q (default)", modify.CurrentConfig["size_gb"], "100")
+	}
+
+	// Verify impact calculations use default 100GB
+	expectedCurrentMonthly := 0.10 * 100 // $10
+	if rec.Impact.CurrentCost != expectedCurrentMonthly {
+		t.Errorf("CurrentCost = %v, want %v", rec.Impact.CurrentCost, expectedCurrentMonthly)
+	}
+}
+
+// TestGetEBSRecommendations_VolumeSizeTag verifies alternative "volume_size" tag is supported.
+func TestGetEBSRecommendations_VolumeSizeTag(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	mock.ebsPrices["gp2"] = 0.10
+	mock.ebsPrices["gp3"] = 0.08
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	plugin := NewAWSPublicPlugin("us-east-1", mock, logger)
+
+	// Use "volume_size" instead of "size"
+	tags := map[string]string{"volume_size": "200"}
+	recs := plugin.getEBSRecommendations("gp2", "us-east-1", tags)
+
+	if len(recs) == 0 {
+		t.Fatal("Expected EBS recommendation")
+	}
+
+	rec := recs[0]
+	modify := rec.GetModify()
+	if modify.CurrentConfig["size_gb"] != "200" {
+		t.Errorf("CurrentConfig[size_gb] = %q, want %q", modify.CurrentConfig["size_gb"], "200")
+	}
+}
+
+// TestGetEBSRecommendations_NoRecommendationForGp3 verifies no recommendation
+// when volume is already gp3.
+func TestGetEBSRecommendations_NoRecommendationForGp3(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	mock.ebsPrices["gp2"] = 0.10
+	mock.ebsPrices["gp3"] = 0.08
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	plugin := NewAWSPublicPlugin("us-east-1", mock, logger)
+
+	recs := plugin.getEBSRecommendations("gp3", "us-east-1", nil)
+
+	if len(recs) != 0 {
+		t.Errorf("Expected no recommendations for gp3 volume, got %d", len(recs))
+	}
+}
+
+// TestGetEBSRecommendations_NoRecommendationForIo1 verifies no recommendation
+// for io1/io2 volumes (out of scope per spec.md).
+func TestGetEBSRecommendations_NoRecommendationForIo1(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	plugin := NewAWSPublicPlugin("us-east-1", mock, logger)
+
+	for _, volumeType := range []string{"io1", "io2", "st1", "sc1"} {
+		recs := plugin.getEBSRecommendations(volumeType, "us-east-1", nil)
+		if len(recs) != 0 {
+			t.Errorf("Expected no recommendations for %s volume, got %d", volumeType, len(recs))
+		}
+	}
+}
+
+// TestGenerateEC2Recommendations_InvalidInstanceType verifies no recommendations
+// for invalid instance type formats.
+func TestGenerateEC2Recommendations_InvalidInstanceType(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	plugin := NewAWSPublicPlugin("us-east-1", mock, logger)
+
+	invalidTypes := []string{"", "invalid", "t2", ".medium", "t2.", "..."}
+
+	for _, instanceType := range invalidTypes {
+		recs := plugin.generateEC2Recommendations(instanceType, "us-east-1")
+		if len(recs) != 0 {
+			t.Errorf("Expected no recommendations for invalid instance type %q, got %d", instanceType, len(recs))
+		}
+	}
+}
+
+// TestRecommendationHasUniqueID verifies each recommendation has a unique UUID.
+func TestRecommendationHasUniqueID(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	mock.ec2Prices["m5.large/Linux/Shared"] = 0.096
+	mock.ec2Prices["m6i.large/Linux/Shared"] = 0.096
+	mock.ec2Prices["m6g.large/Linux/Shared"] = 0.077
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	plugin := NewAWSPublicPlugin("us-east-1", mock, logger)
+
+	recs := plugin.generateEC2Recommendations("m5.large", "us-east-1")
+
+	if len(recs) < 2 {
+		t.Skip("Need at least 2 recommendations to test uniqueness")
+	}
+
+	ids := make(map[string]bool)
+	for _, rec := range recs {
+		if rec.Id == "" {
+			t.Error("Recommendation ID should not be empty")
+		}
+		if ids[rec.Id] {
+			t.Errorf("Duplicate recommendation ID: %s", rec.Id)
+		}
+		ids[rec.Id] = true
+
+		// Verify UUID format (36 chars with hyphens)
+		if len(rec.Id) != 36 {
+			t.Errorf("Recommendation ID %q should be UUID format (36 chars)", rec.Id)
+		}
+	}
+}
+
+// TestGetRecommendations_LogsContainDurationMs verifies log entries include duration_ms.
+func TestGetRecommendations_LogsContainDurationMs(t *testing.T) {
+	var logBuf bytes.Buffer
+	mock := newMockPricingClient("us-east-1", "USD")
+	logger := zerolog.New(&logBuf).Level(zerolog.InfoLevel)
+	plugin := NewAWSPublicPlugin("us-east-1", mock, logger)
+
+	req := &pbc.GetRecommendationsRequest{}
+	_, err := plugin.GetRecommendations(context.Background(), req)
+	if err != nil {
+		t.Fatalf("GetRecommendations() error: %v", err)
+	}
+
+	logEntry, err := parseLastLogEntry(&logBuf)
+	if err != nil {
+		t.Fatalf("Failed to parse log output as JSON: %v\nRaw: %s", err, logBuf.String())
+	}
+
+	durationMs, ok := logEntry["duration_ms"].(float64)
+	if !ok {
+		t.Fatal("duration_ms not found in log entry")
+	}
+
+	if durationMs < 0 {
+		t.Errorf("duration_ms = %v, should be non-negative", durationMs)
+	}
+}
+
+// TestGetRecommendations_LogsContainRecommendationCount verifies log entries include
+// the count of recommendations generated.
+func TestGetRecommendations_LogsContainRecommendationCount(t *testing.T) {
+	var logBuf bytes.Buffer
+	mock := newMockPricingClient("us-east-1", "USD")
+	logger := zerolog.New(&logBuf).Level(zerolog.InfoLevel)
+	plugin := NewAWSPublicPlugin("us-east-1", mock, logger)
+
+	req := &pbc.GetRecommendationsRequest{}
+	_, err := plugin.GetRecommendations(context.Background(), req)
+	if err != nil {
+		t.Fatalf("GetRecommendations() error: %v", err)
+	}
+
+	logEntry, err := parseLastLogEntry(&logBuf)
+	if err != nil {
+		t.Fatalf("Failed to parse log output as JSON: %v\nRaw: %s", err, logBuf.String())
+	}
+
+	_, ok := logEntry["recommendation_count"].(float64)
+	if !ok {
+		t.Fatal("recommendation_count not found in log entry")
+	}
+}
+
+// TestGetRecommendations_ErrorLogsContainErrorCode verifies FR-009 error logging.
+func TestGetRecommendations_ErrorLogsContainErrorCode(t *testing.T) {
+	var logBuf bytes.Buffer
+	mock := newMockPricingClient("us-east-1", "USD")
+	logger := zerolog.New(&logBuf).Level(zerolog.ErrorLevel)
+	plugin := NewAWSPublicPlugin("us-east-1", mock, logger)
+
+	_, err := plugin.GetRecommendations(context.Background(), nil)
+	if err == nil {
+		t.Fatal("Expected error for nil request")
+	}
+
+	logEntry, parseErr := parseLastLogEntry(&logBuf)
+	if parseErr != nil {
+		t.Fatalf("Failed to parse log output as JSON: %v\nRaw: %s", parseErr, logBuf.String())
+	}
+
+	errorCode, ok := logEntry["error_code"].(string)
+	if !ok || errorCode == "" {
+		t.Error("error_code field should be present in error log")
+	}
+
+	if !strings.Contains(errorCode, "INVALID_RESOURCE") {
+		t.Errorf("error_code = %q, should contain INVALID_RESOURCE", errorCode)
+	}
+}

--- a/specs/012-recommendations/checklists/requirements.md
+++ b/specs/012-recommendations/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: GetRecommendations RPC for Cost Optimization
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-15
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Specification derived from GitHub Issue #105 which provided detailed context
+- All 12 functional requirements map to specific acceptance scenarios
+- Out of scope items clearly documented with justification
+- Confidence levels (high/medium) appropriately assigned based on risk
+- Edge cases cover missing data, region availability, and multiple recommendation scenarios

--- a/specs/012-recommendations/data-model.md
+++ b/specs/012-recommendations/data-model.md
@@ -1,0 +1,271 @@
+# Data Model: GetRecommendations RPC
+
+**Date**: 2025-12-15
+**Feature**: 012-recommendations
+
+## Instance Family Mappings
+
+### Generation Upgrade Map
+
+Maps older EC2 instance families to their newer generation equivalents.
+
+```go
+// generationUpgradeMap maps old instance families to newer generations.
+// Only includes mappings where the newer generation is typically the same price
+// or cheaper with better performance.
+var generationUpgradeMap = map[string]string{
+    // T-series (burstable general purpose)
+    "t2":  "t3",   // 2014 → 2018
+    "t3":  "t3a",  // Intel → AMD (often cheaper)
+
+    // M-series (general purpose)
+    "m4":  "m5",   // 2015 → 2017
+    "m5":  "m6i",  // 2017 → 2021
+    "m5a": "m6a",  // AMD 2018 → AMD 2022
+
+    // C-series (compute optimized)
+    "c4":  "c5",   // 2015 → 2017
+    "c5":  "c6i",  // 2017 → 2021
+    "c5a": "c6a",  // AMD 2020 → AMD 2022
+
+    // R-series (memory optimized)
+    "r4":  "r5",   // 2016 → 2018
+    "r5":  "r6i",  // 2018 → 2021
+    "r5a": "r6a",  // AMD 2019 → AMD 2022
+
+    // I-series (storage optimized)
+    "i3":  "i3en", // 2017 → 2019
+
+    // D-series (dense storage)
+    "d2":  "d3",   // 2015 → 2020
+}
+```
+
+**Validation Rule**: Before recommending, verify:
+1. `newType` exists in pricing data for the region
+2. `newPrice <= currentPrice`
+
+### Graviton Migration Map
+
+Maps x86 instance families to ARM/Graviton equivalents.
+
+```go
+// gravitonMap maps x86 instance families to Graviton (ARM) equivalents.
+// Graviton instances typically offer ~20% cost savings with comparable performance.
+var gravitonMap = map[string]string{
+    // M-series → M6g
+    "m5":   "m6g",
+    "m5a":  "m6g",
+    "m5n":  "m6g",
+    "m6i":  "m6g",
+    "m6a":  "m6g",
+
+    // C-series → C6g/C6gn
+    "c5":   "c6g",
+    "c5a":  "c6g",
+    "c5n":  "c6gn",
+    "c6i":  "c6g",
+    "c6a":  "c6g",
+
+    // R-series → R6g
+    "r5":   "r6g",
+    "r5a":  "r6g",
+    "r5n":  "r6g",
+    "r6i":  "r6g",
+    "r6a":  "r6g",
+
+    // T-series → T4g
+    "t3":   "t4g",
+    "t3a":  "t4g",
+}
+```
+
+**Confidence Score**: 0.7 (medium) - Requires ARM compatibility validation.
+
+## Recommendation Types
+
+### EC2 Generation Upgrade
+
+| Field | Value |
+|-------|-------|
+| Category | `RECOMMENDATION_CATEGORY_COST_OPTIMIZATION` |
+| ActionType | `RECOMMENDATION_ACTION_TYPE_MODIFY` |
+| ModificationType | `"generation_upgrade"` |
+| Priority | `RECOMMENDATION_PRIORITY_MEDIUM` |
+| ConfidenceScore | `0.9` |
+| Source | `"aws-public"` |
+
+**CurrentConfig**:
+```json
+{
+  "instance_type": "t2.medium"
+}
+```
+
+**RecommendedConfig**:
+```json
+{
+  "instance_type": "t3.medium"
+}
+```
+
+**Reasoning**:
+- "Newer t3 instances offer better performance at same or lower cost"
+- "Drop-in replacement with no architecture changes required"
+
+### EC2 Graviton Migration
+
+| Field | Value |
+|-------|-------|
+| Category | `RECOMMENDATION_CATEGORY_COST_OPTIMIZATION` |
+| ActionType | `RECOMMENDATION_ACTION_TYPE_MODIFY` |
+| ModificationType | `"graviton_migration"` |
+| Priority | `RECOMMENDATION_PRIORITY_LOW` |
+| ConfidenceScore | `0.7` |
+| Source | `"aws-public"` |
+
+**CurrentConfig**:
+```json
+{
+  "instance_type": "m5.large",
+  "architecture": "x86_64"
+}
+```
+
+**RecommendedConfig**:
+```json
+{
+  "instance_type": "m6g.large",
+  "architecture": "arm64"
+}
+```
+
+**Reasoning**:
+- "Graviton instances are ~20% cheaper with comparable performance"
+- "Requires validation that application supports ARM architecture"
+
+**Metadata**:
+```json
+{
+  "architecture_change": "x86_64 -> arm64",
+  "requires_validation": "Application must support ARM architecture"
+}
+```
+
+### EBS Volume Type Upgrade
+
+| Field | Value |
+|-------|-------|
+| Category | `RECOMMENDATION_CATEGORY_COST_OPTIMIZATION` |
+| ActionType | `RECOMMENDATION_ACTION_TYPE_MODIFY` |
+| ModificationType | `"volume_type_upgrade"` |
+| Priority | `RECOMMENDATION_PRIORITY_MEDIUM` |
+| ConfidenceScore | `0.9` |
+| Source | `"aws-public"` |
+
+**CurrentConfig**:
+```json
+{
+  "volume_type": "gp2",
+  "size_gb": "100"
+}
+```
+
+**RecommendedConfig**:
+```json
+{
+  "volume_type": "gp3",
+  "size_gb": "100"
+}
+```
+
+**Reasoning**:
+- "gp3 volumes are ~20% cheaper than gp2"
+- "gp3 provides better baseline performance (3000 IOPS, 125 MB/s)"
+- "API-compatible change with no data migration required"
+
+**Metadata**:
+```json
+{
+  "baseline_iops": "gp2: 100 IOPS/GB, gp3: 3000 IOPS (included)",
+  "baseline_throughput": "gp2: 128-250 MB/s, gp3: 125 MB/s (included)"
+}
+```
+
+## Impact Calculation
+
+### RecommendationImpact Structure
+
+```go
+impact := &pbc.RecommendationImpact{
+    EstimatedSavings:   monthlySavings,        // currentCost - projectedCost
+    Currency:           "USD",
+    ProjectionPeriod:   "monthly",
+    CurrentCost:        currentMonthlyCost,    // price × 730 for EC2
+    ProjectedCost:      recommendedMonthlyCost,
+    SavingsPercentage:  savingsPercent,        // (1 - projected/current) × 100
+}
+```
+
+### EC2 Cost Calculation
+
+```go
+hoursPerMonth := 730.0
+currentMonthlyCost := currentHourlyPrice * hoursPerMonth
+projectedMonthlyCost := recommendedHourlyPrice * hoursPerMonth
+monthlySavings := currentMonthlyCost - projectedMonthlyCost
+savingsPercent := (monthlySavings / currentMonthlyCost) * 100
+```
+
+### EBS Cost Calculation
+
+```go
+sizeGB := extractSizeFromTags(resource.Tags, 100) // default 100GB
+currentMonthlyCost := gp2PricePerGB * float64(sizeGB)
+projectedMonthlyCost := gp3PricePerGB * float64(sizeGB)
+monthlySavings := currentMonthlyCost - projectedMonthlyCost
+savingsPercent := (monthlySavings / currentMonthlyCost) * 100
+```
+
+## Resource Extraction
+
+### From ResourceDescriptor (Supports/GetProjectedCost pattern)
+
+```go
+type ResourceDescriptor struct {
+    Provider     string            // "aws"
+    ResourceType string            // "ec2", "ebs", "aws:ec2/instance:Instance"
+    Sku          string            // instance type or volume type
+    Region       string            // "us-east-1"
+    Tags         map[string]string // additional attributes
+}
+```
+
+### From RecommendationFilter (GetRecommendations pattern)
+
+The `GetRecommendationsRequest.Filter` may contain:
+- `ResourceIds []string` - specific resources to analyze
+- Metadata in custom fields
+
+For this plugin, if no filter is provided, return empty recommendations
+(plugin doesn't maintain resource inventory).
+
+## Validation Rules
+
+### Pre-recommendation Checks
+
+1. **Instance type exists**: `pricing.EC2OnDemandPricePerHour(type, "Linux", "Shared")` returns `found=true`
+2. **Price comparison**: `recommendedPrice <= currentPrice`
+3. **Region match**: Resource region matches plugin's embedded region
+
+### Post-generation Validation
+
+Use SDK validators:
+```go
+if err := pluginsdk.ValidateRecommendation(rec); err != nil {
+    // Log and skip this recommendation
+}
+if err := pluginsdk.ValidateRecommendationImpact(rec.Impact); err != nil {
+    // Log and skip this recommendation
+}
+```

--- a/specs/012-recommendations/plan.md
+++ b/specs/012-recommendations/plan.md
@@ -1,0 +1,69 @@
+# Implementation Plan: GetRecommendations RPC
+
+**Branch**: `012-recommendations` | **Date**: 2025-12-15 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/012-recommendations/spec.md`
+
+## Summary
+
+Implement the `GetRecommendations` RPC by implementing the `pluginsdk.RecommendationsProvider` interface. The plugin will provide EC2 generation upgrade suggestions, Graviton/ARM migration recommendations, and EBS gp2→gp3 volume type upgrades based on embedded public AWS pricing data comparisons.
+
+## Technical Context
+
+**Language/Version**: Go 1.25+
+**Primary Dependencies**: pulumicost-spec v0.4.7 (gRPC + pluginsdk), zerolog
+**Storage**: N/A (embedded pricing data via `//go:embed`)
+**Testing**: Go testing (`make test`), table-driven tests
+**Target Platform**: Linux server (gRPC plugin process)
+**Project Type**: Single Go module (gRPC plugin)
+**Performance Goals**: < 100ms per GetRecommendations call (SC-001)
+**Constraints**: < 50MB memory per region binary, thread-safe for concurrent calls
+**Scale/Scope**: Max 2 EC2 recommendations + 1 EBS recommendation per resource
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Code Quality & Simplicity | PASS | Single file `recommendations.go`, simple mappings |
+| II. Testing Discipline | PASS | Table-driven tests for mappings, unit tests for helpers |
+| III. Protocol & Interface Consistency | PASS | Implements `RecommendationsProvider` interface from pluginsdk |
+| IV. Performance & Reliability | PASS | Map lookups O(1), < 100ms target |
+| V. Build & Release Quality | PASS | No new build tags needed, same binary |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/012-recommendations/
+├── plan.md              # This file
+├── research.md          # Phase 0: Proto mapping research
+├── data-model.md        # Phase 1: Instance family mappings
+├── quickstart.md        # Phase 1: Quick implementation guide
+├── contracts/           # N/A (uses existing proto)
+└── tasks.md             # Phase 2 output
+```
+
+### Source Code (repository root)
+
+```text
+internal/
+├── plugin/
+│   ├── plugin.go           # Existing - no changes
+│   ├── recommendations.go  # NEW: GetRecommendations implementation
+│   ├── recommendations_test.go  # NEW: Unit tests
+│   └── instance_type.go    # NEW: parseInstanceType + mappings
+└── pricing/
+    └── client.go           # Existing - no changes (uses EC2/EBS lookups)
+```
+
+**Structure Decision**: Follows existing plugin package structure. New files added to `internal/plugin/` for recommendation logic.
+
+## Complexity Tracking
+
+> No violations - implementation follows KISS principle with simple map lookups.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| N/A | N/A | N/A |

--- a/specs/012-recommendations/quickstart.md
+++ b/specs/012-recommendations/quickstart.md
@@ -1,0 +1,254 @@
+# Quickstart: GetRecommendations Implementation
+
+**Date**: 2025-12-15
+**Feature**: 012-recommendations
+
+## Overview
+
+This guide provides a quick implementation path for the GetRecommendations RPC.
+
+## Step 1: Create instance_type.go
+
+```go
+// internal/plugin/instance_type.go
+package plugin
+
+import "strings"
+
+// parseInstanceType splits an EC2 instance type into family and size.
+// Example: "t2.medium" → ("t2", "medium")
+// Returns empty strings if the format is invalid.
+func parseInstanceType(instanceType string) (family, size string) {
+    parts := strings.SplitN(instanceType, ".", 2)
+    if len(parts) != 2 {
+        return "", ""
+    }
+    return parts[0], parts[1]
+}
+
+// generationUpgradeMap maps old instance families to newer generations.
+var generationUpgradeMap = map[string]string{
+    "t2": "t3", "t3": "t3a",
+    "m4": "m5", "m5": "m6i", "m5a": "m6a",
+    "c4": "c5", "c5": "c6i", "c5a": "c6a",
+    "r4": "r5", "r5": "r6i", "r5a": "r6a",
+    "i3": "i3en", "d2": "d3",
+}
+
+// gravitonMap maps x86 families to Graviton equivalents.
+var gravitonMap = map[string]string{
+    "m5": "m6g", "m5a": "m6g", "m6i": "m6g", "m6a": "m6g",
+    "c5": "c6g", "c5a": "c6g", "c6i": "c6g", "c6a": "c6g",
+    "r5": "r6g", "r5a": "r6g", "r6i": "r6g", "r6a": "r6g",
+    "t3": "t4g", "t3a": "t4g",
+}
+```
+
+## Step 2: Create recommendations.go
+
+```go
+// internal/plugin/recommendations.go
+package plugin
+
+import (
+    "context"
+    "fmt"
+    "strconv"
+    "time"
+
+    "github.com/google/uuid"
+    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+    pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+    "google.golang.org/grpc/codes"
+)
+
+const (
+    hoursPerMonth         = 730.0
+    confidenceHigh        = 0.9
+    confidenceMedium      = 0.7
+    sourceAWSPublic       = "aws-public"
+    modTypeGenUpgrade     = "generation_upgrade"
+    modTypeGraviton       = "graviton_migration"
+    modTypeVolumeUpgrade  = "volume_type_upgrade"
+)
+
+// Ensure AWSPublicPlugin implements RecommendationsProvider
+var _ pluginsdk.RecommendationsProvider = (*AWSPublicPlugin)(nil)
+
+// GetRecommendations returns cost optimization recommendations.
+func (p *AWSPublicPlugin) GetRecommendations(
+    ctx context.Context,
+    req *pbc.GetRecommendationsRequest,
+) (*pbc.GetRecommendationsResponse, error) {
+    start := time.Now()
+    traceID := p.getTraceID(ctx)
+
+    if req == nil {
+        err := p.newErrorWithID(traceID, codes.InvalidArgument,
+            "missing request", pbc.ErrorCode_ERROR_CODE_INVALID_RESOURCE)
+        p.logErrorWithID(traceID, "GetRecommendations", err, pbc.ErrorCode_ERROR_CODE_INVALID_RESOURCE)
+        return nil, err
+    }
+
+    // For now, return empty recommendations (no resource inventory)
+    // Future: Extract resource from filter metadata
+    recommendations := []*pbc.Recommendation{}
+
+    p.logger.Info().
+        Str(pluginsdk.FieldTraceID, traceID).
+        Str(pluginsdk.FieldOperation, "GetRecommendations").
+        Int("recommendation_count", len(recommendations)).
+        Int64(pluginsdk.FieldDurationMs, time.Since(start).Milliseconds()).
+        Msg("recommendations generated")
+
+    return &pbc.GetRecommendationsResponse{
+        Recommendations: recommendations,
+        Summary:         pluginsdk.CalculateRecommendationSummary(recommendations, "monthly"),
+    }, nil
+}
+
+// generateEC2Recommendations creates recommendations for an EC2 instance.
+func (p *AWSPublicPlugin) generateEC2Recommendations(
+    instanceType, region string,
+) []*pbc.Recommendation {
+    var recommendations []*pbc.Recommendation
+
+    // Generation upgrade
+    if rec := p.getGenerationUpgradeRecommendation(instanceType, region); rec != nil {
+        recommendations = append(recommendations, rec)
+    }
+
+    // Graviton migration
+    if rec := p.getGravitonRecommendation(instanceType, region); rec != nil {
+        recommendations = append(recommendations, rec)
+    }
+
+    return recommendations
+}
+
+func (p *AWSPublicPlugin) getGenerationUpgradeRecommendation(
+    instanceType, region string,
+) *pbc.Recommendation {
+    family, size := parseInstanceType(instanceType)
+    if family == "" {
+        return nil
+    }
+
+    newFamily, exists := generationUpgradeMap[family]
+    if !exists {
+        return nil
+    }
+
+    newType := newFamily + "." + size
+
+    currentPrice, found := p.pricing.EC2OnDemandPricePerHour(instanceType, "Linux", "Shared")
+    if !found {
+        return nil
+    }
+
+    newPrice, found := p.pricing.EC2OnDemandPricePerHour(newType, "Linux", "Shared")
+    if !found || newPrice > currentPrice {
+        return nil
+    }
+
+    currentMonthly := currentPrice * hoursPerMonth
+    newMonthly := newPrice * hoursPerMonth
+    savings := currentMonthly - newMonthly
+    savingsPercent := (savings / currentMonthly) * 100
+
+    confidence := confidenceHigh
+    return &pbc.Recommendation{
+        Id:         uuid.New().String(),
+        Category:   pbc.RecommendationCategory_RECOMMENDATION_CATEGORY_COST_OPTIMIZATION,
+        ActionType: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MODIFY,
+        Resource: &pbc.ResourceRecommendationInfo{
+            Provider:     "aws",
+            ResourceType: "ec2",
+            Region:       region,
+            Sku:          instanceType,
+        },
+        Modify: &pbc.ModifyAction{
+            ModificationType: modTypeGenUpgrade,
+            CurrentConfig:    map[string]string{"instance_type": instanceType},
+            RecommendedConfig: map[string]string{"instance_type": newType},
+        },
+        Impact: &pbc.RecommendationImpact{
+            EstimatedSavings:  savings,
+            Currency:          "USD",
+            ProjectionPeriod:  "monthly",
+            CurrentCost:       currentMonthly,
+            ProjectedCost:     newMonthly,
+            SavingsPercentage: savingsPercent,
+        },
+        Priority:        pbc.RecommendationPriority_RECOMMENDATION_PRIORITY_MEDIUM,
+        ConfidenceScore: &confidence,
+        Description:     fmt.Sprintf("Upgrade from %s to %s for better performance at same or lower cost", instanceType, newType),
+        Reasoning: []string{
+            fmt.Sprintf("Newer %s instances offer better performance", newFamily),
+            "Drop-in replacement with no architecture changes required",
+        },
+        Source: sourceAWSPublic,
+    }
+}
+
+// Similar pattern for getGravitonRecommendation and getEBSRecommendations...
+```
+
+## Step 3: Add Tests
+
+```go
+// internal/plugin/instance_type_test.go
+package plugin
+
+import "testing"
+
+func TestParseInstanceType(t *testing.T) {
+    tests := []struct {
+        input      string
+        wantFamily string
+        wantSize   string
+    }{
+        {"t2.medium", "t2", "medium"},
+        {"m5.xlarge", "m5", "xlarge"},
+        {"c6i.2xlarge", "c6i", "2xlarge"},
+        {"invalid", "", ""},
+        {"", "", ""},
+    }
+
+    for _, tt := range tests {
+        family, size := parseInstanceType(tt.input)
+        if family != tt.wantFamily || size != tt.wantSize {
+            t.Errorf("parseInstanceType(%q) = (%q, %q), want (%q, %q)",
+                tt.input, family, size, tt.wantFamily, tt.wantSize)
+        }
+    }
+}
+```
+
+## Step 4: Verify Interface Compliance
+
+```bash
+# Build to verify interface implementation
+go build ./...
+
+# Run tests
+make test
+```
+
+## Key Implementation Notes
+
+1. **Thread Safety**: All methods are stateless (use `p.pricing` which is thread-safe)
+2. **Trace ID**: Always extract via `p.getTraceID(ctx)` for log correlation
+3. **Validation**: Use `pluginsdk.ValidateRecommendation()` before returning
+4. **Pagination**: Use `pluginsdk.PaginateRecommendations()` if list > pageSize
+5. **Summary**: Always include via `pluginsdk.CalculateRecommendationSummary()`
+
+## Testing Checklist
+
+- [ ] `parseInstanceType` handles edge cases
+- [ ] Generation upgrade returns nil when new type not found
+- [ ] Generation upgrade returns nil when new price > current
+- [ ] Graviton recommendation has 0.7 confidence
+- [ ] EBS recommendation only for gp2 volumes
+- [ ] Empty list for unsupported services (no error)
+- [ ] ERROR_CODE_INVALID_RESOURCE for nil request

--- a/specs/012-recommendations/research.md
+++ b/specs/012-recommendations/research.md
@@ -1,0 +1,351 @@
+# Research: GetRecommendations RPC Implementation
+
+**Date**: 2025-12-15
+**Feature**: 012-recommendations
+
+## R1: Proto API Structure Analysis
+
+### Decision
+
+Use the official `pulumicost.v1` proto types for recommendations, which differ from the simplified proposal in the GitHub issue.
+
+### Findings
+
+The pulumicost-spec v0.4.7 defines a rich `Recommendation` type:
+
+```go
+type Recommendation struct {
+    Id               string                      // Unique ID (generate UUID)
+    Category         RecommendationCategory      // Enum: COST_OPTIMIZATION, etc.
+    ActionType       RecommendationActionType    // Enum: MODIFY, RIGHTSIZE, etc.
+    Resource         *ResourceRecommendationInfo // Resource context
+    ActionDetail     isRecommendation_ActionDetail // oneof: Modify, Rightsize, etc.
+    Impact           *RecommendationImpact       // Financial impact
+    Priority         RecommendationPriority      // Enum: LOW, MEDIUM, HIGH, CRITICAL
+    ConfidenceScore  *float64                    // 0.0-1.0 (not string)
+    Description      string                      // Human-readable summary
+    Reasoning        []string                    // List of reasons
+    Source           string                      // "aws-public"
+    Metadata         map[string]string           // Additional details
+}
+```
+
+### Mapping Spec Requirements to Proto
+
+| Spec Requirement | Proto Mapping |
+|------------------|---------------|
+| Type: "generation_upgrade" | `Category: RECOMMENDATION_CATEGORY_COST_OPTIMIZATION`, `ActionType: RECOMMENDATION_ACTION_TYPE_MODIFY`, `Modify.ModificationType: "generation_upgrade"` |
+| Type: "graviton" | Same as above with `ModificationType: "graviton_migration"` |
+| Type: "volume_type_upgrade" | Same as above with `ModificationType: "volume_type_upgrade"` |
+| Confidence "high" | `ConfidenceScore: 0.9` |
+| Confidence "medium" | `ConfidenceScore: 0.7` |
+| Monthly savings | `Impact.EstimatedSavings` with `ProjectionPeriod: "monthly"` |
+| Details map | `Metadata` map |
+
+### Rationale
+
+Using official proto types ensures:
+1. Compatibility with PulumiCost core aggregation
+2. Proper validation via `pluginsdk.ValidateRecommendation()`
+3. Pagination support via `pluginsdk.PaginateRecommendations()`
+4. Summary calculation via `pluginsdk.CalculateRecommendationSummary()`
+
+### Alternatives Rejected
+
+- Custom JSON types: Would break protocol compatibility
+- Simplified types: Would require custom serialization
+
+---
+
+## R2: RecommendationsProvider Interface
+
+### Decision
+
+Implement `pluginsdk.RecommendationsProvider` interface to enable GetRecommendations.
+
+### Findings
+
+The SDK provides an optional interface:
+
+```go
+type RecommendationsProvider interface {
+    GetRecommendations(ctx context.Context, req *pbc.GetRecommendationsRequest) (
+        *pbc.GetRecommendationsResponse, error)
+}
+```
+
+Plugins that implement this interface will have `GetRecommendations` available via gRPC.
+
+### Implementation Pattern
+
+```go
+// Ensure AWSPublicPlugin implements RecommendationsProvider
+var _ pluginsdk.RecommendationsProvider = (*AWSPublicPlugin)(nil)
+
+func (p *AWSPublicPlugin) GetRecommendations(
+    ctx context.Context,
+    req *pbc.GetRecommendationsRequest,
+) (*pbc.GetRecommendationsResponse, error) {
+    // Implementation
+}
+```
+
+### SDK Helpers Available
+
+- `pluginsdk.ValidateRecommendation(rec)` - Validate recommendation structure
+- `pluginsdk.ValidateRecommendationImpact(impact)` - Validate impact fields
+- `pluginsdk.ApplyRecommendationFilter(recs, filter)` - Apply request filters
+- `pluginsdk.PaginateRecommendations(recs, pageSize, pageToken)` - Handle pagination
+- `pluginsdk.CalculateRecommendationSummary(recs, period)` - Generate summary
+
+---
+
+## R3: Instance Type Parsing
+
+### Decision
+
+Implement `parseInstanceType(instanceType string) (family, size string)` using simple string split.
+
+### Findings
+
+AWS instance types follow the pattern: `<family><generation>[<modifier>].<size>`
+
+Examples:
+- `t2.medium` → family: `t2`, size: `medium`
+- `t3a.large` → family: `t3a`, size: `large`
+- `m5d.xlarge` → family: `m5d`, size: `xlarge`
+- `c6i.2xlarge` → family: `c6i`, size: `2xlarge`
+
+### Implementation
+
+```go
+func parseInstanceType(instanceType string) (family, size string) {
+    parts := strings.SplitN(instanceType, ".", 2)
+    if len(parts) != 2 {
+        return "", ""
+    }
+    return parts[0], parts[1]
+}
+```
+
+### Edge Cases
+
+- Empty string: returns `"", ""`
+- No dot (e.g., `metal`): returns `"", ""`
+- Multiple dots (shouldn't exist): only splits on first
+
+---
+
+## R4: Generation Upgrade Mappings
+
+### Decision
+
+Create static mapping of instance family generations.
+
+### Findings
+
+Based on AWS documentation and common upgrade paths:
+
+```go
+var generationUpgradeMap = map[string]string{
+    // T-series (burstable)
+    "t2":  "t3",
+    "t3":  "t3a",  // AMD variant, often cheaper
+
+    // M-series (general purpose)
+    "m4":  "m5",
+    "m5":  "m6i",
+    "m5a": "m6a",
+
+    // C-series (compute optimized)
+    "c4":  "c5",
+    "c5":  "c6i",
+    "c5a": "c6a",
+
+    // R-series (memory optimized)
+    "r4":  "r5",
+    "r5":  "r6i",
+    "r5a": "r6a",
+
+    // I-series (storage optimized)
+    "i3":  "i3en",
+
+    // D-series (dense storage)
+    "d2":  "d3",
+}
+```
+
+### Price Validation Required
+
+Before recommending, must verify:
+1. New instance type exists in pricing data
+2. New price ≤ current price (avoid false positives)
+
+---
+
+## R5: Graviton Migration Mappings
+
+### Decision
+
+Create mapping from x86 families to Graviton equivalents.
+
+### Findings
+
+Graviton instances use `g` suffix (m6g, c6g, r6g, t4g):
+
+```go
+var gravitonMap = map[string]string{
+    // From Intel/AMD to Graviton
+    "m5":   "m6g",
+    "m5a":  "m6g",
+    "m5n":  "m6g",
+    "m6i":  "m6g",
+    "m6a":  "m6g",
+
+    "c5":   "c6g",
+    "c5a":  "c6g",
+    "c5n":  "c6gn",
+    "c6i":  "c6g",
+    "c6a":  "c6g",
+
+    "r5":   "r6g",
+    "r5a":  "r6g",
+    "r5n":  "r6g",
+    "r6i":  "r6g",
+    "r6a":  "r6g",
+
+    "t3":   "t4g",
+    "t3a":  "t4g",
+}
+```
+
+### Confidence Level
+
+Set `ConfidenceScore: 0.7` (medium) because:
+- Requires ARM architecture compatibility
+- Application must be tested on Graviton
+- Some software doesn't support ARM
+
+### Required Metadata
+
+Include warning in `Metadata`:
+```go
+"architecture_change": "x86_64 -> arm64"
+"requires_validation": "Application must support ARM architecture"
+```
+
+---
+
+## R6: EBS gp2 to gp3 Migration
+
+### Decision
+
+Recommend gp2→gp3 unconditionally (gp3 is always cheaper and faster).
+
+### Findings
+
+gp3 advantages over gp2:
+- **Price**: ~20% cheaper per GB-month
+- **Baseline IOPS**: 3000 (vs 100 IOPS/GB for gp2)
+- **Baseline Throughput**: 125 MB/s (vs scaling with size for gp2)
+- **API compatible**: Same attach/detach process
+
+### Implementation
+
+Only recommend for `volumeType == "gp2"`:
+
+```go
+func (p *AWSPublicPlugin) getEBSRecommendations(resource *pbc.ResourceDescriptor) []*pbc.Recommendation {
+    if resource.Sku != "gp2" {
+        return nil
+    }
+    // Generate recommendation
+}
+```
+
+### Size Handling
+
+If volume size not in tags, use 100GB default for cost calculation.
+Include actual volume size in metadata if available.
+
+---
+
+## R7: Request Handling
+
+### Decision
+
+The `GetRecommendationsRequest` uses filters, not a direct resource descriptor. Generate recommendations for the plugin's embedded region.
+
+### Findings
+
+The request structure:
+```go
+type GetRecommendationsRequest struct {
+    Filter           *RecommendationFilter
+    ProjectionPeriod string  // "daily", "monthly", "annual"
+    PageSize         int32
+    PageToken        string
+}
+```
+
+### Implementation Approach
+
+Since this plugin is region-specific and doesn't have access to actual resource inventory:
+
+1. **Option A**: Return empty list (plugin doesn't track resources)
+2. **Option B**: Accept resource descriptor via filter metadata
+3. **Option C**: Return static recommendations based on common patterns
+
+**Selected**: Option A with enhancement - Plugin returns empty unless called with specific resource context via the filter's `ResourceId` field.
+
+For practical use, PulumiCost core would call GetRecommendations for specific resources it knows about, passing context via the filter.
+
+---
+
+## R8: Error Handling
+
+### Decision
+
+Return empty recommendations list for unsupported services (not error).
+
+### Findings
+
+Per spec FR-008: "System MUST return empty recommendations list (not error) for unsupported resource types"
+
+Per spec FR-009: "System MUST return ERROR_CODE_INVALID_RESOURCE when request or resource descriptor is nil"
+
+### Implementation
+
+```go
+func (p *AWSPublicPlugin) GetRecommendations(ctx context.Context, req *pbc.GetRecommendationsRequest) (
+    *pbc.GetRecommendationsResponse, error) {
+
+    if req == nil {
+        return nil, p.newErrorWithID(traceID, codes.InvalidArgument,
+            "missing request", pbc.ErrorCode_ERROR_CODE_INVALID_RESOURCE)
+    }
+
+    // For unsupported services, return empty list
+    return &pbc.GetRecommendationsResponse{
+        Recommendations: []*pbc.Recommendation{},
+        Summary:         pluginsdk.CalculateRecommendationSummary(nil, "monthly"),
+    }, nil
+}
+```
+
+---
+
+## Summary
+
+All technical decisions resolved. No NEEDS CLARIFICATION items remaining.
+
+| Research Item | Decision | Confidence |
+|---------------|----------|------------|
+| R1: Proto API | Use official types | High |
+| R2: Interface | Implement RecommendationsProvider | High |
+| R3: Instance parsing | Simple string split | High |
+| R4: Generation map | Static mapping with price check | High |
+| R5: Graviton map | Static mapping, 0.7 confidence | High |
+| R6: EBS gp2→gp3 | Unconditional recommend | High |
+| R7: Request handling | Filter-based or empty | Medium |
+| R8: Error handling | Empty list for unsupported | High |

--- a/specs/012-recommendations/spec.md
+++ b/specs/012-recommendations/spec.md
@@ -1,0 +1,153 @@
+# Feature Specification: GetRecommendations RPC for Cost Optimization
+
+**Feature Branch**: `012-recommendations`
+**Created**: 2025-12-15
+**Status**: Draft
+**GitHub Issue**: #105
+**Input**: User description: "Implement GetRecommendations RPC from pulumicost-spec v0.4.7 for cost optimization recommendations"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - EC2 Instance Generation Upgrade Suggestions (Priority: P1)
+
+As an infrastructure engineer using PulumiCost, I want to receive recommendations when my EC2 instances use older generation types so that I can modernize to newer, more cost-effective instances without manual research.
+
+**Why this priority**: Generation upgrades are the most common and safest optimization opportunity. Newer generations (t2→t3, m4→m5) are drop-in replacements that provide better performance at the same or lower price. This delivers immediate, actionable value with minimal risk.
+
+**Independent Test**: Can be fully tested by requesting recommendations for a t2.medium instance and verifying the system suggests t3.medium with price comparison data.
+
+**Acceptance Scenarios**:
+
+1. **Given** an EC2 instance using t2.medium, **When** GetRecommendations is called, **Then** the system returns a recommendation to upgrade to t3.medium with current cost, recommended cost, and monthly savings calculated.
+2. **Given** an EC2 instance using the latest generation (e.g., t3a.micro), **When** GetRecommendations is called, **Then** no generation upgrade recommendation is returned.
+3. **Given** an EC2 instance type where the newer generation is more expensive in the current region, **When** GetRecommendations is called, **Then** no upgrade recommendation is returned (avoid false positives).
+
+---
+
+### User Story 2 - AWS Graviton/ARM Migration Suggestions (Priority: P2)
+
+As an infrastructure engineer, I want to receive recommendations for migrating x86 instances to ARM-based Graviton instances so that I can evaluate potential cost savings while being aware of compatibility requirements.
+
+**Why this priority**: Graviton migrations offer significant cost savings (~20%) but require ARM compatibility validation. This is high value but needs user judgment, hence medium confidence level.
+
+**Independent Test**: Can be fully tested by requesting recommendations for an m5.large instance and verifying the system suggests m6g.large with savings percentage and architecture change warnings.
+
+**Acceptance Scenarios**:
+
+1. **Given** an EC2 instance using m5.large, **When** GetRecommendations is called, **Then** the system returns a Graviton recommendation with m6g.large, showing ~20% savings and "medium" confidence level.
+2. **Given** the Graviton recommendation, **Then** the recommendation details include a clear warning that ARM architecture compatibility must be validated.
+3. **Given** an instance type with no Graviton equivalent (e.g., mac1.metal), **When** GetRecommendations is called, **Then** no Graviton recommendation is returned.
+
+---
+
+### User Story 3 - EBS Volume Type Upgrade (gp2 to gp3) (Priority: P3)
+
+As an infrastructure engineer, I want to receive recommendations to migrate gp2 volumes to gp3 so that I can reduce storage costs while improving baseline performance.
+
+**Why this priority**: EBS gp2→gp3 migration is a straightforward, API-compatible change that provides both cost savings and performance improvements. Lower priority than EC2 because storage costs are typically smaller than compute costs.
+
+**Independent Test**: Can be fully tested by requesting recommendations for a gp2 volume and verifying the system suggests gp3 with cost comparison and performance improvement details.
+
+**Acceptance Scenarios**:
+
+1. **Given** an EBS volume of type gp2 with 100GB size, **When** GetRecommendations is called, **Then** the system returns a volume type upgrade recommendation to gp3 with cost savings calculated.
+2. **Given** an EBS volume of type gp3, io1, or io2, **When** GetRecommendations is called, **Then** no volume type upgrade recommendation is returned.
+3. **Given** the gp2→gp3 recommendation, **Then** the details include baseline performance comparison (IOPS and throughput).
+
+---
+
+### User Story 4 - Graceful Handling of Unsupported Services (Priority: P4)
+
+As a PulumiCost user, I want GetRecommendations to return an empty list for services where recommendations aren't supported so that my automation doesn't break and I understand the limitation.
+
+**Why this priority**: Important for API completeness and robustness, but doesn't directly deliver cost optimization value.
+
+**Independent Test**: Can be fully tested by calling GetRecommendations for S3, Lambda, RDS, or DynamoDB resources and verifying an empty recommendations list is returned without errors.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource type that is not EC2 or EBS (e.g., S3, Lambda, RDS), **When** GetRecommendations is called, **Then** an empty recommendations list is returned (not an error).
+2. **Given** a request with a missing or nil resource descriptor, **When** GetRecommendations is called, **Then** an appropriate error is returned with ERROR_CODE_INVALID_RESOURCE.
+
+---
+
+### Edge Cases
+
+- What happens when the instance type doesn't exist in pricing data? (Return no recommendations)
+- What happens when the recommended instance type isn't available in the region? (Return no recommendation for that type)
+- What happens when EBS volume size is not specified in tags? (Use reasonable default for calculation, e.g., 100GB)
+- What happens when both generation upgrade AND Graviton are available? (Return both recommendations, letting user choose)
+- What happens when the region doesn't support Graviton instances? (Return no Graviton recommendation)
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST implement the GetRecommendations RPC method as defined in pulumicost-spec v0.4.7
+- **FR-002**: System MUST return generation upgrade recommendations for EC2 instances when newer generations offer same or lower price
+- **FR-003**: System MUST return Graviton/ARM migration recommendations for compatible x86 instance families
+- **FR-004**: System MUST return gp2→gp3 volume type upgrade recommendations for EBS volumes
+- **FR-005**: System MUST calculate monthly savings as (current_cost - recommended_cost) based on 730 hours/month for EC2
+- **FR-006**: System MUST set confidence level to 0.9 (high) for generation upgrades and EBS volume changes
+- **FR-007**: System MUST set confidence level to 0.7 (medium) for Graviton recommendations (requires user validation)
+- **FR-008**: System MUST return empty recommendations list (not error) for unsupported resource types
+- **FR-009**: System MUST return ERROR_CODE_INVALID_RESOURCE when request or resource descriptor is nil
+- **FR-010**: System MUST include trace_id in all log entries for distributed tracing
+- **FR-011**: System MUST only recommend when new option price is less than or equal to current price
+- **FR-012**: System MUST include relevant metadata in recommendation details (instance types, performance info, architecture warnings)
+
+### Key Entities
+
+- **Recommendation**: Represents a cost optimization suggestion with type, title, description, current cost, recommended cost, monthly savings, confidence level, and details map
+- **Instance Family**: The category portion of EC2 instance type (e.g., "t2" from "t2.medium") used for mapping to newer generations
+- **Instance Size**: The size portion of EC2 instance type (e.g., "medium" from "t2.medium") preserved during recommendations
+- **Generation Upgrade Map**: Mapping of older instance families to their newer generation equivalents (t2→t3, m4→m5, etc.)
+- **Graviton Map**: Mapping of x86 instance families to ARM/Graviton equivalents (m5→m6g, c5→c6g, t3→t4g)
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: GetRecommendations returns valid proto response for all supported resource types within 100ms
+- **SC-002**: 100% of generation upgrade recommendations result in equal or lower monthly cost
+- **SC-003**: 100% of Graviton recommendations include architecture change warning in details
+- **SC-004**: All recommendations include accurate monthly savings calculation (verified against pricing data)
+- **SC-005**: Zero false positives - no recommendations where new option costs more than current
+- **SC-006**: Empty list returned for unsupported services (S3, Lambda, RDS, DynamoDB) without errors
+- **SC-007**: All log entries for GetRecommendations operations include trace_id for distributed tracing
+
+## Scope Boundaries *(mandatory)*
+
+### In Scope
+
+- EC2 instance generation upgrade recommendations (t2→t3, m4→m5, c4→c5, r4→r5, etc.)
+- EC2 Graviton/ARM migration recommendations (m5→m6g, c5→c6g, t3→t4g, etc.)
+- EBS gp2→gp3 volume type recommendations
+- Price comparison using embedded public AWS pricing data
+- Confidence levels indicating recommendation safety
+
+### Out of Scope (Intentionally Excluded)
+
+| Feature                           | Reason                                                             |
+| --------------------------------- | ------------------------------------------------------------------ |
+| Reserved Instance recommendations | Cannot know if resource is already covered by RI/Savings Plan      |
+| Rightsizing (downsize)            | No utilization data - could cause outages                          |
+| Spot Instance recommendations     | No fault-tolerance context                                         |
+| Multi-AZ recommendations          | No availability requirements context                               |
+| Storage class tiering (S3)        | No access pattern data                                             |
+| io1/io2 IOPS optimization         | Requires workload analysis                                         |
+
+## Assumptions
+
+- AWS public pricing data is embedded in the binary at build time
+- The pricing client already provides methods for EC2 and EBS price lookups
+- The pulumicost-spec v0.4.7+ proto definitions include GetRecommendationsRequest/Response messages
+- Instance type format is consistently "family.size" (e.g., "t2.medium", "m5.large")
+- 730 hours per month is the standard calculation for on-demand pricing
+- Region-specific pricing is already handled by the region-specific binary builds
+
+## Dependencies
+
+- pulumicost-spec v0.4.7 or later (proto definitions)
+- Existing pricing client with EC2OnDemandPricePerHour and EBSPricePerGBMonth methods
+- pluginsdk for trace_id extraction and logging field constants

--- a/specs/012-recommendations/tasks.md
+++ b/specs/012-recommendations/tasks.md
@@ -1,0 +1,750 @@
+# Tasks: GetRecommendations RPC Implementation
+
+**Feature**: 012-recommendations
+**Branch**: `012-recommendations`
+**Generated**: 2025-12-15
+**Spec**: [spec.md](spec.md) | **Plan**: [plan.md](plan.md)
+
+## Task Overview
+
+| Phase | User Story | Tasks | Priority |
+|-------|------------|-------|----------|
+| 1 | Setup | 3 | - |
+| 2 | US1: EC2 Generation Upgrades | 4 | P1 |
+| 3 | US2: Graviton Migrations | 2 | P2 |
+| 4 | US3: EBS gp2→gp3 | 2 | P3 |
+| 5 | US4: Graceful Error Handling | 3 | P4 |
+| 6 | Polish | 2 | - |
+
+---
+
+## Phase 1: Setup
+
+### T1.1: Create instance_type.go with parsing helper
+
+**File**: `internal/plugin/instance_type.go`
+**Depends on**: None
+**Acceptance**: `go build ./...` passes
+
+Create the instance type parsing utility and static mappings.
+
+```go
+// internal/plugin/instance_type.go
+package plugin
+
+import "strings"
+
+// parseInstanceType splits an EC2 instance type into family and size.
+// Example: "t2.medium" → ("t2", "medium")
+// Returns empty strings if the format is invalid.
+func parseInstanceType(instanceType string) (family, size string) {
+    parts := strings.SplitN(instanceType, ".", 2)
+    if len(parts) != 2 {
+        return "", ""
+    }
+    return parts[0], parts[1]
+}
+
+// generationUpgradeMap maps old instance families to newer generations.
+var generationUpgradeMap = map[string]string{
+    "t2":  "t3",
+    "t3":  "t3a",
+    "m4":  "m5",
+    "m5":  "m6i",
+    "m5a": "m6a",
+    "c4":  "c5",
+    "c5":  "c6i",
+    "c5a": "c6a",
+    "r4":  "r5",
+    "r5":  "r6i",
+    "r5a": "r6a",
+    "i3":  "i3en",
+    "d2":  "d3",
+}
+
+// gravitonMap maps x86 families to Graviton equivalents.
+var gravitonMap = map[string]string{
+    "m5":  "m6g",
+    "m5a": "m6g",
+    "m5n": "m6g",
+    "m6i": "m6g",
+    "m6a": "m6g",
+    "c5":  "c6g",
+    "c5a": "c6g",
+    "c5n": "c6gn",
+    "c6i": "c6g",
+    "c6a": "c6g",
+    "r5":  "r6g",
+    "r5a": "r6g",
+    "r5n": "r6g",
+    "r6i": "r6g",
+    "r6a": "r6g",
+    "t3":  "t4g",
+    "t3a": "t4g",
+}
+```
+
+**Test**: Add `instance_type_test.go` with table-driven tests for `parseInstanceType`.
+
+---
+
+### T1.2: Create recommendations.go skeleton
+
+**File**: `internal/plugin/recommendations.go`
+**Depends on**: T1.1
+**Acceptance**: `go build ./...` passes, interface compile check
+
+Create the GetRecommendations method skeleton implementing `pluginsdk.RecommendationsProvider`.
+
+```go
+// internal/plugin/recommendations.go
+package plugin
+
+import (
+    "context"
+    "time"
+
+    "github.com/rshade/pulumicost-spec/sdk/go/pluginsdk"
+    pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
+    "google.golang.org/grpc/codes"
+)
+
+const (
+    hoursPerMonth        = 730.0
+    confidenceHigh       = 0.9
+    confidenceMedium     = 0.7
+    sourceAWSPublic      = "aws-public"
+    modTypeGenUpgrade    = "generation_upgrade"
+    modTypeGraviton      = "graviton_migration"
+    modTypeVolumeUpgrade = "volume_type_upgrade"
+)
+
+// Ensure AWSPublicPlugin implements RecommendationsProvider
+var _ pluginsdk.RecommendationsProvider = (*AWSPublicPlugin)(nil)
+
+// GetRecommendations returns cost optimization recommendations.
+func (p *AWSPublicPlugin) GetRecommendations(
+    ctx context.Context,
+    req *pbc.GetRecommendationsRequest,
+) (*pbc.GetRecommendationsResponse, error) {
+    start := time.Now()
+    traceID := p.getTraceID(ctx)
+
+    if req == nil {
+        err := p.newErrorWithID(traceID, codes.InvalidArgument,
+            "missing request", pbc.ErrorCode_ERROR_CODE_INVALID_RESOURCE)
+        p.logErrorWithID(traceID, "GetRecommendations", err, pbc.ErrorCode_ERROR_CODE_INVALID_RESOURCE)
+        return nil, err
+    }
+
+    // Placeholder - returns empty recommendations
+    recommendations := []*pbc.Recommendation{}
+
+    p.logger.Info().
+        Str(pluginsdk.FieldTraceID, traceID).
+        Str(pluginsdk.FieldOperation, "GetRecommendations").
+        Int("recommendation_count", len(recommendations)).
+        Int64(pluginsdk.FieldDurationMs, time.Since(start).Milliseconds()).
+        Msg("recommendations generated")
+
+    return &pbc.GetRecommendationsResponse{
+        Recommendations: recommendations,
+        Summary:         pluginsdk.CalculateRecommendationSummary(recommendations, "monthly"),
+    }, nil
+}
+```
+
+**Verify**: Interface compliance via `var _ pluginsdk.RecommendationsProvider = (*AWSPublicPlugin)(nil)`
+
+---
+
+### T1.3: Wire resource dispatchers to GetRecommendations
+
+**File**: `internal/plugin/recommendations.go`
+**Depends on**: T1.2
+**Acceptance**: GetRecommendations dispatches to EC2/EBS handlers based on resource_type
+
+Update the GetRecommendations method to dispatch based on resource type:
+
+```go
+// Inside GetRecommendations, after nil check:
+var recommendations []*pbc.Recommendation
+
+// Extract resource info from filter or request context
+// For now, plugin returns empty (no resource inventory)
+// Future: Extract from req.Filter.Metadata if provided
+
+// Dispatch based on detected service type
+// service := detectService(resource.ResourceType)
+// switch service {
+// case "ec2":
+//     recs := p.generateEC2Recommendations(resource.Sku, resource.Region)
+//     recommendations = append(recommendations, recs...)
+// case "ebs":
+//     recs := p.getEBSRecommendations(resource.Sku, resource.Region, resource.Tags)
+//     recommendations = append(recommendations, recs...)
+// }
+```
+
+**Note**: Full dispatcher implementation depends on how PulumiCost core passes
+resource context. Current skeleton returns empty list per research.md R7.
+
+---
+
+## Phase 2: US1 - EC2 Instance Generation Upgrades (P1)
+
+**User Story**: As an infrastructure engineer, I want to receive recommendations when my EC2 instances use older generation types so that I can modernize to newer, more cost-effective instances.
+
+### T2.1: Implement generateEC2Recommendations dispatcher
+
+**File**: `internal/plugin/recommendations.go`
+**Depends on**: T1.2
+**Acceptance**: Method compiles, dispatches to generation and graviton helpers
+
+```go
+// generateEC2Recommendations creates recommendations for an EC2 instance.
+func (p *AWSPublicPlugin) generateEC2Recommendations(
+    instanceType, region string,
+) []*pbc.Recommendation {
+    var recommendations []*pbc.Recommendation
+
+    // Generation upgrade
+    if rec := p.getGenerationUpgradeRecommendation(instanceType, region); rec != nil {
+        recommendations = append(recommendations, rec)
+    }
+
+    // Graviton migration (added in Phase 3)
+    if rec := p.getGravitonRecommendation(instanceType, region); rec != nil {
+        recommendations = append(recommendations, rec)
+    }
+
+    return recommendations
+}
+```
+
+---
+
+### T2.2: Implement getGenerationUpgradeRecommendation
+
+**File**: `internal/plugin/recommendations.go`
+**Depends on**: T2.1
+**Acceptance**: Returns valid `*pbc.Recommendation` or nil
+
+Implements FR-002, FR-005, FR-006, FR-011 from spec.md.
+
+```go
+func (p *AWSPublicPlugin) getGenerationUpgradeRecommendation(
+    instanceType, region string,
+) *pbc.Recommendation {
+    family, size := parseInstanceType(instanceType)
+    if family == "" {
+        return nil
+    }
+
+    newFamily, exists := generationUpgradeMap[family]
+    if !exists {
+        return nil
+    }
+
+    newType := newFamily + "." + size
+
+    currentPrice, found := p.pricing.EC2OnDemandPricePerHour(instanceType, "Linux", "Shared")
+    if !found {
+        return nil
+    }
+
+    newPrice, found := p.pricing.EC2OnDemandPricePerHour(newType, "Linux", "Shared")
+    if !found || newPrice > currentPrice {
+        return nil  // FR-011: Only recommend when new price <= current
+    }
+
+    currentMonthly := currentPrice * hoursPerMonth
+    newMonthly := newPrice * hoursPerMonth
+    savings := currentMonthly - newMonthly
+    savingsPercent := (savings / currentMonthly) * 100
+
+    confidence := confidenceHigh
+    return &pbc.Recommendation{
+        Id:         uuid.New().String(),
+        Category:   pbc.RecommendationCategory_RECOMMENDATION_CATEGORY_COST_OPTIMIZATION,
+        ActionType: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MODIFY,
+        Resource: &pbc.ResourceRecommendationInfo{
+            Provider:     "aws",
+            ResourceType: "ec2",
+            Region:       region,
+            Sku:          instanceType,
+        },
+        Modify: &pbc.ModifyAction{
+            ModificationType:  modTypeGenUpgrade,
+            CurrentConfig:     map[string]string{"instance_type": instanceType},
+            RecommendedConfig: map[string]string{"instance_type": newType},
+        },
+        Impact: &pbc.RecommendationImpact{
+            EstimatedSavings:  savings,
+            Currency:          "USD",
+            ProjectionPeriod:  "monthly",
+            CurrentCost:       currentMonthly,
+            ProjectedCost:     newMonthly,
+            SavingsPercentage: savingsPercent,
+        },
+        Priority:        pbc.RecommendationPriority_RECOMMENDATION_PRIORITY_MEDIUM,
+        ConfidenceScore: &confidence,
+        Description:     fmt.Sprintf("Upgrade from %s to %s for better performance at same or lower cost", instanceType, newType),
+        Reasoning: []string{
+            fmt.Sprintf("Newer %s instances offer better performance", newFamily),
+            "Drop-in replacement with no architecture changes required",
+        },
+        Source: sourceAWSPublic,
+    }
+}
+```
+
+**Note**: Add `"github.com/google/uuid"` and `"fmt"` imports.
+
+---
+
+### T2.3: Add unit tests for generation upgrade
+
+**File**: `internal/plugin/recommendations_test.go`
+**Depends on**: T2.2
+**Acceptance**: `make test` passes
+
+Test scenarios from spec.md acceptance criteria:
+
+1. t2.medium → t3.medium recommendation returned
+2. Latest generation (t3a.micro) → no recommendation
+3. New generation more expensive → no recommendation (FR-011)
+
+```go
+func TestGetGenerationUpgradeRecommendation(t *testing.T) {
+    tests := []struct {
+        name         string
+        instanceType string
+        wantUpgrade  bool
+        wantNewType  string
+    }{
+        {"t2.medium upgrades to t3.medium", "t2.medium", true, "t3.medium"},
+        {"t3a.micro has no upgrade", "t3a.micro", false, ""},
+        {"m5.large upgrades to m6i.large", "m5.large", true, "m6i.large"},
+        {"invalid type returns nil", "invalid", false, ""},
+    }
+    // ... test implementation
+}
+```
+
+---
+
+### T2.4: Add instance_type_test.go
+
+**File**: `internal/plugin/instance_type_test.go`
+**Depends on**: T1.1
+**Acceptance**: `make test` passes
+
+```go
+func TestParseInstanceType(t *testing.T) {
+    tests := []struct {
+        input      string
+        wantFamily string
+        wantSize   string
+    }{
+        {"t2.medium", "t2", "medium"},
+        {"m5.xlarge", "m5", "xlarge"},
+        {"c6i.2xlarge", "c6i", "2xlarge"},
+        {"invalid", "", ""},
+        {"", "", ""},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.input, func(t *testing.T) {
+            family, size := parseInstanceType(tt.input)
+            if family != tt.wantFamily || size != tt.wantSize {
+                t.Errorf("parseInstanceType(%q) = (%q, %q), want (%q, %q)",
+                    tt.input, family, size, tt.wantFamily, tt.wantSize)
+            }
+        })
+    }
+}
+```
+
+---
+
+## Phase 3: US2 - Graviton/ARM Migration Suggestions (P2)
+
+**User Story**: As an infrastructure engineer, I want to receive recommendations for migrating x86 instances to ARM-based Graviton instances so that I can evaluate potential cost savings.
+
+### T3.1: Implement getGravitonRecommendation
+
+**File**: `internal/plugin/recommendations.go`
+**Depends on**: T2.1
+**Acceptance**: Returns recommendation with 0.7 confidence, includes architecture warning
+
+Implements FR-003, FR-007, FR-012 from spec.md.
+
+```go
+func (p *AWSPublicPlugin) getGravitonRecommendation(
+    instanceType, region string,
+) *pbc.Recommendation {
+    family, size := parseInstanceType(instanceType)
+    if family == "" {
+        return nil
+    }
+
+    gravitonFamily, exists := gravitonMap[family]
+    if !exists {
+        return nil
+    }
+
+    gravitonType := gravitonFamily + "." + size
+
+    currentPrice, found := p.pricing.EC2OnDemandPricePerHour(instanceType, "Linux", "Shared")
+    if !found {
+        return nil
+    }
+
+    gravitonPrice, found := p.pricing.EC2OnDemandPricePerHour(gravitonType, "Linux", "Shared")
+    if !found || gravitonPrice > currentPrice {
+        return nil
+    }
+
+    currentMonthly := currentPrice * hoursPerMonth
+    gravitonMonthly := gravitonPrice * hoursPerMonth
+    savings := currentMonthly - gravitonMonthly
+    savingsPercent := (savings / currentMonthly) * 100
+
+    confidence := confidenceMedium  // 0.7 per FR-007
+    return &pbc.Recommendation{
+        Id:         uuid.New().String(),
+        Category:   pbc.RecommendationCategory_RECOMMENDATION_CATEGORY_COST_OPTIMIZATION,
+        ActionType: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MODIFY,
+        Resource: &pbc.ResourceRecommendationInfo{
+            Provider:     "aws",
+            ResourceType: "ec2",
+            Region:       region,
+            Sku:          instanceType,
+        },
+        Modify: &pbc.ModifyAction{
+            ModificationType:  modTypeGraviton,
+            CurrentConfig:     map[string]string{"instance_type": instanceType, "architecture": "x86_64"},
+            RecommendedConfig: map[string]string{"instance_type": gravitonType, "architecture": "arm64"},
+        },
+        Impact: &pbc.RecommendationImpact{
+            EstimatedSavings:  savings,
+            Currency:          "USD",
+            ProjectionPeriod:  "monthly",
+            CurrentCost:       currentMonthly,
+            ProjectedCost:     gravitonMonthly,
+            SavingsPercentage: savingsPercent,
+        },
+        Priority:        pbc.RecommendationPriority_RECOMMENDATION_PRIORITY_LOW,
+        ConfidenceScore: &confidence,
+        Description:     fmt.Sprintf("Migrate from %s to %s (Graviton) for ~%.0f%% cost savings", instanceType, gravitonType, savingsPercent),
+        Reasoning: []string{
+            "Graviton instances are typically ~20% cheaper with comparable performance",
+            "Requires validation that application supports ARM architecture",
+        },
+        Metadata: map[string]string{
+            "architecture_change":  "x86_64 -> arm64",
+            "requires_validation": "Application must support ARM architecture",
+        },
+        Source: sourceAWSPublic,
+    }
+}
+```
+
+---
+
+### T3.2: Add unit tests for Graviton recommendation
+
+**File**: `internal/plugin/recommendations_test.go`
+**Depends on**: T3.1
+**Acceptance**: `make test` passes, metadata verified
+
+Implements SC-003 from spec.md.
+
+Test scenarios:
+
+1. m5.large → m6g.large with 0.7 confidence
+2. Architecture warning in metadata (`Metadata["architecture_change"]` = "x86_64 -> arm64")
+3. Validation warning in metadata (`Metadata["requires_validation"]` present)
+4. No Graviton equivalent (mac1.metal) → no recommendation
+
+```go
+func TestGetGravitonRecommendation(t *testing.T) {
+    tests := []struct {
+        name             string
+        instanceType     string
+        wantRecommend    bool
+        wantGravitonType string
+        wantConfidence   float64
+    }{
+        {"m5.large to m6g.large", "m5.large", true, "m6g.large", 0.7},
+        {"t3.micro to t4g.micro", "t3.micro", true, "t4g.micro", 0.7},
+        {"no graviton for mac1.metal", "mac1.metal", false, "", 0},
+    }
+    // ... test implementation
+
+    // For successful recommendations, verify metadata:
+    // assert.Equal(t, "x86_64 -> arm64", rec.Metadata["architecture_change"])
+    // assert.Contains(t, rec.Metadata["requires_validation"], "ARM")
+}
+```
+
+---
+
+## Phase 4: US3 - EBS Volume Type Upgrade (P3)
+
+**User Story**: As an infrastructure engineer, I want to receive recommendations to migrate gp2 volumes to gp3 so that I can reduce storage costs while improving baseline performance.
+
+### T4.1: Implement getEBSRecommendations
+
+**File**: `internal/plugin/recommendations.go`
+**Depends on**: T1.2
+**Acceptance**: Returns gp2→gp3 recommendation with size handling
+
+Implements FR-004, FR-006 from spec.md.
+
+```go
+func (p *AWSPublicPlugin) getEBSRecommendations(
+    volumeType, region string,
+    tags map[string]string,
+) []*pbc.Recommendation {
+    // Only recommend for gp2 volumes
+    if volumeType != "gp2" {
+        return nil
+    }
+
+    // Extract size from tags, default 100GB
+    sizeGB := 100
+    if sizeStr, ok := tags["size"]; ok {
+        if parsed, err := strconv.Atoi(sizeStr); err == nil && parsed > 0 {
+            sizeGB = parsed
+        }
+    } else if sizeStr, ok := tags["volume_size"]; ok {
+        if parsed, err := strconv.Atoi(sizeStr); err == nil && parsed > 0 {
+            sizeGB = parsed
+        }
+    }
+
+    gp2Price, found := p.pricing.EBSPricePerGBMonth("gp2")
+    if !found {
+        return nil
+    }
+
+    gp3Price, found := p.pricing.EBSPricePerGBMonth("gp3")
+    if !found || gp3Price > gp2Price {
+        return nil
+    }
+
+    currentMonthly := gp2Price * float64(sizeGB)
+    gp3Monthly := gp3Price * float64(sizeGB)
+    savings := currentMonthly - gp3Monthly
+    savingsPercent := (savings / currentMonthly) * 100
+
+    confidence := confidenceHigh
+    return []*pbc.Recommendation{{
+        Id:         uuid.New().String(),
+        Category:   pbc.RecommendationCategory_RECOMMENDATION_CATEGORY_COST_OPTIMIZATION,
+        ActionType: pbc.RecommendationActionType_RECOMMENDATION_ACTION_TYPE_MODIFY,
+        Resource: &pbc.ResourceRecommendationInfo{
+            Provider:     "aws",
+            ResourceType: "ebs",
+            Region:       region,
+            Sku:          volumeType,
+        },
+        Modify: &pbc.ModifyAction{
+            ModificationType:  modTypeVolumeUpgrade,
+            CurrentConfig:     map[string]string{"volume_type": "gp2", "size_gb": strconv.Itoa(sizeGB)},
+            RecommendedConfig: map[string]string{"volume_type": "gp3", "size_gb": strconv.Itoa(sizeGB)},
+        },
+        Impact: &pbc.RecommendationImpact{
+            EstimatedSavings:  savings,
+            Currency:          "USD",
+            ProjectionPeriod:  "monthly",
+            CurrentCost:       currentMonthly,
+            ProjectedCost:     gp3Monthly,
+            SavingsPercentage: savingsPercent,
+        },
+        Priority:        pbc.RecommendationPriority_RECOMMENDATION_PRIORITY_MEDIUM,
+        ConfidenceScore: &confidence,
+        Description:     fmt.Sprintf("Upgrade %dGB gp2 volume to gp3 for ~%.0f%% cost savings", sizeGB, savingsPercent),
+        Reasoning: []string{
+            "gp3 volumes are ~20% cheaper than gp2",
+            "gp3 provides better baseline performance (3000 IOPS, 125 MB/s)",
+            "API-compatible change with no data migration required",
+        },
+        Metadata: map[string]string{
+            "baseline_iops":       "gp2: 100 IOPS/GB, gp3: 3000 IOPS (included)",
+            "baseline_throughput": "gp2: 128-250 MB/s, gp3: 125 MB/s (included)",
+        },
+        Source: sourceAWSPublic,
+    }}
+}
+```
+
+**Note**: Add `"strconv"` import.
+
+---
+
+### T4.2: Add unit tests for EBS recommendations
+
+**File**: `internal/plugin/recommendations_test.go`
+**Depends on**: T4.1
+**Acceptance**: `make test` passes, metadata verified
+
+Test scenarios:
+
+1. gp2 100GB → gp3 recommendation with savings
+2. gp3 volume → no recommendation
+3. io1/io2 volume → no recommendation
+4. Missing size tag → uses 100GB default
+5. Performance metadata present (`Metadata["baseline_iops"]`, `Metadata["baseline_throughput"]`)
+
+```go
+func TestGetEBSRecommendations(t *testing.T) {
+    // ... test implementation
+
+    // For gp2 recommendations, verify metadata:
+    // assert.Contains(t, rec.Metadata["baseline_iops"], "gp3: 3000 IOPS")
+    // assert.Contains(t, rec.Metadata["baseline_throughput"], "gp3: 125 MB/s")
+}
+```
+
+---
+
+## Phase 5: US4 - Graceful Error Handling (P4)
+
+**User Story**: As a PulumiCost user, I want GetRecommendations to return an empty list for unsupported services so that my automation doesn't break.
+
+### T5.1: Verify empty list for unsupported services
+
+**File**: `internal/plugin/recommendations_test.go`
+**Depends on**: T1.2
+**Acceptance**: `make test` passes
+
+Implements FR-008 from spec.md.
+
+Test scenarios:
+
+1. S3 resource → empty list, no error
+2. Lambda resource → empty list, no error
+3. RDS resource → empty list, no error
+4. DynamoDB resource → empty list, no error
+
+```go
+func TestGetRecommendations_UnsupportedServices(t *testing.T) {
+    unsupportedTypes := []string{"s3", "lambda", "rds", "dynamodb"}
+    for _, resourceType := range unsupportedTypes {
+        t.Run(resourceType, func(t *testing.T) {
+            // Call GetRecommendations
+            // Assert empty list returned, no error
+        })
+    }
+}
+```
+
+---
+
+### T5.2: Verify ERROR_CODE_INVALID_RESOURCE for nil request
+
+**File**: `internal/plugin/recommendations_test.go`
+**Depends on**: T1.2
+**Acceptance**: `make test` passes
+
+Implements FR-009 from spec.md.
+
+```go
+func TestGetRecommendations_NilRequest(t *testing.T) {
+    plugin := NewAWSPublicPlugin(/* ... */)
+    resp, err := plugin.GetRecommendations(context.Background(), nil)
+
+    // Assert err is not nil
+    // Assert error contains ERROR_CODE_INVALID_RESOURCE
+    // Assert resp is nil
+}
+```
+
+---
+
+### T5.3: Verify trace_id propagation in logs
+
+**File**: `internal/plugin/recommendations_test.go`
+**Depends on**: T1.2
+**Acceptance**: `make test` passes
+
+Implements FR-010, SC-007 from spec.md.
+
+```go
+func TestGetRecommendations_TraceIDLogging(t *testing.T) {
+    // Capture log output
+    var logBuf bytes.Buffer
+    logger := zerolog.New(&logBuf)
+
+    plugin := NewAWSPublicPluginWithLogger(/* ... */, logger)
+
+    // Create context with trace_id metadata
+    md := metadata.New(map[string]string{
+        pluginsdk.TraceIDMetadataKey: "test-trace-123",
+    })
+    ctx := metadata.NewOutgoingContext(context.Background(), md)
+
+    _, _ = plugin.GetRecommendations(ctx, &pbc.GetRecommendationsRequest{})
+
+    // Verify trace_id appears in log output
+    logOutput := logBuf.String()
+    assert.Contains(t, logOutput, "test-trace-123")
+    assert.Contains(t, logOutput, "trace_id")
+}
+```
+
+**Note**: May require exposing logger injection in plugin constructor for testability.
+
+---
+
+## Phase 6: Polish
+
+### T6.1: Run make lint and fix issues
+
+**Depends on**: All previous tasks
+**Acceptance**: `make lint` passes with zero errors
+
+Common issues to check:
+
+- gofmt formatting
+- golangci-lint rules
+- Exported function documentation
+
+---
+
+### T6.2: Run make test and verify coverage
+
+**Depends on**: T6.1
+**Acceptance**: `make test` passes, coverage report shows new code covered
+
+Verify all acceptance scenarios from spec.md pass:
+
+- [ ] SC-001: GetRecommendations returns valid proto response within 100ms
+- [ ] SC-002: 100% of generation upgrades result in equal or lower cost
+- [ ] SC-003: 100% of Graviton recommendations include architecture warning
+- [ ] SC-004: All recommendations include accurate monthly savings
+- [ ] SC-005: Zero false positives (no recs where new > current)
+- [ ] SC-006: Empty list for unsupported services
+- [ ] SC-007: All log entries include trace_id
+
+---
+
+## Checklist
+
+### Before Starting
+
+- [ ] Read spec.md user stories and acceptance criteria
+- [ ] Read data-model.md for mapping definitions
+- [ ] Understand existing plugin.go structure
+- [ ] Verify pulumicost-spec v0.4.7 dependency
+
+### After Completion
+
+- [ ] `make lint` passes
+- [ ] `make test` passes
+- [ ] `go build ./...` passes
+- [ ] All acceptance scenarios verified
+- [ ] PR_MESSAGE.md generated with conventional commit


### PR DESCRIPTION
## Summary

- Implements the GetRecommendations RPC from pulumicost-spec v0.4.7
- Provides EC2 generation upgrade recommendations (t2→t3, m4→m5, etc.) with 0.9 confidence for safe drop-in replacements
- Provides Graviton/ARM migration recommendations (m5→m6g, c5→c6g, etc.) with 0.7 confidence due to architecture validation requirement
- Provides EBS gp2→gp3 volume type recommendations with cost and performance improvement details
- All recommendations include monthly savings calculations (730 hrs/month), current vs projected costs, and relevant metadata
- Returns empty list for unsupported resources (FR-008) rather than errors

## Test plan

- [x] `make lint` passes with zero issues
- [x] `make test` passes (175+ tests including 26 new recommendation tests)
- [x] Unit tests cover EC2 generation upgrades, Graviton migrations, EBS
- [x] Tests verify confidence levels (0.9 high, 0.7 medium)
- [x] Tests verify FR-011: no recommendations when new price > current
- [x] Tests verify FR-009: ERROR_CODE_INVALID_RESOURCE for nil request
- [x] Tests verify trace_id propagation in logs (FR-010)

## Changes

### New files

- `internal/plugin/instance_type.go` - EC2 instance type parser and upgrade mapping tables (generationUpgradeMap, gravitonMap)
- `internal/plugin/instance_type_test.go` - Tests for parsing and map validation
- `internal/plugin/recommendations.go` - GetRecommendations RPC implementation with generation upgrade, Graviton, and EBS helpers
- `internal/plugin/recommendations_test.go` - Comprehensive test coverage for all recommendation types and edge cases

### Modified files

- `go.mod` - Go version bump to 1.25.5
- `go.sum` - Updated pulumicost-spec to v0.4.7, protobuf to v1.36.11
- `CLAUDE.md` - Added 012-recommendations feature context

Closes #105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cost-optimization recommendations: EC2 generation upgrades, Graviton (ARM) migration options, and EBS gp2→gp3 storage recommendations with estimated monthly savings.

* **Tests**
  * Added comprehensive unit tests covering recommendation logic, instance-type mappings, EBS sizing/defaults, edge cases, logging, and unique ID behavior.

* **Documentation**
  * Updated Active Technologies and embedded pricing notes to reflect Go 1.25.5.

* **Chores**
  * Bumped Go toolchain to 1.25.5 and updated related config references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->