### PR TITLE
chore: adding in the roadmap and context files

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,50 @@
+# Project Context: pulumicost-plugin-aws-public
+
+## Core Architectural Identity
+
+The **pulumicost-plugin-aws-public** is a stateless, air-gapped gRPC projection
+engine. It serves as a specialized provider for the PulumiCost ecosystem,
+transforming resource descriptors into cost and carbon estimates. Its primary
+design goal is to provide "good-enough" on-demand estimates without requiring
+AWS credentials or network access at runtime.
+
+## Technical Boundaries (Hard No's)
+
+1. **No Runtime Network Dependencies:** The plugin MUST NOT make any outbound
+   network calls (AWS APIs, Pricing APIs, etc.) during execution. All data
+   required for estimation must be embedded in the binary at build time.
+2. **No Credential Management:** This plugin does not handle AWS IAM roles,
+   access keys, or STS tokens. It is intentionally decoupled from the user's AWS
+   account security boundary.
+3. **No Dynamic Resource Discovery:** The plugin does not "verify" if a resource
+   exists in AWS. It purely calculates costs based on the `ResourceDescriptor`
+   provided via gRPC.
+4. **No Persistent State:** The plugin is completely ephemeral. It does not
+   maintain a database, cache (beyond in-memory initialization), or local
+   filesystem state.
+5. **No Real-time Pricing:** It does not reflect Spot instance fluctuations,
+   Savings Plans, or Reserved Instance discounts. It provides static On-Demand
+   estimates based on the version of data embedded at build time.
+
+## Data Source of Truth
+
+- **Financial Data:** AWS Public Price List API. This data is fetched during the
+  build process by `tools/generate-pricing`, filtered for On-Demand terms, and
+  embedded via `//go:embed`.
+- **Carbon Data:** Cloud Carbon Footprint (CCF) methodology. Power coefficients
+  are sourced from the `cloud-carbon-coefficients` repository, stored in
+  `ccf_instance_specs.csv`, and embedded at build time.
+- **Regionality:** The source of truth is partitioned by AWS region. Each
+  binary is compiled with a specific region's data subset using Go build tags
+  (e.g., `region_use1`).
+
+## Interaction Model
+
+- **Protocol:** gRPC (implementing `pulumicost.v1.CostSourceService`).
+- **Lifecycle:** Orchestrated as a subprocess by PulumiCost Core.
+- **Discovery:** Announces its listening port via `stdout` (format:
+  `PORT=XXXXX`).
+- **Telemetry:** Structured JSON logging (via `zerolog`) sent exclusively to
+  `stderr` to avoid corrupting the port discovery channel.
+- **Input:** Receives `ResourceDescriptor` objects containing provider, type,
+  SKU, region, and tags.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,72 @@
+# Strategic Roadmap: pulumicost-plugin-aws-public
+
+## Mission Statement
+
+To provide the most comprehensive, air-gapped cost and carbon estimation engine
+for AWS, enabling continuous governance and pre-deployment planning without the
+security overhead of cloud credentials.
+
+---
+
+## Past Milestones [Done]
+
+- **Core Infrastructure:** gRPC `CostSourceService` implementation, regional
+  build matrix (9+ regions), and `zerolog` trace propagation.
+- **Compute:** EC2 On-Demand cost estimation and CCF-based Carbon Footprint
+  (gCO2e) metrics.
+- **Storage:** EBS (Basic Storage), S3 (Standard Storage), and basic Lambda
+  estimation.
+- **Managed Services:** EKS Control Plane, DynamoDB (On-Demand/Provisioned), and
+  ELB (ALB/NLB with LCU/NLCU support).
+- **Optimization:** `GetRecommendations` batch processing for
+  `target_resources` (up to 100 items).
+- **Architecture:** Transition to per-service raw JSON embedding to manage
+  binary size and initialization speed.
+
+---
+
+## Immediate Focus [In Progress / Planned]
+
+- **[In Progress] RDS Implementation:** Move RDS from stub to full support
+  (Instance types, Multi-AZ flags, and Storage).
+- **[Planned] Documentation Alignment:** Update `README.md` and `CLAUDE.md` to
+  reflect that S3, EKS, DynamoDB, and ELB are fully implemented and no longer
+  stubs.
+- **[Planned] Refined "Actual Cost" Logic:** Enhance `GetActualCost` to
+  intelligently prioritize usage hours from request metadata, defaulting to
+  730-hour monthly projections only when usage is absent.
+- **[Planned] Service Breadth Expansion:**
+  - **ElastiCache:** Node type and engine-based pricing.
+  - **Route53:** Hosted zones and basic query volume estimation.
+  - **CloudFront:** Basic data transfer and request pricing (based on regional
+    estimates).
+
+---
+
+## Future Vision [Researching / Planned]
+
+- **[Researching] Memory Optimization:** Implementing lazy-loading or
+  memory-mapped access for embedded JSON files to reduce the runtime memory
+  footprint without moving to an external database.
+- **[Planned] Service Depth (Phase 2):**
+  - **EBS Depth:** Adding IOPS and Throughput pricing for `gp3`, `io1`, and
+    `io2`.
+  - **EC2 Depth:** Integrating GPU-specific carbon coefficients as data becomes
+    available in CCF.
+- **[Researching] Cross-Service Recommendations:** Static lookup logic to
+  suggest move-to-managed alternatives (e.g., self-managed DB on EC2 -> RDS)
+  based on Resource Tags.
+- **[Planned] Additional Regions:** Expansion to GovCloud (US-West/East) and
+  specialized regions (e.g., Beijing/Ningxia) as public pricing data parity
+  allows.
+
+---
+
+## Strategic Guardrails (From CONTEXT.md)
+
+1. **Statelessness:** No local databases or historical trend storage. Data
+   "intelligence" (comparisons) belongs in PulumiCost Core.
+2. **Air-Gapped:** Zero runtime network calls. All estimates derived from
+   build-time snapshots.
+3. **Static Logic:** Recommendations are based on static mappings and SKU
+   attributes, never on live monitoring or external telemetry.


### PR DESCRIPTION
This pull request introduces two important documentation files: `CONTEXT.md` and `ROADMAP.md`. These documents clarify the architectural principles, technical constraints, and strategic direction for the `pulumicost-plugin-aws-public` project, providing clear guidance for both current and future development.

Project context and architectural principles:

* Added `CONTEXT.md` to define the core identity of the plugin, including its stateless, air-gapped design, hard technical boundaries (such as no runtime network dependencies or credential management), and the sources of embedded financial and carbon data. It also outlines the gRPC-based interaction model and operational lifecycle.

Strategic planning and development roadmap:

* Added `ROADMAP.md` to document the mission statement, completed milestones, immediate development focus (such as RDS support and documentation updates), and future vision for service expansion, memory optimization, and new region support. It also reiterates strategic guardrails from the context document.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added project context documentation describing the plugin's architecture, operational boundaries, data sources, and communication protocol.
  * Added strategic roadmap document outlining the project's mission, past milestones, current focus areas, future vision, and governance guardrails.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->