### PR TITLE
chore: comprehensive bug fixes, refactoring and documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ public pricing data at build time and serves cost estimates via gRPC.
 
 - RDS
 
+## Actual Cost Estimation
+
+This plugin provides basic actual cost estimation based on resource runtime and public pricing. However, it has significant limitations compared to billing-integrated solutions.
+
+👉 **[Read the Actual Cost Estimation Guide](docs/actual-cost-estimation.md)** for details on accuracy, limitations with imported resources, and when to use a dedicated FinOps plugin.
+
 ## Features
 
 - **gRPC Protocol**: Implements `CostSourceService` from `pulumicost.v1` proto

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -66,6 +66,6 @@ Use `grpcurl` to test the plugin manually:
 
 ```bash
 # Capture the PORT from stdout
-PORT=50051 # replace with actual port
+PORT=12345 # replace with actual port from plugin startup output (e.g., PORT=12345)
 grpcurl -plaintext localhost:$PORT pulumicost.v1.CostSourceService/Name
 ```

--- a/cmd/pulumicost-plugin-aws-public/main.go
+++ b/cmd/pulumicost-plugin-aws-public/main.go
@@ -70,7 +70,9 @@ func run() error {
 			logger.Warn().
 				Str("env_var", "PORT").
 				Str("replacement", "PULUMICOST_PLUGIN_PORT").
-				Msg("PORT environment variable is deprecated and will be removed in v0.1.0. Please use PULUMICOST_PLUGIN_PORT instead.")
+				Str("deprecated_since", "v0.0.8").
+				Str("removal_version", "v0.1.0").
+				Msg("PORT environment variable is deprecated since v0.0.8 and will be removed in v0.1.0. Please use PULUMICOST_PLUGIN_PORT instead.")
 			if parsed, err := strconv.Atoi(portStr); err == nil {
 				port = parsed
 			}

--- a/docs/actual-cost-estimation.md
+++ b/docs/actual-cost-estimation.md
@@ -1,0 +1,64 @@
+# Actual Cost Estimation Limitations
+
+The `aws-public` plugin estimates actual costs using public pricing data and runtime calculations. This document explains how it works, its accuracy limitations, and when to use it versus a dedicated FinOps plugin.
+
+## How It Works
+
+The plugin estimates actual costs using the following formula:
+
+```
+actual_cost = projected_hourly_rate × hours_running
+```
+
+Where:
+- `projected_hourly_rate` = Monthly projected cost / 730 hours
+- `hours_running` = Time between resource creation timestamp and query end time
+
+## Accuracy Levels
+
+| Resource Origin | Accuracy | Notes |
+|-----------------|----------|-------|
+| `pulumi up` | **Good** | Pulumi "Created" timestamp matches actual cloud creation time within seconds. |
+| `pulumi import` | **Poor** | "Created" timestamp is set to the import time, not the actual cloud creation time. |
+
+## Known Limitations
+
+### 1. Imported Resources Are Inaccurate
+
+When you run `pulumi import` to bring existing cloud resources under Pulumi management, the `Created` timestamp in the state file is set to the time of import. The plugin cannot see when the resource was originally created in AWS.
+
+**Example:**
+- EC2 instance launched: **January 1, 2024**
+- Imported to Pulumi: **December 24, 2024**
+- aws-public sees Created: **December 24, 2024**
+- **Estimated runtime: 0 days** (actual: 358 days)
+- **Estimated cost: Near $0** (actual: significant)
+
+### 2. No Stop/Start Tracking
+
+Pulumi state tracks resource existence, not runtime state. The plugin assumes the resource has been running 100% of the time since creation. It cannot account for stopped instances (which have lower or zero compute costs).
+
+### 3. No Billing Features
+
+Because the plugin uses public on-demand pricing data, it cannot account for account-specific billing features:
+- **Reserved Instances (RIs)**: Upfront payments and discounted hourly rates are ignored.
+- **Spot Instances**: Variable spot pricing is not supported; on-demand rates are used.
+- **Savings Plans**: Compute/EC2 Savings Plans discounts are not applied.
+- **Free Tier**: Free tier usage limits are not tracked.
+- **Volume Discounts**: Tiered pricing (e.g., S3/data transfer) is estimated based on the single resource's usage, not aggregated account usage.
+- **Credits**: AWS credits are not visible.
+
+## When to Use
+
+Use `aws-public` for actual cost estimation when:
+- You need a quick, rough estimate without configuring AWS credentials.
+- You are in a development/testing environment.
+- You cannot use a plugin that requires read access to your AWS billing data.
+
+## For Accurate Costs
+
+For accurate actual cost reporting, we strongly recommend using a dedicated FinOps plugin that integrates with your cloud provider's billing data:
+
+- **[Vantage Plugin](https://github.com/rshade/pulumicost-plugin-vantage)**: Integrates with Vantage to provide precise historical cost data.
+- **AWS Cost Explorer Plugin** (Planned): Will integrate directly with AWS Cost Explorer API.
+- **Kubecost Plugin** (Planned): For Kubernetes-specific cost visibility.

--- a/internal/plugin/constants.go
+++ b/internal/plugin/constants.go
@@ -1,6 +1,9 @@
 // Package plugin provides the CostSourceService gRPC implementation for AWS public pricing.
 package plugin
 
+// providerAWS is the constant identifier for the AWS provider.
+const providerAWS = "aws"
+
 // PricingNotFoundTemplate is the standard message template for missing pricing data.
 // Use with fmt.Sprintf to format specific resource details.
 //

--- a/internal/plugin/pricingspec.go
+++ b/internal/plugin/pricingspec.go
@@ -33,7 +33,8 @@ func (p *AWSPublicPlugin) GetPricingSpec(ctx context.Context, req *pbc.GetPricin
 	resource := req.Resource
 
 	// Normalize resource type (handles Pulumi formats like aws:ec2/instance:Instance)
-	serviceType := detectService(resource.ResourceType)
+	normalizedResourceType := normalizeResourceType(resource.ResourceType)
+	serviceType := detectService(normalizedResourceType)
 
 	var spec *pbc.PricingSpec
 
@@ -88,7 +89,7 @@ func (p *AWSPublicPlugin) ec2PricingSpec(resource *pbc.ResourceDescriptor) *pbc.
 			RatePerUnit:  0,
 			Currency:     "USD",
 			Unit:         "hour",
-			Description:  fmt.Sprintf("EC2 instance type %q not found in pricing data", instanceType),
+			Description:  fmt.Sprintf(PricingNotFoundTemplate, "EC2 instance type", instanceType),
 			Source:       "aws-public",
 			Assumptions:  []string{"Instance type not found in embedded pricing data"},
 		}
@@ -129,7 +130,7 @@ func (p *AWSPublicPlugin) ebsPricingSpec(resource *pbc.ResourceDescriptor) *pbc.
 			RatePerUnit:  0,
 			Currency:     "USD",
 			Unit:         "GB-month",
-			Description:  fmt.Sprintf("EBS volume type %q not found in pricing data", volumeType),
+			Description:  fmt.Sprintf(PricingNotFoundTemplate, "EBS volume type", volumeType),
 			Source:       "aws-public",
 			Assumptions:  []string{"Volume type not found in embedded pricing data"},
 		}

--- a/internal/plugin/projected_test.go
+++ b/internal/plugin/projected_test.go
@@ -1305,9 +1305,10 @@ func TestDetectService(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := detectService(tt.input)
+			normalized := normalizeResourceType(tt.input)
+			got := detectService(normalized)
 			if got != tt.expected {
-				t.Errorf("detectService(%q) = %q, want %q", tt.input, got, tt.expected)
+				t.Errorf("detectService(normalizeResourceType(%q)) = %q, want %q", tt.input, got, tt.expected)
 			}
 		})
 	}

--- a/internal/plugin/supports.go
+++ b/internal/plugin/supports.go
@@ -34,10 +34,11 @@ func (p *AWSPublicPlugin) Supports(ctx context.Context, req *pbc.SupportsRequest
 	// Note: detectService() is called multiple times across validation and support checks.
 	// For optimization opportunity: consider caching normalized service types per resource_type
 	// to avoid repeated string parsing if high-frequency batches of identical resource types occur.
-	normalizedType := detectService(resource.ResourceType)
+	normalizedResourceType := normalizeResourceType(resource.ResourceType)
+	normalizedType := detectService(normalizedResourceType)
 
 	// Check provider
-	if resource.Provider != "aws" {
+	if resource.Provider != providerAWS {
 		p.logger.Info().
 			Str(pluginsdk.FieldTraceID, traceID).
 			Str(pluginsdk.FieldOperation, "Supports").
@@ -49,7 +50,7 @@ func (p *AWSPublicPlugin) Supports(ctx context.Context, req *pbc.SupportsRequest
 
 		return &pbc.SupportsResponse{
 			Supported: false,
-			Reason:    fmt.Sprintf("Provider %q not supported (only 'aws' is supported)", resource.Provider),
+			Reason:    fmt.Sprintf("Provider %q not supported (only %q is supported)", resource.Provider, providerAWS),
 		}, nil
 	}
 

--- a/tools/generate-embeds/Makefile
+++ b/tools/generate-embeds/Makefile
@@ -1,0 +1,9 @@
+# tools/generate-embeds/Makefile
+
+CONFIG ?= ../../internal/pricing/regions.yaml
+TEMPLATE ?= embed_template.go.tmpl
+OUTPUT ?= ../../internal/pricing
+
+.PHONY: run-generator
+run-generator:
+	go run . --config $(CONFIG) --template $(TEMPLATE) --output $(OUTPUT)

--- a/tools/generate-goreleaser/Makefile
+++ b/tools/generate-goreleaser/Makefile
@@ -1,0 +1,8 @@
+# tools/generate-goreleaser/Makefile
+
+CONFIG ?= ../../internal/pricing/regions.yaml
+OUTPUT ?= ../../.goreleaser.yaml
+
+.PHONY: run-generator
+run-generator:
+	go run . --config $(CONFIG) --output $(OUTPUT)

--- a/tools/parse-regions/Makefile
+++ b/tools/parse-regions/Makefile
@@ -1,0 +1,9 @@
+# tools/parse-regions/Makefile
+
+CONFIG ?= ../../internal/pricing/regions.yaml
+FORMAT ?= lines
+FIELD ?= name
+
+.PHONY: run-parser
+run-generator:
+	go run . -config $(CONFIG) -format $(FORMAT) -field $(FIELD)


### PR DESCRIPTION
- **Refactor(plugin): Normalize resource type format at entry point (#124, #125)**: Created `normalizeResourceType()` to handle various Pulumi resource type formats (e.g., `aws:ec2/instance:Instance`) and convert them to canonical forms (e.g., `ec2`). This simplifies `detectService()` logic and ensures consistent handling across the plugin.
- **Perf(recommendations): Reduce string allocations in detectService (#125)**: Optimized `detectService()` by expecting normalized input, reducing `strings.ToLower()` calls and associated allocations.
- **Perf(plugin): Optimize tag sanitization loop efficiency (#115)**: Refactored `sanitizeTagsForLogging` to use explicit count tracking for better iteration efficiency.
- **Fix: Potential race condition in carbon logger initialization (#159)**: Ensured `carbon.SetLogger()` is called before any carbon estimator functions to prevent race conditions during plugin startup.
- **Fix: Race condition in region assignment during parallel parsing (#179)**: Added synchronization to shared variables used during parallel pricing data parsing.

- **Fix(validation): Add ARN to error message when ARN parsing fails (#114, #161)**: Updated error messages to include the failing ARN and other identifying information (resource type, region) to improve debugging ergonomics.
- **Refactor: Use standardized error templates across all service estimators (#213)**: Adopted `PricingNotFoundTemplate` and `PricingUnavailableTemplate` consistently across all service estimators.
- **Feat(elb): Add optional warning logs for unrealistic capacity unit values (#165)**: Added warning logs for unusually high ELB capacity unit values (>1000 LCU/NLCU) to help catch configuration errors.
- **Refactor(plugin): Extract magic string 'aws' to constant (#126)**: Defined `providerAWS = "aws"` and updated all usages for better maintainability.

- **Docs: Clarify pulumicost-spec v0.4.11 dependency in CLAUDE.md (#202)**: Updated documentation to explain that v0.4.11 adds the `Id` field for request/response correlation.
- **Docs(dynamodb): Clarify unit_price semantics for multi-component costs (#150)**: Added documentation in `projected.go` and `CLAUDE.md` regarding the informational nature of `unit_price` for multi-component services like DynamoDB.
- **Docs: Document critical vs non-critical service failure policy (#180)**: Explicitly documented the plugin's policy on failure during initialization for different services.
- **Docs: Document Reserved/Savings Plans term filtering in CLAUDE.md (#183)**: Documented that RI/SP terms are filtered out to reduce binary size and that the plugin supports On-Demand pricing only.
- **Docs: Add actual cost estimation limitations documentation (#197)**: Created `docs/actual-cost-estimation.md` detailing limitations with imported resources, stop/start tracking, and billing features.
- **Docs: Fix magic port number in TROUBLESHOOTING.md (#163)**: Replaced hardcoded port 50051 with dynamic guidance.
- **Docs: Clarify deprecation timeline in PORT environment variable warning (#164)**: Specified that `PORT` deprecation started in v0.0.8.
- **Docs(elb): Add AWS documentation references for LCU/NLCU estimation (#166)**: Added links and typical value tables for ELB capacity unit estimation.
- **Docs: Add user-facing CloudWatch cost estimation examples (#214)**: Added examples for CloudWatch logs, metrics, and combined estimation modes.
- **Docs: Add explanatory comment for tiered cost calculation edge case (#211)**: Added defensive check explanation in `calculateTieredCost()`.

- **Chore: make Makefile targets idiomatic with recursive make or subshells (#67)**: Created tool-specific Makefiles and updated the root Makefile to use recursive make for better directory isolation and maintainability.
- **Fix: Add fallback handling for non-standard version formats in Makefile (#178)**: Sanitized PATCH version extraction to handle non-numeric components in tags.
- **Chore(deps): Update pulumicost-spec to enable gRPC reflection (#177)**: Updated dependency to v0.4.11.
- **Test: Use t.TempDir() for integration test binary cleanup (#158)**: Updated integration tests to use temporary directories for build artifacts, ensuring automatic cleanup even on panic.
- **Feat: Add trace-level logging for resource ID source debugging (#201)**: Added trace logs to indicate if a resource ID was sourced from the native field or tag fallback.
- **Test(recommendations): Add test for EBS batch mode with empty tags (#127)**: Added coverage for default 100GB fallback in batch recommendations.

- **Refactor: Consolidate duplicate nil checks in recommendations.go (#162)**: Combined redundant resource nil checks.
- **Style(recommendations): Remove trailing empty line (#130)**: Fixed file ending to adhere to Go conventions.

- Modified `internal/plugin/projected.go`, `internal/plugin/validation.go`, `internal/plugin/recommendations.go`, `internal/plugin/supports.go`, `internal/plugin/plugin.go`, `internal/plugin/constants.go`, `internal/pricing/client.go`.
- Updated `Makefile`, `go.mod`, `go.sum`, `CLAUDE.md`, `README.md`, `TROUBLESHOOTING.md`.
- Created `docs/actual-cost-estimation.md` and tool-specific Makefiles.

- [x] `make lint` passes.
- [x] `make test` passes (all unit tests).
- [x] Verified `TestGetRecommendations_Batch_EBSDefaultSize` specifically for #127.
- [x] Verified `TestDetectService` with new normalization logic.
- [x] `go test -race ./internal/pricing/...` verified for #179.

closes #67
closes #114
closes #115
closes #124
closes #125
closes #126
closes #127
closes #130
closes #150
closes #158
closes #159
closes #161
closes #162
closes #163
closes #164
closes #165
closes #166
closes #177
closes #178
closes #179
closes #180
closes #183
closes #197
closes #201
closes #202
closes #211
closes #213
closes #214

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Actual Cost Estimation documentation and capacity unit estimation resources; quick-reference pricing table.

* **Bug Fixes**
  * Improved region-mismatch handling and clearer unsupported-region errors.
  * Increased thread-safety for concurrent region pricing processing.
  * Ensured EBS default sizing uses 100GB when missing.

* **Documentation**
  * Expanded region-specific binary guidance, CloudWatch examples, logging recommendations, and resource-type normalization patterns.

* **Tests**
  * Added integration/testing patterns and new tests to prevent normalization regressions.

* **Chores**
  * Added Make targets for embed/goreleaser/region tooling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->