### PR TITLE
feat(actual): implement runtime-based actual cost from Pulumi metadata

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,1 +1,8 @@
-{"MD041": false}
+{
+  "MD041": false,
+  "MD013": false,
+  "MD024": false,
+  "MD032": false,
+  "MD036": false,
+  "MD060": false
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,9 @@ added to `tools/generate-pricing/main.go` that stripped 85% of pricing data:
 - Elastic Load Balancing (ALB/NLB) - Application Load Balancers and Network Load Balancers
 - NAT Gateway
 - CloudWatch (Logs ingestion/storage, custom metrics)
+- S3 (Storage per GB-month by storage class)
+- Lambda (Requests + compute GB-seconds, x86_64/arm64 architecture support)
+- RDS (Instance hours + storage, Multi-engine support)
 
 ## Directory Structure
 
@@ -541,9 +544,9 @@ and excluded helps users accurately estimate total infrastructure costs.
 | ELB (ALB/NLB) | Fixed hourly + capacity unit charges | Data transfer, SSL/TLS termination | N/A |
 | NAT Gateway | Hourly rate + data processing (per GB) | Data transfer OUT to internet, VPC peering transfer | N/A |
 | CloudWatch | Logs ingestion (tiered), storage, custom metrics (tiered) | Dashboards, alarms, contributor insights, cross-account | N/A |
-| RDS | Not implemented | - | ❌ [#137](https://github.com/rshade/pulumicost-plugin-aws-public/issues/137) |
-| S3 | Not implemented | - | ❌ [#137](https://github.com/rshade/pulumicost-plugin-aws-public/issues/137) |
-| Lambda | Not implemented | - | ❌ [#137](https://github.com/rshade/pulumicost-plugin-aws-public/issues/137) |
+| RDS | Instance hours + storage (gp2/gp3/io1), Multi-engine | Multi-AZ, read replicas, backups, IOPS | N/A |
+| S3 | Storage per GB-month by storage class | Requests, data transfer, lifecycle | N/A |
+| Lambda | Requests + compute (GB-seconds), x86_64/arm64 | Provisioned concurrency, Lambda@Edge | N/A |
 | DynamoDB | On-Demand/Provisioned throughput, storage | Global tables, streams, DAX, backups | ❌ [#137](https://github.com/rshade/pulumicost-plugin-aws-public/issues/137) |
 
 ### EKS Clusters
@@ -997,3 +1000,10 @@ Always refer to the proto files in `../pulumicost-spec/proto/` for the authorita
 - **pulumicost-spec** protos for CostSourceService API
 - **zerolog** for structured JSON logging (stderr only)
 - **Embedded JSON** pricing data via `//go:embed` (no external storage)
+
+## Active Technologies
+- Go 1.25+ + gRPC, pulumicost-spec (proto), zerolog, google.golang.org/protobuf (timestamppb) (016-runtime-actual-cost)
+- N/A (embedded pricing data, stateless service) (016-runtime-actual-cost)
+
+## Recent Changes
+- 016-runtime-actual-cost: Added Go 1.25+ + gRPC, pulumicost-spec (proto), zerolog, google.golang.org/protobuf (timestamppb)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,13 +11,14 @@ security overhead of cloud credentials.
 ## Past Milestones [Done]
 
 - **Core Infrastructure:** gRPC `CostSourceService` implementation, regional
-  build matrix (9+ regions), and `zerolog` trace propagation.
-- **Compute:** EC2 On-Demand cost estimation and CCF-based Carbon Footprint
-  (gCO2e) metrics.
-- **Storage:** EBS (Basic Storage), S3 (Standard Storage), and basic Lambda
-  estimation.
-- **Managed Services:** EKS Control Plane, DynamoDB (On-Demand/Provisioned), and
-  ELB (ALB/NLB with LCU/NLCU support).
+  build matrix (12 regions), and `zerolog` trace propagation.
+- **Compute:** EC2 On-Demand cost estimation, Lambda (requests + GB-seconds,
+  x86_64/arm64), and CCF-based Carbon Footprint (gCO2e) metrics.
+- **Storage:** EBS (Basic Storage GB-month pricing), S3 (Storage by storage class).
+- **Managed Services:** EKS Control Plane, DynamoDB (On-Demand/Provisioned),
+  ELB (ALB/NLB with LCU/NLCU support), and RDS (instance + storage, multi-engine).
+- **Networking:** NAT Gateway (hourly + data processing per GB), CloudWatch
+  (Logs ingestion/storage with tiered pricing, custom metrics).
 - **Optimization:** `GetRecommendations` batch processing for
   `target_resources` (up to 100 items).
 - **Architecture:** Transition to per-service raw JSON embedding to manage
@@ -27,11 +28,6 @@ security overhead of cloud credentials.
 
 ## Immediate Focus [In Progress / Planned]
 
-- **[In Progress] RDS Implementation:** Move RDS from stub to full support
-  (Instance types, Multi-AZ flags, and Storage).
-- **[Planned] Documentation Alignment:** Update `README.md` and `CLAUDE.md` to
-  reflect that S3, EKS, DynamoDB, and ELB are fully implemented and no longer
-  stubs.
 - **[Planned] Refined "Actual Cost" Logic:** Enhance `GetActualCost` to
   intelligently prioritize usage hours from request metadata, defaulting to
   730-hour monthly projections only when usage is absent.
@@ -56,9 +52,9 @@ security overhead of cloud credentials.
 - **[Researching] Cross-Service Recommendations:** Static lookup logic to
   suggest move-to-managed alternatives (e.g., self-managed DB on EC2 -> RDS)
   based on Resource Tags.
-- **[Planned] Additional Regions:** Expansion to GovCloud (US-West/East) and
-  specialized regions (e.g., Beijing/Ningxia) as public pricing data parity
-  allows.
+- **[Planned] Additional Regions:** Expansion to specialized regions (e.g.,
+  Beijing/Ningxia, EU-North-1) as public pricing data parity allows. GovCloud
+  (US-West/East) already supported.
 - **[Planned] Forecasting Intelligence:**
   - **Growth Hints:** Implement logic to return `GrowthType` (Linear) for
     accumulation-based resources (S3, ECR, Backup) to support Core forecasting.

--- a/internal/plugin/actual.go
+++ b/internal/plugin/actual.go
@@ -1,11 +1,218 @@
 package plugin
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
 	pbc "github.com/rshade/pulumicost-spec/sdk/go/proto/pulumicost/v1"
 )
+
+// Pulumi metadata tag keys.
+// These keys are injected by pulumicost-core from Pulumi state.
+const (
+	// TagPulumiCreated is the RFC3339 timestamp of resource creation in Pulumi state.
+	// For imported resources, this is the import time, not actual cloud creation.
+	TagPulumiCreated = "pulumi:created"
+
+	// TagPulumiModified is the RFC3339 timestamp of last modification.
+	// NOTE: This feature does NOT use modified time as a fallback for created.
+	TagPulumiModified = "pulumi:modified"
+
+	// TagPulumiExternal indicates the resource was imported (not created by Pulumi).
+	// Value is "true" when present; absence means native Pulumi resource.
+	TagPulumiExternal = "pulumi:external"
+)
+
+// ConfidenceLevel represents the estimation confidence for actual cost calculations.
+// The level affects how the cost data should be interpreted by consumers.
+type ConfidenceLevel string
+
+const (
+	// ConfidenceHigh indicates precise calculation with known timestamps.
+	// Used when: explicit request timestamps OR native resource with pulumi:created.
+	ConfidenceHigh ConfidenceLevel = "HIGH"
+
+	// ConfidenceMedium indicates reasonable estimate with caveats.
+	// Used when: imported resource (pulumi:external=true) - timestamp is import time.
+	ConfidenceMedium ConfidenceLevel = "MEDIUM"
+
+	// ConfidenceLow indicates rough estimate or fallback.
+	// Used when: unsupported resource, missing data, or significant assumptions.
+	ConfidenceLow ConfidenceLevel = "LOW"
+)
+
+// TimestampResolution captures the resolved timestamps and their source.
+// This struct is used internally to track how timestamps were determined
+// and whether the resource was imported.
+type TimestampResolution struct {
+	// Start is the resolved start timestamp for cost calculation.
+	Start time.Time
+
+	// End is the resolved end timestamp for cost calculation.
+	End time.Time
+
+	// Source indicates how timestamps were resolved.
+	// Values: "explicit", "pulumi:created", "mixed"
+	Source string
+
+	// IsImported is true when the resource has pulumi:external=true.
+	// This affects confidence level (MEDIUM vs HIGH).
+	IsImported bool
+}
+
+// extractPulumiCreated parses the pulumi:created timestamp from tags.
+// Returns (timestamp, true) if valid RFC3339, or (zero, false) if missing/invalid.
+// This function is thread-safe and has no side effects.
+func extractPulumiCreated(tags map[string]string) (time.Time, bool) {
+	if tags == nil {
+		return time.Time{}, false
+	}
+	createdStr, exists := tags[TagPulumiCreated]
+	if !exists || createdStr == "" {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(time.RFC3339, createdStr)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+// isImportedResource checks if the resource has pulumi:external=true.
+// The comparison is case-sensitive per the spec.
+func isImportedResource(tags map[string]string) bool {
+	if tags == nil {
+		return false
+	}
+	return tags[TagPulumiExternal] == "true"
+}
+
+// formatSourceWithConfidence creates the source string with embedded confidence.
+// Format: "aws-public-fallback[confidence:LEVEL] optional_note"
+func formatSourceWithConfidence(confidence ConfidenceLevel, note string) string {
+	base := fmt.Sprintf("aws-public-fallback[confidence:%s]", confidence)
+	if note != "" {
+		return base + " " + note
+	}
+	return base
+}
+
+// mergeTagsFromRequest extracts tags from both req.Tags and ResourceId JSON.
+// Tags in req.Tags take precedence over those in ResourceId JSON.
+// This ensures Pulumi metadata tags work regardless of where they're placed.
+func mergeTagsFromRequest(req *pbc.GetActualCostRequest) map[string]string {
+	merged := make(map[string]string)
+
+	// First, try to extract tags from ResourceId JSON
+	if req.ResourceId != "" {
+		var resource struct {
+			Tags map[string]string `json:"tags"`
+		}
+		if json.Unmarshal([]byte(req.ResourceId), &resource) == nil && resource.Tags != nil {
+			for k, v := range resource.Tags {
+				merged[k] = v
+			}
+		}
+	}
+
+	// Then overlay req.Tags (takes precedence)
+	if req.Tags != nil {
+		for k, v := range req.Tags {
+			merged[k] = v
+		}
+	}
+
+	return merged
+}
+
+// resolveTimestamps applies priority-based timestamp resolution.
+// Priority order: (1) explicit req.Start/End, (2) pulumi:created tag, (3) error
+//
+// This function MUST be called BEFORE validateTimestamps() to allow automatic
+// timestamp detection from Pulumi state metadata. If explicit timestamps are
+// provided, they take precedence over tags.
+//
+// Tags are merged from both req.Tags and ResourceId JSON (if present).
+// req.Tags takes precedence over ResourceId JSON tags.
+//
+// For end time: if explicit End is provided, use it; otherwise default to now.
+//
+// Returns TimestampResolution with source tracking for confidence determination.
+// Returns error if no valid timestamps can be resolved.
+func resolveTimestamps(req *pbc.GetActualCostRequest) (*TimestampResolution, error) {
+	if req == nil {
+		return nil, fmt.Errorf("request is nil")
+	}
+
+	// Merge tags from both req.Tags and ResourceId JSON
+	mergedTags := mergeTagsFromRequest(req)
+
+	resolution := &TimestampResolution{
+		IsImported: isImportedResource(mergedTags),
+	}
+
+	// Track which timestamp sources are used
+	hasExplicitStart := req.Start != nil
+	hasExplicitEnd := req.End != nil
+
+	// Resolve start time
+	if hasExplicitStart {
+		resolution.Start = req.Start.AsTime()
+		resolution.Source = "explicit"
+	} else {
+		// Try pulumi:created from merged tags
+		if created, found := extractPulumiCreated(mergedTags); found {
+			resolution.Start = created
+			resolution.Source = "pulumi:created"
+		} else {
+			return nil, fmt.Errorf("start time required: provide explicit Start or pulumi:created tag")
+		}
+	}
+
+	// Resolve end time
+	if hasExplicitEnd {
+		resolution.End = req.End.AsTime()
+		// Update source if we have mixed sources
+		if !hasExplicitStart && resolution.Source == "pulumi:created" {
+			resolution.Source = "mixed"
+		}
+	} else {
+		// Default end to now
+		resolution.End = time.Now().UTC()
+		// Update source if we had explicit start only
+		if hasExplicitStart {
+			resolution.Source = "mixed"
+		}
+	}
+
+	return resolution, nil
+}
+
+// determineConfidence maps resolution source and import status to confidence level.
+//
+// Confidence rules:
+//   - HIGH: Explicit timestamps OR native resource with pulumi:created
+//   - MEDIUM: Imported resource (pulumi:external=true) with pulumi:created
+//   - LOW: Unsupported resource type or significant assumptions (handled elsewhere)
+func determineConfidence(resolution *TimestampResolution) ConfidenceLevel {
+	if resolution == nil {
+		return ConfidenceLow
+	}
+
+	// Explicit timestamps always get HIGH confidence
+	if resolution.Source == "explicit" {
+		return ConfidenceHigh
+	}
+
+	// For pulumi:created or mixed sources, check if imported
+	if resolution.IsImported {
+		return ConfidenceMedium
+	}
+
+	// Native resource with pulumi:created
+	return ConfidenceHigh
+}
 
 // calculateRuntimeHours computes the duration between two timestamps in hours.
 // Returns a float64 for precise fractional hour calculations.

--- a/internal/plugin/actual_test.go
+++ b/internal/plugin/actual_test.go
@@ -188,6 +188,102 @@ func makeResourceJSON(provider, resourceType, sku, region string, tags map[strin
 	return string(b)
 }
 
+// TestMergeTagsFromRequest tests the mergeTagsFromRequest helper function.
+// This function merges tags from req.Tags and ResourceId JSON, with req.Tags taking precedence.
+func TestMergeTagsFromRequest(t *testing.T) {
+	tests := []struct {
+		name         string
+		req          *pbc.GetActualCostRequest
+		wantTags     map[string]string
+		wantContains []string // Keys that must be present
+	}{
+		{
+			name: "tags only from ResourceId JSON",
+			req: &pbc.GetActualCostRequest{
+				ResourceId: makeResourceJSON("aws", "ec2", "t3.micro", "us-east-1", map[string]string{
+					TagPulumiCreated: "2025-01-01T00:00:00Z",
+				}),
+			},
+			wantContains: []string{TagPulumiCreated},
+		},
+		{
+			name: "tags only from req.Tags",
+			req: &pbc.GetActualCostRequest{
+				Tags: map[string]string{
+					TagPulumiCreated: "2025-01-01T00:00:00Z",
+				},
+			},
+			wantContains: []string{TagPulumiCreated},
+		},
+		{
+			name: "req.Tags overrides ResourceId JSON",
+			req: &pbc.GetActualCostRequest{
+				ResourceId: makeResourceJSON("aws", "ec2", "t3.micro", "us-east-1", map[string]string{
+					TagPulumiCreated: "2025-01-01T00:00:00Z", // Will be overridden
+				}),
+				Tags: map[string]string{
+					TagPulumiCreated: "2025-06-15T00:00:00Z", // Takes precedence
+				},
+			},
+			wantTags: map[string]string{
+				TagPulumiCreated: "2025-06-15T00:00:00Z",
+			},
+		},
+		{
+			name: "merge tags from both sources",
+			req: &pbc.GetActualCostRequest{
+				ResourceId: makeResourceJSON("aws", "ec2", "t3.micro", "us-east-1", map[string]string{
+					TagPulumiCreated:  "2025-01-01T00:00:00Z",
+					TagPulumiExternal: "true",
+				}),
+				Tags: map[string]string{
+					"custom_tag": "custom_value",
+				},
+			},
+			wantContains: []string{TagPulumiCreated, TagPulumiExternal, "custom_tag"},
+		},
+		{
+			name: "empty request",
+			req:  &pbc.GetActualCostRequest{},
+			wantTags: map[string]string{},
+		},
+		{
+			name: "invalid JSON in ResourceId uses only req.Tags",
+			req: &pbc.GetActualCostRequest{
+				ResourceId: "not-valid-json",
+				Tags: map[string]string{
+					TagPulumiCreated: "2025-01-01T00:00:00Z",
+				},
+			},
+			wantTags: map[string]string{
+				TagPulumiCreated: "2025-01-01T00:00:00Z",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeTagsFromRequest(tt.req)
+
+			// Check expected tags if specified
+			if tt.wantTags != nil {
+				for k, v := range tt.wantTags {
+					if got[k] != v {
+						t.Errorf("mergeTagsFromRequest()[%s] = %q, want %q", k, got[k], v)
+					}
+				}
+			}
+
+			// Check that required keys are present
+			for _, key := range tt.wantContains {
+				if _, exists := got[key]; !exists {
+					t.Errorf("mergeTagsFromRequest() missing key %q", key)
+				}
+			}
+		})
+	}
+}
+
 // TestCalculateRuntimeHours tests the runtime hours calculation helper.
 func TestCalculateRuntimeHours(t *testing.T) {
 	tests := []struct {
@@ -532,29 +628,35 @@ func TestGetActualCostInvalidRange(t *testing.T) {
 }
 
 // TestGetActualCostNilTimestamps tests error handling for nil timestamps.
+// Feature 016 changed behavior: nil End now defaults to "now", but nil Start
+// without pulumi:created tag still errors.
 func TestGetActualCostNilTimestamps(t *testing.T) {
 	plugin := newTestPluginForActual()
 	ctx := context.Background()
 
 	tests := []struct {
-		name  string
-		start *timestamppb.Timestamp
-		end   *timestamppb.Timestamp
+		name      string
+		start     *timestamppb.Timestamp
+		end       *timestamppb.Timestamp
+		wantError bool // Feature 016: nil end is OK (defaults to now)
 	}{
 		{
-			name:  "nil start",
-			start: nil,
-			end:   timestamppb.New(time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)),
+			name:      "nil start without pulumi:created",
+			start:     nil,
+			end:       timestamppb.New(time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)),
+			wantError: true, // No pulumi:created tag to fall back to
 		},
 		{
-			name:  "nil end",
-			start: timestamppb.New(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)),
-			end:   nil,
+			name:      "nil end",
+			start:     timestamppb.New(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)),
+			end:       nil,
+			wantError: false, // Feature 016: defaults to now
 		},
 		{
-			name:  "both nil",
-			start: nil,
-			end:   nil,
+			name:      "both nil without pulumi:created",
+			start:     nil,
+			end:       nil,
+			wantError: true, // No pulumi:created tag to fall back to
 		},
 	}
 
@@ -567,8 +669,14 @@ func TestGetActualCostNilTimestamps(t *testing.T) {
 			}
 
 			_, err := plugin.GetActualCost(ctx, req)
-			if err == nil {
-				t.Errorf("GetActualCost() expected error for nil timestamp, got nil")
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("GetActualCost() expected error for nil timestamp, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("GetActualCost() unexpected error: %v", err)
+				}
 			}
 		})
 	}
@@ -758,5 +866,641 @@ func TestGetActualCostWithInvalidResourceJSON(t *testing.T) {
 		if !strings.Contains(err.Error(), "missing resource information") {
 			t.Errorf("Expected 'missing resource information' error, got: %v", err)
 		}
+	}
+}
+
+// TestExtractPulumiCreated tests the extractPulumiCreated helper function.
+// This tests RFC3339 timestamp parsing from Pulumi state metadata tags.
+func TestExtractPulumiCreated(t *testing.T) {
+	tests := []struct {
+		name      string
+		tags      map[string]string
+		wantTime  time.Time
+		wantFound bool
+	}{
+		{
+			name:      "nil tags",
+			tags:      nil,
+			wantTime:  time.Time{},
+			wantFound: false,
+		},
+		{
+			name:      "empty tags",
+			tags:      map[string]string{},
+			wantTime:  time.Time{},
+			wantFound: false,
+		},
+		{
+			name:      "missing pulumi:created key",
+			tags:      map[string]string{"other": "value"},
+			wantTime:  time.Time{},
+			wantFound: false,
+		},
+		{
+			name:      "empty pulumi:created value",
+			tags:      map[string]string{TagPulumiCreated: ""},
+			wantTime:  time.Time{},
+			wantFound: false,
+		},
+		{
+			name:      "valid RFC3339 timestamp",
+			tags:      map[string]string{TagPulumiCreated: "2025-01-15T10:30:00Z"},
+			wantTime:  time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC),
+			wantFound: true,
+		},
+		{
+			name:      "valid RFC3339 with timezone offset",
+			tags:      map[string]string{TagPulumiCreated: "2025-01-15T10:30:00+05:00"},
+			wantTime:  time.Date(2025, 1, 15, 10, 30, 0, 0, time.FixedZone("+05:00", 5*3600)),
+			wantFound: true,
+		},
+		{
+			name:      "invalid RFC3339 format",
+			tags:      map[string]string{TagPulumiCreated: "2025-01-15 10:30:00"},
+			wantTime:  time.Time{},
+			wantFound: false,
+		},
+		{
+			name:      "invalid RFC3339 garbage",
+			tags:      map[string]string{TagPulumiCreated: "not-a-timestamp"},
+			wantTime:  time.Time{},
+			wantFound: false,
+		},
+		{
+			name:      "Unix timestamp (invalid)",
+			tags:      map[string]string{TagPulumiCreated: "1705314600"},
+			wantTime:  time.Time{},
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotTime, gotFound := extractPulumiCreated(tt.tags)
+			if gotFound != tt.wantFound {
+				t.Errorf("extractPulumiCreated() found = %v, want %v", gotFound, tt.wantFound)
+			}
+			if tt.wantFound && !gotTime.Equal(tt.wantTime) {
+				t.Errorf("extractPulumiCreated() time = %v, want %v", gotTime, tt.wantTime)
+			}
+		})
+	}
+}
+
+// TestIsImportedResource tests the isImportedResource helper function.
+// This validates case-sensitive comparison for pulumi:external=true.
+func TestIsImportedResource(t *testing.T) {
+	tests := []struct {
+		name       string
+		tags       map[string]string
+		wantResult bool
+	}{
+		{
+			name:       "nil tags",
+			tags:       nil,
+			wantResult: false,
+		},
+		{
+			name:       "empty tags",
+			tags:       map[string]string{},
+			wantResult: false,
+		},
+		{
+			name:       "missing pulumi:external key",
+			tags:       map[string]string{"other": "value"},
+			wantResult: false,
+		},
+		{
+			name:       "pulumi:external=true (exact match)",
+			tags:       map[string]string{TagPulumiExternal: "true"},
+			wantResult: true,
+		},
+		{
+			name:       "pulumi:external=True (case-sensitive, should fail)",
+			tags:       map[string]string{TagPulumiExternal: "True"},
+			wantResult: false,
+		},
+		{
+			name:       "pulumi:external=TRUE (case-sensitive, should fail)",
+			tags:       map[string]string{TagPulumiExternal: "TRUE"},
+			wantResult: false,
+		},
+		{
+			name:       "pulumi:external=false",
+			tags:       map[string]string{TagPulumiExternal: "false"},
+			wantResult: false,
+		},
+		{
+			name:       "pulumi:external=yes (not a boolean)",
+			tags:       map[string]string{TagPulumiExternal: "yes"},
+			wantResult: false,
+		},
+		{
+			name:       "pulumi:external=1 (not a boolean)",
+			tags:       map[string]string{TagPulumiExternal: "1"},
+			wantResult: false,
+		},
+		{
+			name:       "pulumi:external=empty",
+			tags:       map[string]string{TagPulumiExternal: ""},
+			wantResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isImportedResource(tt.tags)
+			if got != tt.wantResult {
+				t.Errorf("isImportedResource() = %v, want %v", got, tt.wantResult)
+			}
+		})
+	}
+}
+
+// TestResolveTimestamps tests the resolveTimestamps() function priority logic.
+// This validates Feature 016 timestamp resolution: explicit > pulumi:created > error
+func TestResolveTimestamps(t *testing.T) {
+	// Helper time values
+	explicitStart := time.Date(2025, 1, 10, 0, 0, 0, 0, time.UTC)
+	explicitEnd := time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC)
+	pulumiCreated := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	pulumiCreatedStr := pulumiCreated.Format(time.RFC3339)
+
+	tests := []struct {
+		name       string
+		req        *pbc.GetActualCostRequest
+		wantStart  time.Time
+		wantSource string
+		wantError  bool
+		errMsg     string
+	}{
+		{
+			name: "explicit start and end - highest priority",
+			req: &pbc.GetActualCostRequest{
+				Start: timestamppb.New(explicitStart),
+				End:   timestamppb.New(explicitEnd),
+				Tags:  map[string]string{TagPulumiCreated: pulumiCreatedStr},
+			},
+			wantStart:  explicitStart,
+			wantSource: "explicit",
+			wantError:  false,
+		},
+		{
+			name: "pulumi:created as fallback",
+			req: &pbc.GetActualCostRequest{
+				Start: nil,
+				End:   timestamppb.New(explicitEnd),
+				Tags:  map[string]string{TagPulumiCreated: pulumiCreatedStr},
+			},
+			wantStart:  pulumiCreated,
+			wantSource: "mixed", // pulumi:created for start, explicit for end
+			wantError:  false,
+		},
+		{
+			name: "pulumi:created for start, now for end",
+			req: &pbc.GetActualCostRequest{
+				Start: nil,
+				End:   nil,
+				Tags:  map[string]string{TagPulumiCreated: pulumiCreatedStr},
+			},
+			wantStart:  pulumiCreated,
+			wantSource: "pulumi:created",
+			wantError:  false,
+		},
+		{
+			name: "no timestamps and no pulumi:created - error",
+			req: &pbc.GetActualCostRequest{
+				Start: nil,
+				End:   nil,
+				Tags:  map[string]string{},
+			},
+			wantError: true,
+			errMsg:    "start time required",
+		},
+		{
+			name: "nil request - error",
+			req:  nil,
+			wantError: true,
+			errMsg:    "request is nil",
+		},
+		{
+			name: "invalid pulumi:created format - error",
+			req: &pbc.GetActualCostRequest{
+				Start: nil,
+				End:   timestamppb.New(explicitEnd),
+				Tags:  map[string]string{TagPulumiCreated: "invalid-timestamp"},
+			},
+			wantError: true,
+			errMsg:    "start time required",
+		},
+		{
+			name: "imported resource tracks flag",
+			req: &pbc.GetActualCostRequest{
+				Start: timestamppb.New(explicitStart),
+				End:   timestamppb.New(explicitEnd),
+				Tags:  map[string]string{TagPulumiExternal: "true"},
+			},
+			wantStart:  explicitStart,
+			wantSource: "explicit",
+			wantError:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolution, err := resolveTimestamps(tt.req)
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("resolveTimestamps() expected error containing %q, got nil", tt.errMsg)
+				} else if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("resolveTimestamps() error = %v, want containing %q", err, tt.errMsg)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveTimestamps() unexpected error: %v", err)
+			}
+			if resolution == nil {
+				t.Fatal("resolveTimestamps() returned nil resolution")
+			}
+			if !resolution.Start.Equal(tt.wantStart) {
+				t.Errorf("resolveTimestamps() Start = %v, want %v", resolution.Start, tt.wantStart)
+			}
+			if resolution.Source != tt.wantSource {
+				t.Errorf("resolveTimestamps() Source = %q, want %q", resolution.Source, tt.wantSource)
+			}
+			// Check imported flag for the relevant test case
+			if tt.name == "imported resource tracks flag" && !resolution.IsImported {
+				t.Error("resolveTimestamps() IsImported = false, want true")
+			}
+		})
+	}
+}
+
+// TestDetermineConfidence tests the determineConfidence() function.
+// This validates Feature 016 confidence level determination.
+func TestDetermineConfidence(t *testing.T) {
+	tests := []struct {
+		name       string
+		resolution *TimestampResolution
+		want       ConfidenceLevel
+	}{
+		{
+			name:       "nil resolution - LOW",
+			resolution: nil,
+			want:       ConfidenceLow,
+		},
+		{
+			name: "explicit timestamps - HIGH",
+			resolution: &TimestampResolution{
+				Source:     "explicit",
+				IsImported: false,
+			},
+			want: ConfidenceHigh,
+		},
+		{
+			name: "explicit timestamps with imported - HIGH (explicit wins)",
+			resolution: &TimestampResolution{
+				Source:     "explicit",
+				IsImported: true,
+			},
+			want: ConfidenceHigh,
+		},
+		{
+			name: "pulumi:created native resource - HIGH",
+			resolution: &TimestampResolution{
+				Source:     "pulumi:created",
+				IsImported: false,
+			},
+			want: ConfidenceHigh,
+		},
+		{
+			name: "pulumi:created imported resource - MEDIUM",
+			resolution: &TimestampResolution{
+				Source:     "pulumi:created",
+				IsImported: true,
+			},
+			want: ConfidenceMedium,
+		},
+		{
+			name: "mixed source native resource - HIGH",
+			resolution: &TimestampResolution{
+				Source:     "mixed",
+				IsImported: false,
+			},
+			want: ConfidenceHigh,
+		},
+		{
+			name: "mixed source imported resource - MEDIUM",
+			resolution: &TimestampResolution{
+				Source:     "mixed",
+				IsImported: true,
+			},
+			want: ConfidenceMedium,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := determineConfidence(tt.resolution)
+			if got != tt.want {
+				t.Errorf("determineConfidence() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRuntimeHoursZeroDuration tests the edge case where zero duration returns zero cost.
+// This validates T012 requirement from tasks.md.
+func TestRuntimeHoursZeroDuration(t *testing.T) {
+	// Zero duration should return zero hours, not an error
+	sameTime := time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
+	hours, err := calculateRuntimeHours(sameTime, sameTime)
+	if err != nil {
+		t.Errorf("calculateRuntimeHours(same, same) unexpected error: %v", err)
+	}
+	if hours != 0 {
+		t.Errorf("calculateRuntimeHours(same, same) = %v, want 0", hours)
+	}
+}
+
+// TestResolveTimestampsPartialExplicit tests T028 - partial explicit scenarios.
+// This validates mixed source handling: explicit start with pulumi:created end, etc.
+func TestResolveTimestampsPartialExplicit(t *testing.T) {
+	explicitStart := time.Date(2025, 1, 10, 0, 0, 0, 0, time.UTC)
+	explicitEnd := time.Date(2025, 1, 20, 0, 0, 0, 0, time.UTC)
+	pulumiCreated := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	pulumiCreatedStr := pulumiCreated.Format(time.RFC3339)
+
+	tests := []struct {
+		name       string
+		start      *timestamppb.Timestamp
+		end        *timestamppb.Timestamp
+		tags       map[string]string
+		wantStart  time.Time
+		wantEnd    time.Time // Use zero value for "now" check
+		wantSource string
+	}{
+		{
+			name:       "explicit start only (end defaults to now)",
+			start:      timestamppb.New(explicitStart),
+			end:        nil,
+			tags:       map[string]string{TagPulumiCreated: pulumiCreatedStr},
+			wantStart:  explicitStart,
+			wantSource: "mixed", // explicit start, default end
+		},
+		{
+			name:       "explicit end only with pulumi:created",
+			start:      nil,
+			end:        timestamppb.New(explicitEnd),
+			tags:       map[string]string{TagPulumiCreated: pulumiCreatedStr},
+			wantStart:  pulumiCreated,
+			wantEnd:    explicitEnd,
+			wantSource: "mixed", // pulumi:created start, explicit end
+		},
+		{
+			name:       "neither explicit with pulumi:created (end defaults to now)",
+			start:      nil,
+			end:        nil,
+			tags:       map[string]string{TagPulumiCreated: pulumiCreatedStr},
+			wantStart:  pulumiCreated,
+			wantSource: "pulumi:created",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &pbc.GetActualCostRequest{
+				Start: tt.start,
+				End:   tt.end,
+				Tags:  tt.tags,
+			}
+			resolution, err := resolveTimestamps(req)
+			if err != nil {
+				t.Fatalf("resolveTimestamps() unexpected error: %v", err)
+			}
+			if !resolution.Start.Equal(tt.wantStart) {
+				t.Errorf("Start = %v, want %v", resolution.Start, tt.wantStart)
+			}
+			if resolution.Source != tt.wantSource {
+				t.Errorf("Source = %q, want %q", resolution.Source, tt.wantSource)
+			}
+			// For explicit end, check exact match
+			if !tt.wantEnd.IsZero() && !resolution.End.Equal(tt.wantEnd) {
+				t.Errorf("End = %v, want %v", resolution.End, tt.wantEnd)
+			}
+			// For default end (now), just check it's after start
+			if tt.wantEnd.IsZero() && !resolution.End.After(resolution.Start) {
+				t.Errorf("End %v should be after Start %v", resolution.End, resolution.Start)
+			}
+		})
+	}
+}
+
+// TestPulumiModifiedNotUsed validates T034 - pulumi:modified is NOT used as fallback.
+// The feature explicitly only uses pulumi:created, not pulumi:modified.
+func TestPulumiModifiedNotUsed(t *testing.T) {
+	pulumiModified := time.Date(2025, 1, 15, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+
+	req := &pbc.GetActualCostRequest{
+		Start: nil,
+		End:   timestamppb.New(time.Date(2025, 1, 20, 0, 0, 0, 0, time.UTC)),
+		Tags: map[string]string{
+			TagPulumiModified: pulumiModified,
+			// Note: NO pulumi:created tag
+		},
+	}
+
+	_, err := resolveTimestamps(req)
+	if err == nil {
+		t.Error("resolveTimestamps() should error when only pulumi:modified is provided (not pulumi:created)")
+	}
+	if !strings.Contains(err.Error(), "start time required") {
+		t.Errorf("Error should mention start time, got: %v", err)
+	}
+}
+
+// TestGetActualCost_WithPulumiCreated tests Feature 016 end-to-end.
+// This validates that GetActualCost correctly uses pulumi:created timestamp
+// when explicit timestamps are not provided.
+func TestGetActualCost_WithPulumiCreated(t *testing.T) {
+	plugin := newTestPluginForActual()
+	ctx := context.Background()
+
+	// Create resource with pulumi:created tag but no explicit timestamps
+	created := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2025, 1, 8, 0, 0, 0, 0, time.UTC) // 7 days later = 168 hours
+
+	req := &pbc.GetActualCostRequest{
+		ResourceId: makeResourceJSON("aws", "ec2", "t3.micro", "us-east-1", map[string]string{
+			TagPulumiCreated: created.Format(time.RFC3339),
+		}),
+		Start: nil, // Let it resolve from pulumi:created
+		End:   timestamppb.New(end),
+	}
+
+	resp, err := plugin.GetActualCost(ctx, req)
+	if err != nil {
+		t.Fatalf("GetActualCost() unexpected error: %v", err)
+	}
+	if resp == nil || len(resp.Results) == 0 {
+		t.Fatal("GetActualCost() returned empty response")
+	}
+
+	result := resp.Results[0]
+
+	// Should use pulumi:created for start, so runtime = 168 hours
+	// $0.0104/hr * 730 hrs = $7.592/month
+	// $7.592 * (168/730) = $1.7472
+	expectedCost := 1.7472
+	tolerance := expectedCost * 0.0001
+	if diff := result.Cost - expectedCost; diff > tolerance || diff < -tolerance {
+		t.Errorf("GetActualCost() cost = %v, want %v", result.Cost, expectedCost)
+	}
+
+	// Verify confidence is encoded in source (Feature 016)
+	if !strings.Contains(result.Source, "[confidence:") {
+		t.Errorf("Source should contain confidence encoding, got: %s", result.Source)
+	}
+}
+
+// TestGetActualCost_ImportedResourceConfidence tests Feature 016 US2.
+// This validates that imported resources show MEDIUM confidence.
+func TestGetActualCost_ImportedResourceConfidence(t *testing.T) {
+	plugin := newTestPluginForActual()
+	ctx := context.Background()
+
+	created := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2025, 1, 8, 0, 0, 0, 0, time.UTC)
+
+	req := &pbc.GetActualCostRequest{
+		ResourceId: makeResourceJSON("aws", "ec2", "t3.micro", "us-east-1", map[string]string{
+			TagPulumiCreated:  created.Format(time.RFC3339),
+			TagPulumiExternal: "true", // Imported resource
+		}),
+		Start: nil, // Let it resolve from pulumi:created
+		End:   timestamppb.New(end),
+	}
+
+	resp, err := plugin.GetActualCost(ctx, req)
+	if err != nil {
+		t.Fatalf("GetActualCost() unexpected error: %v", err)
+	}
+	if resp == nil || len(resp.Results) == 0 {
+		t.Fatal("GetActualCost() returned empty response")
+	}
+
+	result := resp.Results[0]
+
+	// Imported resource with pulumi:created should show MEDIUM confidence
+	if !strings.Contains(result.Source, "[confidence:MEDIUM]") {
+		t.Errorf("Imported resource should have MEDIUM confidence, got: %s", result.Source)
+	}
+
+	// Should also include "imported resource" note
+	if !strings.Contains(result.Source, "imported resource") {
+		t.Errorf("Source should mention 'imported resource', got: %s", result.Source)
+	}
+}
+
+// TestGetActualCost_ExplicitOverridesPulumiCreated tests Feature 016 US3.
+// This validates that explicit timestamps take precedence over pulumi:created.
+func TestGetActualCost_ExplicitOverridesPulumiCreated(t *testing.T) {
+	plugin := newTestPluginForActual()
+	ctx := context.Background()
+
+	// pulumi:created says resource is 30 days old
+	created := time.Date(2024, 12, 1, 0, 0, 0, 0, time.UTC)
+	// But explicit timestamps say only query 7 days
+	explicitStart := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	explicitEnd := time.Date(2025, 1, 8, 0, 0, 0, 0, time.UTC) // 7 days = 168 hours
+
+	req := &pbc.GetActualCostRequest{
+		ResourceId: makeResourceJSON("aws", "ec2", "t3.micro", "us-east-1", map[string]string{
+			TagPulumiCreated: created.Format(time.RFC3339),
+		}),
+		Start: timestamppb.New(explicitStart), // Explicit overrides pulumi:created
+		End:   timestamppb.New(explicitEnd),
+	}
+
+	resp, err := plugin.GetActualCost(ctx, req)
+	if err != nil {
+		t.Fatalf("GetActualCost() unexpected error: %v", err)
+	}
+	if resp == nil || len(resp.Results) == 0 {
+		t.Fatal("GetActualCost() returned empty response")
+	}
+
+	result := resp.Results[0]
+
+	// Should use explicit timestamps (168 hours), NOT pulumi:created (would be ~730 hours)
+	// $0.0104/hr * 730 hrs = $7.592/month
+	// $7.592 * (168/730) = $1.7472
+	expectedCost := 1.7472
+	tolerance := expectedCost * 0.0001
+	if diff := result.Cost - expectedCost; diff > tolerance || diff < -tolerance {
+		t.Errorf("GetActualCost() cost = %v, want %v (explicit should override pulumi:created)", result.Cost, expectedCost)
+	}
+
+	// Explicit timestamps get HIGH confidence
+	if !strings.Contains(result.Source, "[confidence:HIGH]") {
+		t.Errorf("Explicit timestamps should have HIGH confidence, got: %s", result.Source)
+	}
+}
+
+// TestFormatSourceWithConfidence tests the formatSourceWithConfidence helper function.
+// This validates the semantic encoding format in the source field.
+func TestFormatSourceWithConfidence(t *testing.T) {
+	tests := []struct {
+		name       string
+		confidence ConfidenceLevel
+		note       string
+		want       string
+	}{
+		{
+			name:       "HIGH confidence no note",
+			confidence: ConfidenceHigh,
+			note:       "",
+			want:       "aws-public-fallback[confidence:HIGH]",
+		},
+		{
+			name:       "MEDIUM confidence no note",
+			confidence: ConfidenceMedium,
+			note:       "",
+			want:       "aws-public-fallback[confidence:MEDIUM]",
+		},
+		{
+			name:       "LOW confidence no note",
+			confidence: ConfidenceLow,
+			note:       "",
+			want:       "aws-public-fallback[confidence:LOW]",
+		},
+		{
+			name:       "HIGH confidence with note",
+			confidence: ConfidenceHigh,
+			note:       "explicit timestamps",
+			want:       "aws-public-fallback[confidence:HIGH] explicit timestamps",
+		},
+		{
+			name:       "MEDIUM confidence with imported note",
+			confidence: ConfidenceMedium,
+			note:       "imported resource",
+			want:       "aws-public-fallback[confidence:MEDIUM] imported resource",
+		},
+		{
+			name:       "LOW confidence with explanation",
+			confidence: ConfidenceLow,
+			note:       "unsupported resource type",
+			want:       "aws-public-fallback[confidence:LOW] unsupported resource type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatSourceWithConfidence(tt.confidence, tt.note)
+			if got != tt.want {
+				t.Errorf("formatSourceWithConfidence() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/plugin/validation_test.go
+++ b/internal/plugin/validation_test.go
@@ -160,7 +160,7 @@ func TestValidateActualCostRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res, err := p.ValidateActualCostRequest(ctx, tt.req)
+			res, _, err := p.ValidateActualCostRequest(ctx, tt.req)
 			if tt.wantError {
 				require.Error(t, err)
 				st, ok := status.FromError(err)
@@ -338,7 +338,7 @@ func TestValidateActualCostRequest_ARN(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res, err := p.ValidateActualCostRequest(ctx, tt.req)
+			res, _, err := p.ValidateActualCostRequest(ctx, tt.req)
 			if tt.wantError {
 				require.Error(t, err)
 				st, ok := status.FromError(err)
@@ -407,7 +407,7 @@ func TestRegionFallbackGlobalServices(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res, err := p.ValidateActualCostRequest(ctx, tt.req)
+			res, _, err := p.ValidateActualCostRequest(ctx, tt.req)
 			if tt.wantError {
 				require.Error(t, err, "expected validation error")
 			} else {

--- a/specs/016-runtime-actual-cost/checklists/requirements.md
+++ b/specs/016-runtime-actual-cost/checklists/requirements.md
@@ -1,0 +1,43 @@
+# Specification Quality Checklist: Runtime-Based Actual Cost Estimation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-31
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Validation Results
+
+**Status**: PASSED
+
+All checklist items verified. The specification is ready for `/speckit.plan`.
+
+## Notes
+
+- Spec references GitHub Issue #196 which contains detailed technical context
+- Existing `GetActualCost` implementation provides foundation; this enhances
+  timestamp resolution
+- Assumes pulumicost-core already injects Pulumi state metadata (A-001)

--- a/specs/016-runtime-actual-cost/contracts/README.md
+++ b/specs/016-runtime-actual-cost/contracts/README.md
@@ -1,0 +1,109 @@
+# API Contracts: Runtime-Based Actual Cost Estimation
+
+**Feature Branch**: `016-runtime-actual-cost`
+**Date**: 2025-12-31
+
+## Overview
+
+This feature does NOT require proto schema modifications. All new functionality is
+implemented using existing proto message fields with semantic encoding.
+
+## Existing Contract (Unchanged)
+
+The `GetActualCost` RPC uses the existing `pulumicost.v1.CostSourceService` contract:
+
+```protobuf
+service CostSourceService {
+  rpc GetActualCost(GetActualCostRequest) returns (GetActualCostResponse);
+}
+
+message GetActualCostRequest {
+  string resource_id = 1;
+  google.protobuf.Timestamp start = 2;  // Now OPTIONAL (resolved from tags)
+  google.protobuf.Timestamp end = 3;    // Now OPTIONAL (defaults to now)
+  map<string, string> tags = 4;         // Pulumi metadata injected here
+  string arn = 5;
+}
+
+message GetActualCostResponse {
+  repeated ActualCostResult results = 1;
+  FallbackHint fallback_hint = 2;
+}
+
+message ActualCostResult {
+  google.protobuf.Timestamp timestamp = 1;
+  double cost = 2;
+  double usage_amount = 3;
+  string usage_unit = 4;
+  string source = 5;  // Confidence encoded here
+  FocusCostRecord focus_record = 6;
+  repeated ImpactMetric impact_metrics = 7;
+}
+```
+
+## Extended Semantics (This Feature)
+
+### Request Tags Extension
+
+The `tags` map accepts the following Pulumi metadata keys (injected by pulumicost-core):
+
+| Key | Required | Format | Description |
+|-----|----------|--------|-------------|
+| `pulumi:created` | No | RFC3339 | Resource creation timestamp |
+| `pulumi:modified` | No | RFC3339 | Last modification timestamp |
+| `pulumi:external` | No | "true" | Indicates imported resource |
+
+### Response Source Field Extension
+
+The `source` field in `ActualCostResult` uses semantic encoding to communicate
+confidence level:
+
+**Format**: `provider[confidence:LEVEL] optional_note`
+
+**Examples**:
+
+```text
+aws-public-fallback[confidence:HIGH]
+aws-public-fallback[confidence:MEDIUM] imported resource
+aws-public-fallback[confidence:LOW] unsupported resource type
+```
+
+**Confidence Levels**:
+
+| Level | Meaning |
+|-------|---------|
+| HIGH | Precise calculation with known timestamps |
+| MEDIUM | Reasonable estimate with caveats (e.g., imported resource) |
+| LOW | Rough estimate or significant assumptions |
+
+## No Proto Changes Required
+
+This design intentionally avoids proto modifications:
+
+1. **Backward Compatible**: Existing clients continue to work unchanged
+2. **No Coordination**: No pulumicost-spec PR or version bump needed
+3. **Self-Documenting**: Source field carries its own metadata
+4. **Easy Parsing**: Simple string pattern matching for consumers
+
+## Future Proto Enhancement (Optional)
+
+If the community desires explicit confidence fields, a future proto version could add:
+
+```protobuf
+message ActualCostResult {
+  // ... existing fields ...
+
+  // Proposed: Explicit confidence enum
+  ConfidenceLevel confidence = 8;
+}
+
+enum ConfidenceLevel {
+  CONFIDENCE_LEVEL_UNSPECIFIED = 0;
+  CONFIDENCE_LEVEL_HIGH = 1;
+  CONFIDENCE_LEVEL_MEDIUM = 2;
+  CONFIDENCE_LEVEL_LOW = 3;
+}
+```
+
+This would be a MINOR version increment to pulumicost-spec and is not required
+for this feature implementation.

--- a/specs/016-runtime-actual-cost/data-model.md
+++ b/specs/016-runtime-actual-cost/data-model.md
@@ -1,0 +1,292 @@
+# Data Model: Runtime-Based Actual Cost Estimation
+
+**Feature Branch**: `016-runtime-actual-cost`
+**Date**: 2025-12-31
+
+## Overview
+
+This document defines the data structures and their relationships for the runtime-based
+actual cost estimation feature. The design extends existing proto messages without
+modification, using semantic encoding for new metadata.
+
+---
+
+## Entity Definitions
+
+### 1. TimestampResolution
+
+**Purpose**: Captures the resolved start/end timestamps and their provenance.
+
+**Location**: `internal/plugin/actual.go` (new type)
+
+```go
+// TimestampResolution captures the resolved timestamps and their source.
+// This struct is used internally to track how timestamps were determined
+// and whether the resource was imported.
+type TimestampResolution struct {
+    // Start is the resolved start timestamp for cost calculation.
+    Start time.Time
+
+    // End is the resolved end timestamp for cost calculation.
+    End time.Time
+
+    // Source indicates how timestamps were resolved.
+    // Values: "explicit", "pulumi:created", "mixed"
+    Source string
+
+    // IsImported is true when the resource has pulumi:external=true.
+    // This affects confidence level (MEDIUM vs HIGH).
+    IsImported bool
+}
+```
+
+**Validation Rules**:
+- `Start` must be before or equal to `End`
+- If `End` equals `Start`, runtime is zero (valid case)
+- `Source` must be one of the defined values
+
+**State Transitions**: N/A (immutable value object)
+
+---
+
+### 2. ConfidenceLevel
+
+**Purpose**: Represents the estimation confidence for actual cost calculations.
+
+**Location**: `internal/plugin/actual.go` (new type)
+
+```go
+// ConfidenceLevel represents the estimation confidence for actual cost calculations.
+// The level affects how the cost data should be interpreted by consumers.
+type ConfidenceLevel string
+
+const (
+    // ConfidenceHigh indicates precise calculation with known timestamps.
+    // Used when: explicit request timestamps OR native resource with pulumi:created.
+    ConfidenceHigh ConfidenceLevel = "HIGH"
+
+    // ConfidenceMedium indicates reasonable estimate with caveats.
+    // Used when: imported resource (pulumi:external=true) - timestamp is import time.
+    ConfidenceMedium ConfidenceLevel = "MEDIUM"
+
+    // ConfidenceLow indicates rough estimate or fallback.
+    // Used when: unsupported resource, missing data, or significant assumptions.
+    ConfidenceLow ConfidenceLevel = "LOW"
+)
+```
+
+**Confidence Determination Logic**:
+
+| Scenario | IsImported | Confidence |
+|----------|------------|------------|
+| Explicit timestamps provided | false | HIGH |
+| Explicit timestamps provided | true | HIGH |
+| Using pulumi:created | false | HIGH |
+| Using pulumi:created | true | MEDIUM |
+| Unsupported resource type | - | LOW |
+| Zero cost (no runtime) | - | HIGH |
+
+---
+
+### 3. Pulumi Metadata Tags
+
+**Purpose**: Standard tag keys for Pulumi state metadata injected by pulumicost-core.
+
+**Location**: `internal/plugin/actual.go` (constants)
+
+```go
+// Pulumi metadata tag keys.
+// These keys are injected by pulumicost-core from Pulumi state.
+const (
+    // TagPulumiCreated is the RFC3339 timestamp of resource creation in Pulumi state.
+    // For imported resources, this is the import time, not actual cloud creation.
+    TagPulumiCreated = "pulumi:created"
+
+    // TagPulumiModified is the RFC3339 timestamp of last modification.
+    // NOTE: This feature does NOT use modified time as a fallback for created.
+    TagPulumiModified = "pulumi:modified"
+
+    // TagPulumiExternal indicates the resource was imported (not created by Pulumi).
+    // Value is "true" when present; absence means native Pulumi resource.
+    TagPulumiExternal = "pulumi:external"
+)
+```
+
+**Input Validation**:
+- Timestamps must be valid RFC3339 format
+- Invalid timestamps are treated as missing (fallback to explicit times)
+- `pulumi:external` value comparison is case-sensitive ("true" only)
+
+---
+
+## Proto Message Extensions
+
+### ActualCostResult.source Field Encoding
+
+**Existing Proto Field** (no modification needed):
+
+```protobuf
+message ActualCostResult {
+    // ... other fields ...
+    string source = 5;  // Identifies the data source
+}
+```
+
+**Semantic Encoding Format**:
+
+```text
+source = base_source "[confidence:" level "]" [ " " note ]
+
+base_source = "aws-public-fallback"
+level       = "HIGH" | "MEDIUM" | "LOW"
+note        = arbitrary_string
+
+Examples:
+  "aws-public-fallback[confidence:HIGH]"
+  "aws-public-fallback[confidence:MEDIUM] imported resource"
+  "aws-public-fallback[confidence:LOW] unsupported resource type"
+```
+
+**Parser Pattern** (for consumers):
+
+```go
+// ParseSourceConfidence extracts the confidence level from an ActualCostResult.source string.
+// Returns ("HIGH"|"MEDIUM"|"LOW", true) if found, or ("", false) if not encoded.
+func ParseSourceConfidence(source string) (string, bool) {
+    const prefix = "[confidence:"
+    start := strings.Index(source, prefix)
+    if start < 0 {
+        return "", false
+    }
+    start += len(prefix)
+    end := strings.Index(source[start:], "]")
+    if end < 0 {
+        return "", false
+    }
+    return source[start : start+end], true
+}
+```
+
+---
+
+## Relationships
+
+```text
+┌─────────────────────────┐
+│  GetActualCostRequest   │
+├─────────────────────────┤
+│ start: Timestamp (opt)  │──┐
+│ end: Timestamp (opt)    │  │
+│ tags: map[string]string │──┼──► resolveTimestamps()
+└─────────────────────────┘  │
+                             │
+  Tags contain:              │
+  - pulumi:created ─────────►│
+  - pulumi:external ────────►│
+                             │
+                             ▼
+                  ┌─────────────────────────┐
+                  │   TimestampResolution   │
+                  ├─────────────────────────┤
+                  │ Start: time.Time        │
+                  │ End: time.Time          │
+                  │ Source: string          │──► determineConfidence()
+                  │ IsImported: bool        │         │
+                  └─────────────────────────┘         │
+                             │                        │
+                             │                        ▼
+                             │              ┌─────────────────┐
+                             │              │ ConfidenceLevel │
+                             │              └─────────────────┘
+                             │                        │
+                             ▼                        │
+                  ┌─────────────────────────┐         │
+                  │   GetActualCostResponse │         │
+                  ├─────────────────────────┤         │
+                  │ results: []ActualCost   │◄────────┘
+                  │   └─ source: string     │  (confidence encoded)
+                  └─────────────────────────┘
+```
+
+---
+
+## Function Signatures
+
+### New Functions (internal/plugin/actual.go)
+
+```go
+// resolveTimestamps applies priority-based timestamp resolution.
+// Priority: (1) explicit req.Start/End, (2) pulumi:created, (3) error
+//
+// Returns TimestampResolution with source tracking for confidence determination.
+// Returns error if no valid timestamps can be resolved.
+func resolveTimestamps(req *pbc.GetActualCostRequest) (*TimestampResolution, error)
+
+// extractPulumiCreated parses the pulumi:created timestamp from tags.
+// Returns (timestamp, true) if valid RFC3339, or (zero, false) if missing/invalid.
+func extractPulumiCreated(tags map[string]string) (time.Time, bool)
+
+// isImportedResource checks if the resource has pulumi:external=true.
+func isImportedResource(tags map[string]string) bool
+
+// determineConfidence maps resolution source and import status to confidence level.
+func determineConfidence(resolution *TimestampResolution) ConfidenceLevel
+
+// formatSourceWithConfidence creates the source string with embedded confidence.
+func formatSourceWithConfidence(confidence ConfidenceLevel, note string) string
+```
+
+### Modified Functions (internal/plugin/plugin.go)
+
+```go
+// GetActualCost - MODIFIED
+// Changes:
+// 1. Call resolveTimestamps() before validation
+// 2. Update req.Start/End with resolved values if needed
+// 3. Determine confidence from resolution
+// 4. Include confidence in response source field
+func (p *AWSPublicPlugin) GetActualCost(ctx context.Context, req *pbc.GetActualCostRequest) (*pbc.GetActualCostResponse, error)
+```
+
+---
+
+## Test Scenarios Mapping
+
+| Spec Scenario | Data Model Element | Validation |
+|---------------|-------------------|------------|
+| US1-1: pulumi:created 7 days ago | extractPulumiCreated | Parse RFC3339 |
+| US1-2: Explicit start after creation | resolveTimestamps | Priority check |
+| US1-3: Missing pulumi:created | resolveTimestamps | Error path |
+| US2-1: pulumi:external=true | isImportedResource | MEDIUM confidence |
+| US2-2: No pulumi:external | isImportedResource | HIGH confidence |
+| US3-1: Override with explicit times | resolveTimestamps | Explicit wins |
+| Edge: Invalid RFC3339 | extractPulumiCreated | Returns false |
+| Edge: End before start | resolveTimestamps | Zero cost path |
+
+---
+
+## Constants and Limits
+
+```go
+const (
+    // hoursPerMonth is the standard hours-per-month constant for cost calculations.
+    // Existing constant, documented here for reference.
+    hoursPerMonth = 730.0
+
+    // RFC3339 is the expected timestamp format.
+    // Go's time.RFC3339 = "2006-01-02T15:04:05Z07:00"
+)
+```
+
+---
+
+## Migration Notes
+
+**Backward Compatibility**:
+
+1. **Existing callers**: Continue to work unchanged (explicit timestamps required)
+2. **New callers**: Can omit timestamps if `pulumi:created` is in tags
+3. **Response parsing**: Existing consumers see `source` as before; new consumers
+   can parse confidence suffix
+
+**No database migrations**: Feature is stateless, no persistent storage changes.

--- a/specs/016-runtime-actual-cost/plan.md
+++ b/specs/016-runtime-actual-cost/plan.md
@@ -1,0 +1,194 @@
+# Implementation Plan: Runtime-Based Actual Cost Estimation
+
+**Branch**: `016-runtime-actual-cost` | **Date**: 2025-12-31 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/016-runtime-actual-cost/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+
+## Summary
+
+Enhance `GetActualCost` to automatically detect resource runtime from Pulumi state metadata (`pulumi:created`, `pulumi:external`) when explicit timestamps are not provided. The fallback formula (`projected_monthly_cost × runtime_hours / 730`) remains unchanged; this feature adds smart timestamp resolution and confidence indicators.
+
+## Technical Context
+
+**Language/Version**: Go 1.25+
+**Primary Dependencies**: gRPC, pulumicost-spec (proto), zerolog, google.golang.org/protobuf (timestamppb)
+**Storage**: N/A (embedded pricing data, stateless service)
+**Testing**: Go testing with table-driven tests, integration tests with `-tags=integration`
+**Target Platform**: Linux server (gRPC service on 127.0.0.1)
+**Project Type**: Single project (gRPC plugin)
+**Performance Goals**: GetActualCost RPC < 100ms per call (existing target)
+**Constraints**: Thread-safe handlers, no external network calls at runtime
+**Scale/Scope**: Extends existing `GetActualCost` handler in `internal/plugin/`
+
+### Technical Clarifications (RESOLVED)
+
+All clarifications have been resolved in [research.md](./research.md).
+
+| Clarification | Decision | Reference |
+|---------------|----------|-----------|
+| Confidence encoding | Semantic encoding in `source` field | research.md R1 |
+| Pulumi metadata keys | Read from `req.Tags` map | research.md R2 |
+| Timestamp priority | Explicit > pulumi:created > error | research.md R3 |
+
+## Constitution Check
+
+*GATE: All checks pass post-Phase 1 design.*
+
+### I. Code Quality & Simplicity ✅
+
+| Principle | Status | Justification |
+|-----------|--------|---------------|
+| KISS | ✅ | Single-purpose timestamp resolution logic |
+| Single Responsibility | ✅ | New functions: `resolveTimestamps()`, `determineConfidence()` |
+| Explicit behavior | ✅ | Priority order documented in code comments |
+| Stateless | ✅ | No state changes; each RPC independent |
+
+### II. Testing Discipline ✅
+
+| Requirement | Status | Justification |
+|-------------|--------|---------------|
+| Unit tests for transformations | ✅ | Table-driven tests for timestamp parsing |
+| Integration tests for gRPC | ✅ | Test with `pulumi:created` in tags |
+| No external mocking | ✅ | Uses existing mock pricing client |
+| < 1s unit suite | ✅ | Pure functions, no I/O |
+
+### III. Protocol & Interface Consistency ✅
+
+| Requirement | Status | Justification |
+|-------------|--------|---------------|
+| Proto-defined types | ✅ | Uses existing `source` field semantically (no proto change) |
+| Error codes from enum | ✅ | Existing error handling pattern |
+| Thread safety | ✅ | Stateless timestamp parsing |
+| Logging (zerolog) | ✅ | Existing pattern with trace_id |
+
+### IV. Performance & Reliability ✅
+
+| Requirement | Status | Justification |
+|-------------|--------|---------------|
+| GetActualCost < 100ms | ✅ | Adds ~1ms for timestamp parsing |
+| Memory < 400MB | ✅ | No additional memory allocation |
+| Concurrent calls | ✅ | Stateless functions |
+
+### V. Build & Release Quality ✅
+
+| Requirement | Status | Justification |
+|-------------|--------|---------------|
+| `make lint` pass | ✅ | Standard Go code |
+| `make test` pass | ✅ | New tests added |
+| Markdown lint | ✅ | Documentation follows conventions |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/016-runtime-actual-cost/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output - COMPLETE
+├── data-model.md        # Phase 1 output - COMPLETE
+├── quickstart.md        # Phase 1 output - COMPLETE
+├── contracts/           # Phase 1 output - COMPLETE (no proto changes needed)
+│   └── README.md
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+internal/
+├── plugin/
+│   ├── actual.go            # MODIFY: Add resolveTimestamps(), determineConfidence(), etc.
+│   ├── actual_test.go       # MODIFY: Add table-driven tests
+│   ├── plugin.go            # MODIFY: Update GetActualCost handler
+│   └── validation.go        # MINOR: May adjust timestamp validation flow
+└── ...
+
+test/
+└── fixtures/
+    └── actual-cost/         # NEW: Test fixtures with Pulumi metadata
+        ├── with-created.json
+        ├── with-external.json
+        └── explicit-override.json
+```
+
+**Structure Decision**: Single project structure. Changes isolated to `internal/plugin/` package. No new packages required.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| None identified | N/A | N/A |
+
+---
+
+## Phase 0: Research (COMPLETE)
+
+All research items resolved. See [research.md](./research.md) for details.
+
+### R1: Confidence Field Representation ✅
+
+**Decision**: Semantic encoding in `source` field.
+**Format**: `aws-public-fallback[confidence:HIGH|MEDIUM|LOW]`
+
+### R2: Pulumi Metadata Injection ✅
+
+**Decision**: Read from `req.Tags` map with keys:
+- `pulumi:created` (RFC3339)
+- `pulumi:external` ("true")
+- `pulumi:modified` (RFC3339, not used for fallback)
+
+### R3: Timestamp Priority Semantics ✅
+
+**Decision**: Two-phase resolution:
+1. Pre-validation: Resolve timestamps from explicit or tags
+2. Post-resolution: Standard validation with guaranteed non-nil timestamps
+
+Priority: Explicit request > pulumi:created > error
+
+---
+
+## Phase 1: Design & Contracts (COMPLETE)
+
+### Artifacts Generated
+
+| Artifact | Status | Description |
+|----------|--------|-------------|
+| [data-model.md](./data-model.md) | ✅ | Entity definitions, relationships, function signatures |
+| [contracts/README.md](./contracts/README.md) | ✅ | API contract (no proto changes needed) |
+| [quickstart.md](./quickstart.md) | ✅ | Testing guide with grpcurl examples |
+| CLAUDE.md | ✅ | Agent context updated |
+
+### Key Design Decisions
+
+1. **No Proto Changes**: Confidence encoded in `source` field semantically
+2. **TimestampResolution Struct**: New value object to track resolution provenance
+3. **ConfidenceLevel Type**: String enum (HIGH/MEDIUM/LOW) for clarity
+4. **Backward Compatible**: Existing callers unaffected
+
+---
+
+## Next Steps
+
+Run `/speckit.tasks` to generate `tasks.md` with implementation tasks.
+
+The implementation will consist of:
+
+1. **New functions in actual.go**:
+   - `resolveTimestamps()` - Priority-based timestamp resolution
+   - `extractPulumiCreated()` - Parse RFC3339 from tags
+   - `isImportedResource()` - Check pulumi:external
+   - `determineConfidence()` - Map resolution to confidence
+   - `formatSourceWithConfidence()` - Encode confidence in source
+
+2. **Modified GetActualCost in plugin.go**:
+   - Call `resolveTimestamps()` before validation
+   - Use resolved timestamps for calculation
+   - Include confidence in response
+
+3. **Tests in actual_test.go**:
+   - Table-driven tests for each new function
+   - Integration tests for end-to-end scenarios
+
+4. **Test fixtures**:
+   - JSON fixtures for manual/automated testing

--- a/specs/016-runtime-actual-cost/quickstart.md
+++ b/specs/016-runtime-actual-cost/quickstart.md
@@ -1,0 +1,187 @@
+# Quickstart: Testing Runtime-Based Actual Cost Estimation
+
+**Feature Branch**: `016-runtime-actual-cost`
+**Date**: 2025-12-31
+
+## Prerequisites
+
+- Go 1.25+ installed
+- grpcurl (optional, for manual testing)
+- Built plugin binary with region tag
+
+## Build the Plugin
+
+```bash
+# Build for us-east-1 with embedded pricing data
+make build-default-region
+
+# Or build a specific region
+make build-region REGION=us-east-1
+```
+
+## Run Unit Tests
+
+```bash
+# Run all unit tests (includes new timestamp resolution tests)
+make test
+
+# Run specific tests for this feature
+go test -v -tags=region_use1 ./internal/plugin/... -run TestResolveTimestamps
+go test -v -tags=region_use1 ./internal/plugin/... -run TestExtractPulumiCreated
+go test -v -tags=region_use1 ./internal/plugin/... -run TestDetermineConfidence
+go test -v -tags=region_use1 ./internal/plugin/... -run TestGetActualCost_WithPulumiCreated
+```
+
+## Run Integration Tests
+
+```bash
+# Full integration test suite
+go test -tags=integration,region_use1 ./internal/plugin/... -v
+
+# Specific integration tests for this feature
+go test -tags=integration,region_use1 ./internal/plugin/... -run TestIntegration_ActualCost_RuntimeFromMetadata
+```
+
+## Manual Testing with grpcurl
+
+### Start the Plugin
+
+```bash
+# Start the plugin (note the PORT output)
+./pulumicost-plugin-aws-public-us-east-1
+# Output: PORT=12345
+```
+
+### Test Case 1: Auto-Calculate from pulumi:created
+
+```bash
+# Resource created 7 days ago, using automatic timestamp resolution
+START_TIME=$(date -u -d "7 days ago" +%Y-%m-%dT%H:%M:%SZ)
+
+grpcurl -plaintext -d '{
+  "resource_id": "{\"provider\":\"aws\",\"resource_type\":\"ec2\",\"sku\":\"t3.micro\",\"region\":\"us-east-1\"}",
+  "tags": {
+    "pulumi:created": "'$START_TIME'"
+  }
+}' localhost:12345 pulumicost.v1.CostSourceService/GetActualCost
+```
+
+**Expected Response**:
+
+```json
+{
+  "results": [{
+    "timestamp": "2025-12-24T00:00:00Z",
+    "cost": 0.1234,
+    "usageAmount": 168.0,
+    "usageUnit": "hours",
+    "source": "aws-public-fallback[confidence:HIGH]"
+  }]
+}
+```
+
+### Test Case 2: Imported Resource (Lower Confidence)
+
+```bash
+START_TIME=$(date -u -d "30 days ago" +%Y-%m-%dT%H:%M:%SZ)
+
+grpcurl -plaintext -d '{
+  "resource_id": "{\"provider\":\"aws\",\"resource_type\":\"ec2\",\"sku\":\"t3.micro\",\"region\":\"us-east-1\"}",
+  "tags": {
+    "pulumi:created": "'$START_TIME'",
+    "pulumi:external": "true"
+  }
+}' localhost:12345 pulumicost.v1.CostSourceService/GetActualCost
+```
+
+**Expected Response** (note MEDIUM confidence):
+
+```json
+{
+  "results": [{
+    "timestamp": "2025-12-01T00:00:00Z",
+    "cost": 0.528,
+    "usageAmount": 720.0,
+    "usageUnit": "hours",
+    "source": "aws-public-fallback[confidence:MEDIUM] imported resource"
+  }]
+}
+```
+
+### Test Case 3: Explicit Timestamps Override
+
+```bash
+# Explicit last 7 days, even though resource is 30 days old
+START_TIME=$(date -u -d "7 days ago" +%Y-%m-%dT%H:%M:%SZ)
+END_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+CREATED_TIME=$(date -u -d "30 days ago" +%Y-%m-%dT%H:%M:%SZ)
+
+grpcurl -plaintext -d '{
+  "resource_id": "{\"provider\":\"aws\",\"resource_type\":\"ec2\",\"sku\":\"t3.micro\",\"region\":\"us-east-1\"}",
+  "start": {"seconds": '$(date -d "$START_TIME" +%s)'},
+  "end": {"seconds": '$(date -d "$END_TIME" +%s)'},
+  "tags": {
+    "pulumi:created": "'$CREATED_TIME'"
+  }
+}' localhost:12345 pulumicost.v1.CostSourceService/GetActualCost
+```
+
+**Expected**: Cost for 168 hours (7 days), NOT 720 hours (30 days)
+
+### Test Case 4: Missing Timestamps (Error)
+
+```bash
+grpcurl -plaintext -d '{
+  "resource_id": "{\"provider\":\"aws\",\"resource_type\":\"ec2\",\"sku\":\"t3.micro\",\"region\":\"us-east-1\"}",
+  "tags": {}
+}' localhost:12345 pulumicost.v1.CostSourceService/GetActualCost
+```
+
+**Expected**: gRPC error with code INVALID_ARGUMENT
+
+## Test Fixtures
+
+Test fixtures are provided in `test/fixtures/actual-cost/`:
+
+| File | Description |
+|------|-------------|
+| `with-created.json` | Resource with valid pulumi:created |
+| `with-external.json` | Imported resource (pulumi:external=true) |
+| `explicit-override.json` | Both explicit times and pulumi:created |
+| `missing-timestamps.json` | No timestamps (error case) |
+
+## Verification Checklist
+
+- [ ] Unit tests pass (`make test`)
+- [ ] Integration tests pass (`go test -tags=integration,region_use1 ...`)
+- [ ] Manual test case 1: Auto-calculate from pulumi:created
+- [ ] Manual test case 2: Imported resource shows MEDIUM confidence
+- [ ] Manual test case 3: Explicit timestamps override pulumi:created
+- [ ] Manual test case 4: Missing timestamps returns error
+- [ ] Lint passes (`make lint`)
+- [ ] Build succeeds (`make build-default-region`)
+
+## Troubleshooting
+
+### "start_time is required" Error
+
+This error occurs when:
+
+1. No explicit `start` timestamp in request, AND
+2. No valid `pulumi:created` in tags
+
+**Solution**: Ensure either explicit timestamps or `pulumi:created` tag is provided.
+
+### "cannot parse time" Log Warning
+
+This warning appears when `pulumi:created` contains invalid RFC3339 format.
+The plugin falls back to requiring explicit timestamps.
+
+**Solution**: Verify timestamp format matches `2006-01-02T15:04:05Z`.
+
+### Confidence Shows HIGH When Expected MEDIUM
+
+Check that:
+
+1. `pulumi:external` tag value is exactly `"true"` (case-sensitive)
+2. The tag is in `tags` map, not `resource_id` JSON

--- a/specs/016-runtime-actual-cost/research.md
+++ b/specs/016-runtime-actual-cost/research.md
@@ -1,0 +1,336 @@
+# Research: Runtime-Based Actual Cost Estimation
+
+**Feature Branch**: `016-runtime-actual-cost`
+**Date**: 2025-12-31
+**Status**: Complete
+
+## Summary
+
+This document resolves the technical clarifications identified in the implementation
+plan for feature #196. All NEEDS CLARIFICATION items have been researched and decisions
+documented.
+
+---
+
+## R1: Confidence Field Representation
+
+### Question
+
+How to represent confidence levels (HIGH/MEDIUM/LOW) in `ActualCostResult` without
+modifying the pulumicost-spec proto schema?
+
+### Research Findings
+
+The `ActualCostResult` message has these available fields:
+
+```protobuf
+message ActualCostResult {
+  google.protobuf.Timestamp timestamp = 1;
+  double cost = 2;
+  double usage_amount = 3;
+  string usage_unit = 4;
+  string source = 5;           // <-- Best option
+  FocusCostRecord focus_record = 6;
+  repeated ImpactMetric impact_metrics = 7;
+}
+```
+
+**Options Evaluated:**
+
+| Approach | Proto Change | Complexity | Clarity | Recommended |
+|----------|--------------|-----------|---------|-------------|
+| Semantic encoding in `source` | None | Low | Medium | **YES** |
+| FOCUS extended_columns | None | Medium | High | Alternative |
+| Custom ImpactMetric abuse | None | Low | Poor | No |
+| Proto amendment | Yes | Medium | High | Future |
+
+### Decision: Semantic Encoding in `source` Field
+
+**Format Specification:**
+
+```text
+source_format = provider_name "[confidence:" level "]" [ notes ]
+provider_name = "aws-public-fallback"
+level         = "HIGH" | "MEDIUM" | "LOW"
+notes         = " " detail_string
+
+Examples:
+  "aws-public-fallback[confidence:HIGH]"
+  "aws-public-fallback[confidence:MEDIUM] imported resource"
+  "aws-public-fallback[confidence:LOW] unsupported resource"
+```
+
+**Confidence Level Guidelines:**
+
+| Scenario | Level | Rationale |
+|----------|-------|-----------|
+| Native resource with valid `pulumi:created` | HIGH | Precise runtime calculation |
+| Explicit request timestamps provided | HIGH | User-specified time range |
+| Imported resource (`pulumi:external=true`) | MEDIUM | Import time, not actual creation |
+| Missing `pulumi:created`, no explicit times | LOW | Cannot determine runtime |
+| Unsupported resource type | LOW | $0 estimate with explanation |
+
+### Implementation Pattern
+
+```go
+// internal/plugin/actual.go
+
+// ConfidenceLevel represents the estimation confidence for actual cost calculations.
+type ConfidenceLevel string
+
+const (
+    ConfidenceHigh   ConfidenceLevel = "HIGH"
+    ConfidenceMedium ConfidenceLevel = "MEDIUM"
+    ConfidenceLow    ConfidenceLevel = "LOW"
+)
+
+// formatSourceWithConfidence creates the source string with embedded confidence level.
+func formatSourceWithConfidence(confidence ConfidenceLevel, note string) string {
+    if note != "" {
+        return fmt.Sprintf("aws-public-fallback[confidence:%s] %s", confidence, note)
+    }
+    return fmt.Sprintf("aws-public-fallback[confidence:%s]", confidence)
+}
+```
+
+### Alternatives Considered
+
+1. **FOCUS `extended_columns`**: Good for detailed metadata but requires populating
+   the entire FocusCostRecord, adding complexity for simple confidence indication.
+
+2. **Proto amendment**: Ideal long-term but blocks implementation on external spec
+   changes. Can be pursued in parallel if there's consensus in pulumicost-spec.
+
+---
+
+## R2: Pulumi Metadata Injection
+
+### Question
+
+How does pulumicost-core inject `pulumi:created`, `pulumi:modified`, and
+`pulumi:external` into `GetActualCostRequest`? What are the exact key names?
+
+### Research Findings
+
+Per spec assumption A-001:
+> pulumicost-core injects `pulumi:created`, `pulumi:modified`, and `pulumi:external`
+> into resource properties before calling the plugin.
+
+The injection point is `GetActualCostRequest.tags` map. This follows the existing
+pattern where resource metadata is passed via tags.
+
+**Key Names (from spec):**
+
+| Key | Type | Format | Description |
+|-----|------|--------|-------------|
+| `pulumi:created` | string | RFC3339 | Resource creation timestamp |
+| `pulumi:modified` | string | RFC3339 | Last modification timestamp |
+| `pulumi:external` | string | "true" | Present when resource was imported |
+
+### Decision: Read from `req.Tags` Map
+
+The plugin will read Pulumi metadata from the existing tags mechanism:
+
+```go
+// internal/plugin/actual.go
+
+// PulumiMetadataKeys defines the standard keys for Pulumi state metadata.
+const (
+    TagPulumiCreated  = "pulumi:created"
+    TagPulumiModified = "pulumi:modified"
+    TagPulumiExternal = "pulumi:external"
+)
+
+// extractPulumiCreated parses the pulumi:created timestamp from tags.
+// Returns (timestamp, true) if valid, or (zero, false) if missing/invalid.
+func extractPulumiCreated(tags map[string]string) (time.Time, bool) {
+    if tags == nil {
+        return time.Time{}, false
+    }
+    createdStr, ok := tags[TagPulumiCreated]
+    if !ok || createdStr == "" {
+        return time.Time{}, false
+    }
+    t, err := time.Parse(time.RFC3339, createdStr)
+    if err != nil {
+        return time.Time{}, false
+    }
+    return t, true
+}
+
+// isImportedResource checks if the resource was imported (pulumi:external=true).
+func isImportedResource(tags map[string]string) bool {
+    if tags == nil {
+        return false
+    }
+    return tags[TagPulumiExternal] == "true"
+}
+```
+
+### Verification
+
+- The current `parseResourceFromRequest()` function in `plugin.go` already copies
+  tags from the request to the ResourceDescriptor.
+- The tags map is accessible via both `req.Tags` directly and through the parsed
+  `resource.Tags` after validation.
+
+---
+
+## R3: Timestamp Priority Semantics
+
+### Question
+
+How should explicit `req.Start`/`req.End` interact with `pulumi:created`? What
+happens when both are present? When neither is present?
+
+### Research Findings
+
+Current validation (`validateTimestamps` in `validation.go:158-170`) **requires**
+both `req.Start` and `req.End` to be non-nil:
+
+```go
+func validateTimestamps(req *pbc.GetActualCostRequest) error {
+    if req.Start == nil {
+        return status.Error(codes.InvalidArgument, "start_time is required")
+    }
+    if req.End == nil {
+        return status.Error(codes.InvalidArgument, "end_time is required")
+    }
+    // ...
+}
+```
+
+This means the feature cannot make timestamps "optional" without modifying the
+validation flow.
+
+### Decision: Two-Phase Timestamp Resolution
+
+**Phase 1: Pre-Validation Resolution (NEW)**
+
+Before SDK validation, resolve timestamps using the priority order:
+
+1. **Explicit Request Timestamps** (highest priority)
+   - If `req.Start` and `req.End` are both set, use them
+   - This enables "last 7 days" queries regardless of resource age
+
+2. **Pulumi Metadata** (fallback)
+   - If `req.Start` is nil but `tags["pulumi:created"]` exists, use it
+   - If `req.End` is nil, default to `time.Now()`
+
+3. **Error** (no timestamps available)
+   - If neither explicit times nor `pulumi:created` is available, return error
+
+**Phase 2: Validation**
+
+After resolution, the existing `validateTimestamps()` runs with guaranteed
+non-nil timestamps.
+
+### Implementation Pattern
+
+```go
+// internal/plugin/actual.go
+
+// TimestampResolution captures the resolved timestamps and their source.
+type TimestampResolution struct {
+    Start      time.Time
+    End        time.Time
+    Source     string       // "explicit", "pulumi:created", "mixed"
+    IsImported bool         // true if pulumi:external=true
+}
+
+// resolveTimestamps applies the priority-based timestamp resolution.
+// Priority: (1) explicit req.Start/End, (2) pulumi:created from tags, (3) error
+func resolveTimestamps(req *pbc.GetActualCostRequest) (*TimestampResolution, error) {
+    res := &TimestampResolution{}
+
+    // Check explicit timestamps first
+    hasExplicitStart := req.Start != nil && req.Start.IsValid()
+    hasExplicitEnd := req.End != nil && req.End.IsValid()
+
+    if hasExplicitStart && hasExplicitEnd {
+        res.Start = req.Start.AsTime()
+        res.End = req.End.AsTime()
+        res.Source = "explicit"
+        res.IsImported = isImportedResource(req.Tags)
+        return res, nil
+    }
+
+    // Try pulumi:created for start time
+    pulumiCreated, hasCreated := extractPulumiCreated(req.Tags)
+
+    if !hasExplicitStart {
+        if hasCreated {
+            res.Start = pulumiCreated
+            res.Source = "pulumi:created"
+        } else {
+            return nil, fmt.Errorf("start_time required: no explicit timestamp and no pulumi:created in tags")
+        }
+    } else {
+        res.Start = req.Start.AsTime()
+        res.Source = "explicit"
+    }
+
+    if !hasExplicitEnd {
+        // Default end time to now
+        res.End = time.Now()
+        if res.Source == "explicit" {
+            res.Source = "mixed"
+        }
+    } else {
+        res.End = req.End.AsTime()
+        if res.Source == "pulumi:created" {
+            res.Source = "mixed"
+        }
+    }
+
+    res.IsImported = isImportedResource(req.Tags)
+    return res, nil
+}
+```
+
+### Confidence Mapping
+
+| Source | IsImported | Confidence |
+|--------|------------|------------|
+| explicit | false | HIGH |
+| explicit | true | HIGH |
+| pulumi:created | false | HIGH |
+| pulumi:created | true | MEDIUM |
+| mixed | false | HIGH |
+| mixed | true | MEDIUM |
+| error | - | (no response) |
+
+### Edge Cases
+
+1. **End before Start**: Return zero cost with explanation (FR-009)
+2. **Invalid RFC3339**: Fall back to requiring explicit timestamps
+3. **pulumi:modified without pulumi:created**: Do NOT use modified as creation time
+
+---
+
+## Design Decisions Summary
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Confidence encoding | `source` field semantic | No proto changes, backward compatible |
+| Metadata source | `req.Tags` map | Matches existing pattern |
+| Timestamp priority | Explicit > pulumi:created > error | Per FR-003 |
+| Imported resource detection | `pulumi:external=true` tag | Per FR-004 |
+| Default end time | `time.Now()` | Intuitive "cost since creation" |
+
+---
+
+## References
+
+- **Proto Source**: `pulumicost-spec/proto/pulumicost/v1/costsource.proto`
+  - ActualCostResult: lines 369-386
+  - GetActualCostRequest: lines 140-152
+
+- **Plugin Source**: `internal/plugin/`
+  - validation.go: Request validation
+  - plugin.go: GetActualCost handler
+  - actual.go: Calculation helpers
+
+- **Spec**: `/specs/016-runtime-actual-cost/spec.md`
+  - FR-001 through FR-009
+  - Assumptions A-001 through A-005

--- a/specs/016-runtime-actual-cost/spec.md
+++ b/specs/016-runtime-actual-cost/spec.md
@@ -1,0 +1,165 @@
+# Feature Specification: Runtime-Based Actual Cost Estimation
+
+**Feature Branch**: `016-runtime-actual-cost`
+**Created**: 2025-12-31
+**Status**: Draft
+**GitHub Issue**: #196
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Auto-Calculate Cost from Creation Time (Priority: P1)
+
+As a cloud cost analyst, I want actual cost calculations to automatically use the
+resource's creation timestamp from Pulumi state, so I can get accurate runtime-based
+cost estimates without manually specifying start times.
+
+**Why this priority**: This is the core value proposition. Using `pulumi:created`
+timestamps enables automatic runtime detection, making cost tracking effortless
+for resources managed by Pulumi.
+
+**Independent Test**: Can be fully tested by providing a resource with
+`pulumi:created` in its properties and verifying the cost is calculated from
+that timestamp to the specified end time.
+
+**Acceptance Scenarios**:
+
+1. **Given** an EC2 instance with `pulumi:created` set to 7 days ago, **When**
+   actual cost is requested with end time of now, **Then** the system returns
+   cost based on 168 hours of runtime.
+2. **Given** a resource with `pulumi:created` and a request with explicit start
+   time after creation, **When** actual cost is calculated, **Then** the explicit
+   start time takes precedence over creation time.
+3. **Given** a resource without `pulumi:created`, **When** actual cost is
+   requested, **Then** the system falls back to requiring explicit start time
+   in the request.
+
+---
+
+### User Story 2 - Identify Imported Resources with Lower Confidence (Priority: P2)
+
+As a cloud cost analyst, I want to know when cost estimates may be less accurate
+due to resource imports, so I can make informed decisions about the reliability
+of the data.
+
+**Why this priority**: Imported resources have `pulumi:created` set to import
+time, not actual cloud creation time. Users need visibility into estimate accuracy.
+
+**Independent Test**: Can be tested by providing a resource with
+`pulumi:external=true` and verifying the response includes a lower confidence
+indicator.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource with `pulumi:external=true`, **When** actual cost is
+   calculated, **Then** the response indicates lower confidence with an
+   explanatory note.
+2. **Given** a resource without `pulumi:external`, **When** actual cost is
+   calculated, **Then** the response indicates standard confidence.
+
+---
+
+### User Story 3 - Prioritize Runtime from Request Metadata (Priority: P2)
+
+As a cost analyst using automation, I want to optionally override the creation
+timestamp with explicit request parameters, so I can calculate costs for specific
+time windows regardless of resource age.
+
+**Why this priority**: Flexibility for reporting and auditing use cases where
+specific date ranges matter more than actual resource age.
+
+**Independent Test**: Can be tested by providing both `pulumi:created` and
+explicit request timestamps, verifying the request parameters take precedence.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource created 30 days ago, **When** actual cost is requested
+   for only the last 7 days, **Then** the cost reflects only those 7 days.
+2. **Given** explicit start and end times in the request, **When** actual cost
+   is calculated, **Then** `pulumi:created` is ignored in favor of request times.
+
+---
+
+### Edge Cases
+
+- What happens when `pulumi:created` contains an invalid or unparseable timestamp?
+  System falls back to requiring explicit request timestamps.
+- What happens when the requested end time is before `pulumi:created`?
+  System returns zero cost with an explanatory note.
+- What happens when `pulumi:modified` exists but `pulumi:created` is missing?
+  System does not use `pulumi:modified` as a creation time substitute.
+- What happens for resources that can be stopped (EC2)?
+  System cannot track stop/start events; estimates assume continuous runtime
+  with a documented limitation note.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST parse `pulumi:created` from resource properties when
+  present (RFC3339 format).
+- **FR-002**: System MUST use `pulumi:created` as the default start time when
+  no explicit start time is provided in the request.
+- **FR-003**: System MUST allow explicit request start/end times to override
+  `pulumi:created`.
+- **FR-004**: System MUST detect `pulumi:external=true` and flag the estimate
+  as lower confidence.
+- **FR-005**: System MUST include confidence level in the response (HIGH for
+  native resources, MEDIUM for imported resources).
+- **FR-006**: System MUST include explanatory notes in the response describing
+  the estimation basis and any limitations.
+- **FR-007**: System MUST handle missing `pulumi:created` gracefully by
+  requiring explicit timestamps or returning an appropriate error.
+- **FR-008**: System MUST calculate actual cost using the formula:
+  `actual_cost = projected_monthly_cost × (runtime_hours / 730)`.
+- **FR-009**: System MUST return zero cost with explanation when end time
+  precedes start time (after validation).
+
+### Key Entities
+
+- **Resource Properties**: Metadata injected by pulumicost-core from Pulumi state
+  - `pulumi:created`: RFC3339 timestamp of resource creation
+  - `pulumi:modified`: RFC3339 timestamp of last modification
+  - `pulumi:external`: Boolean flag indicating imported resource
+- **Actual Cost Result**: Response containing calculated cost with metadata
+  - Cost amount and currency
+  - Time range used for calculation
+  - Confidence level (HIGH/MEDIUM/LOW)
+  - Explanatory notes
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of resources with valid `pulumi:created` timestamps
+  automatically use that time for cost calculation when no explicit start
+  is provided.
+- **SC-002**: Imported resources (`pulumi:external=true`) are correctly
+  identified and flagged in 100% of cases.
+- **SC-003**: Cost calculation accuracy matches the existing projected cost
+  system (same hourly rate derivation).
+- **SC-004**: Response includes confidence indicator for every actual cost
+  calculation.
+- **SC-005**: Users receive clear explanatory notes describing the estimation
+  basis and any limitations.
+
+## Assumptions
+
+- **A-001**: pulumicost-core injects `pulumi:created`, `pulumi:modified`, and
+  `pulumi:external` into resource properties before calling the plugin.
+- **A-002**: Timestamps are in RFC3339 format as specified by pulumicost-core.
+- **A-003**: The existing `GetActualCost` calculation formula remains unchanged;
+  this feature adds smarter timestamp resolution.
+- **A-004**: Stop/start tracking for EC2 instances is out of scope; estimates
+  assume continuous runtime.
+- **A-005**: The 730-hour month constant is used consistently with projected
+  cost calculations.
+
+## Limitations (Must Document to Users)
+
+- **L-001**: Imported resources have inaccurate creation times (import time,
+  not cloud creation time).
+- **L-002**: Stop/start events are not tracked; estimates assume 100% uptime.
+- **L-003**: Estimates do not reflect Reserved Instance, Spot, or Savings Plans
+  pricing.
+- **L-004**: For accurate billing data, users should use FinOps plugins with
+  access to real billing APIs.

--- a/specs/016-runtime-actual-cost/tasks.md
+++ b/specs/016-runtime-actual-cost/tasks.md
@@ -1,0 +1,236 @@
+# Tasks: Runtime-Based Actual Cost Estimation
+
+**Input**: Design documents from `/specs/016-runtime-actual-cost/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+**Tests**: Included per Constitution II Testing Discipline requirements
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Single Go project**: `internal/plugin/` at repository root
+- **Test files**: Co-located with source files (`*_test.go`)
+- **Test fixtures**: `test/fixtures/actual-cost/`
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Define constants and types shared by all user stories
+
+- [ ] T001 Add Pulumi metadata tag constants (TagPulumiCreated, TagPulumiModified, TagPulumiExternal) in internal/plugin/actual.go
+- [ ] T002 Add ConfidenceLevel type and constants (ConfidenceHigh, ConfidenceMedium, ConfidenceLow) in internal/plugin/actual.go
+- [ ] T003 Add TimestampResolution struct type in internal/plugin/actual.go
+- [ ] T004 [P] Create test fixtures directory at test/fixtures/actual-cost/
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core helper functions that MUST be complete before user story work
+
+**⚠️ CRITICAL**: All three user stories depend on these helper functions
+
+- [ ] T005 Implement extractPulumiCreated() function to parse RFC3339 from tags in internal/plugin/actual.go
+- [ ] T006 [P] Implement isImportedResource() function to check pulumi:external=true in internal/plugin/actual.go
+- [ ] T007 Implement formatSourceWithConfidence() function for semantic source encoding in internal/plugin/actual.go
+- [ ] T008 Add table-driven unit tests for extractPulumiCreated() in internal/plugin/actual_test.go
+- [ ] T009 [P] Add table-driven unit tests for isImportedResource() in internal/plugin/actual_test.go
+- [ ] T010 [P] Add table-driven unit tests for formatSourceWithConfidence() in internal/plugin/actual_test.go
+
+**Checkpoint**: Foundation ready - helper functions tested and working
+
+---
+
+## Phase 3: User Story 1 - Auto-Calculate Cost from Creation Time (Priority: P1) 🎯 MVP
+
+**Goal**: Enable automatic runtime detection from `pulumi:created` timestamps when explicit timestamps are not provided
+
+**Independent Test**: Provide a resource with `pulumi:created` in tags and verify cost is calculated from that timestamp
+
+### Tests for User Story 1
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [ ] T011 [P] [US1] Add unit tests for resolveTimestamps() priority logic in internal/plugin/actual_test.go
+- [ ] T012 [P] [US1] Add unit test for runtime hours calculation edge case (zero duration returns zero cost) in internal/plugin/actual_test.go
+
+### Implementation for User Story 1
+
+- [ ] T013 [US1] Implement resolveTimestamps() with priority: explicit > pulumi:created > error in internal/plugin/actual.go
+- [ ] T014 [US1] Implement determineConfidence() to map resolution source to confidence level in internal/plugin/actual.go
+- [ ] T015 [US1] Modify GetActualCost() handler to call resolveTimestamps() before validation in internal/plugin/plugin.go
+- [ ] T016 [US1] Update GetActualCost() to use resolved timestamps for cost calculation in internal/plugin/plugin.go
+- [ ] T017 [US1] Add logging for timestamp resolution source (explicit vs pulumi:created) in internal/plugin/plugin.go
+
+### Test Fixtures for User Story 1
+
+- [ ] T018 [P] [US1] Create with-created.json test fixture with valid pulumi:created in test/fixtures/actual-cost/
+- [ ] T019 [P] [US1] Create explicit-override.json test fixture with both explicit times and pulumi:created in test/fixtures/actual-cost/
+
+**Checkpoint**: Resources with `pulumi:created` automatically use that time for cost calculation
+
+---
+
+## Phase 4: User Story 2 - Identify Imported Resources with Lower Confidence (Priority: P2)
+
+**Goal**: Flag imported resources with MEDIUM confidence indicator so users know estimates may be less accurate
+
+**Independent Test**: Provide a resource with `pulumi:external=true` and verify response includes MEDIUM confidence
+
+### Tests for User Story 2
+
+- [ ] T020 [P] [US2] Add unit test for determineConfidence() with imported=true scenarios in internal/plugin/actual_test.go
+- [ ] T021 [P] [US2] Add unit test for confidence encoding in source field output in internal/plugin/actual_test.go
+
+### Implementation for User Story 2
+
+- [ ] T022 [US2] Update resolveTimestamps() to track IsImported flag from pulumi:external tag in internal/plugin/actual.go
+- [ ] T023 [US2] Update determineConfidence() to return MEDIUM when IsImported=true with pulumi:created source in internal/plugin/actual.go
+- [ ] T024 [US2] Update GetActualCost() to include confidence and explanatory notes in response source field per FR-006 in internal/plugin/plugin.go
+- [ ] T025 [US2] Add specific "imported resource" note when pulumi:external=true detected in internal/plugin/plugin.go
+
+### Test Fixtures for User Story 2
+
+- [ ] T026 [P] [US2] Create with-external.json test fixture with pulumi:external=true in test/fixtures/actual-cost/
+
+**Checkpoint**: Imported resources correctly show MEDIUM confidence indicator
+
+---
+
+## Phase 5: User Story 3 - Prioritize Runtime from Request Metadata (Priority: P2)
+
+**Goal**: Allow explicit request timestamps to override pulumi:created for specific time window queries
+
+**Independent Test**: Provide both `pulumi:created` and explicit timestamps, verify explicit timestamps take precedence
+
+### Tests for User Story 3
+
+- [ ] T027 [P] [US3] Add unit test for resolveTimestamps() explicit override scenario in internal/plugin/actual_test.go
+- [ ] T028 [P] [US3] Add unit test for partial explicit (start only, end only) scenarios in internal/plugin/actual_test.go
+
+### Implementation for User Story 3
+
+- [ ] T029 [US3] Add docstring to resolveTimestamps() documenting priority order (explicit > pulumi:created > error) in internal/plugin/actual.go
+- [ ] T030 [US3] Handle mixed source case (explicit start, pulumi:created end default) in internal/plugin/actual.go
+- [ ] T031 [US3] Update source field to indicate "explicit" when user-provided timestamps used in internal/plugin/plugin.go
+
+### Edge Case Handling for User Story 3
+
+- [ ] T032 [US3] Handle invalid RFC3339 in pulumi:created by falling back to explicit requirement in internal/plugin/actual.go
+- [ ] T033 [US3] Handle end time before start time with zero cost and explanation in internal/plugin/plugin.go
+- [ ] T034 [US3] Ensure pulumi:modified is NOT used as fallback (explicit behavior) in internal/plugin/actual.go
+
+**Checkpoint**: Explicit timestamps correctly override pulumi:created timestamps
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Integration verification, documentation, and final validation
+
+- [ ] T035 Run `make lint` and fix any linting issues
+- [ ] T036 Run `make test` and verify all unit tests pass
+- [ ] T037 [P] Run integration test with grpcurl commands from quickstart.md
+- [ ] T038 [P] Verify backward compatibility: existing callers without pulumi metadata still work
+- [ ] T039 Update CLAUDE.md if new patterns or conventions emerged
+- [ ] T040 Run `npx markdownlint` on all spec markdown files
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories (Phase 3-5)**: All depend on Foundational phase completion
+  - User stories can proceed sequentially in priority order (P1 → P2)
+  - US2 and US3 are both P2 but can be done in order listed
+- **Polish (Phase 6)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational (Phase 2) - Core MVP functionality
+- **User Story 2 (P2)**: Depends on US1 confidence infrastructure - Adds imported resource handling
+- **User Story 3 (P2)**: Depends on US1 timestamp resolution - Refines priority semantics
+
+### Within Each User Story
+
+- Tests SHOULD be written and FAIL before implementation (TDD)
+- Helper functions before handler modifications
+- Core implementation before edge case handling
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+- All Setup tasks can run sequentially (same file)
+- T006, T007 can run in parallel with T005 (different functions)
+- Test fixture creation (T018, T019, T026) can run in parallel
+- Test writing (T011, T012) can run in parallel (different test tables)
+
+---
+
+## Parallel Example: Foundational Phase
+
+```bash
+# After T005 completes, these can run in parallel:
+Task: T006 - Implement isImportedResource() in actual.go
+Task: T007 - Implement formatSourceWithConfidence() in actual.go
+
+# Then all tests can run in parallel:
+Task: T008 - Unit tests for extractPulumiCreated()
+Task: T009 - Unit tests for isImportedResource()
+Task: T010 - Unit tests for formatSourceWithConfidence()
+```
+
+## Parallel Example: Test Fixtures
+
+```bash
+# All fixture creation can run in parallel:
+Task: T018 - Create with-created.json
+Task: T019 - Create explicit-override.json
+Task: T026 - Create with-external.json
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001-T004)
+2. Complete Phase 2: Foundational (T005-T010)
+3. Complete Phase 3: User Story 1 (T011-T019)
+4. **STOP and VALIDATE**: Test with grpcurl using with-created.json fixture
+5. Deploy/demo if ready - core functionality working
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational → Foundation ready
+2. Add User Story 1 → Test independently → **MVP!** (auto-calculate from creation time)
+3. Add User Story 2 → Test independently → **Enhanced!** (imported resource confidence)
+4. Add User Story 3 → Test independently → **Complete!** (explicit override support)
+5. Each story adds value without breaking previous stories
+
+### Estimated Scope
+
+- **MVP (US1 only)**: ~19 tasks (T001-T019)
+- **Full feature**: 40 tasks (T001-T040)
+- **Parallel potential**: ~15 tasks can be parallelized
+
+---
+
+## Notes
+
+- All code changes isolated to `internal/plugin/` package
+- No proto changes required (semantic encoding in existing source field)
+- Backward compatible: existing callers unaffected
+- Constitution compliance: Table-driven tests, zerolog logging, thread-safe functions
+- Verify with `make lint && make test` after each phase

--- a/test/fixtures/actual-cost/explicit-override.json
+++ b/test/fixtures/actual-cost/explicit-override.json
@@ -1,0 +1,21 @@
+{
+  "description": "Resource with both explicit timestamps and pulumi:created - tests priority",
+  "resource_id": {
+    "provider": "aws",
+    "resource_type": "ec2",
+    "sku": "t3.micro",
+    "region": "us-east-1",
+    "tags": {
+      "pulumi:created": "2025-01-01T00:00:00Z",
+      "Name": "test-instance"
+    }
+  },
+  "explicit_start": "2025-01-10T00:00:00Z",
+  "explicit_end": "2025-01-15T00:00:00Z",
+  "expected": {
+    "confidence": "HIGH",
+    "source_contains": "[confidence:HIGH]",
+    "runtime_hours": 120,
+    "notes": "Explicit timestamps should override pulumi:created (7 days, not 14 days)"
+  }
+}

--- a/test/fixtures/actual-cost/with-created.json
+++ b/test/fixtures/actual-cost/with-created.json
@@ -1,0 +1,18 @@
+{
+  "description": "Resource with valid pulumi:created timestamp - tests automatic runtime detection",
+  "resource_id": {
+    "provider": "aws",
+    "resource_type": "ec2",
+    "sku": "t3.micro",
+    "region": "us-east-1",
+    "tags": {
+      "pulumi:created": "2025-01-15T10:30:00Z",
+      "Name": "test-instance"
+    }
+  },
+  "expected": {
+    "confidence": "HIGH",
+    "source_contains": "[confidence:HIGH]",
+    "notes": "Native resource with pulumi:created should return HIGH confidence"
+  }
+}

--- a/test/fixtures/actual-cost/with-external.json
+++ b/test/fixtures/actual-cost/with-external.json
@@ -1,0 +1,20 @@
+{
+  "description": "Imported resource with pulumi:external=true - tests MEDIUM confidence",
+  "resource_id": {
+    "provider": "aws",
+    "resource_type": "ec2",
+    "sku": "t3.micro",
+    "region": "us-east-1",
+    "tags": {
+      "pulumi:created": "2025-01-01T00:00:00Z",
+      "pulumi:external": "true",
+      "Name": "imported-instance"
+    }
+  },
+  "expected": {
+    "confidence": "MEDIUM",
+    "source_contains": "[confidence:MEDIUM]",
+    "note_contains": "imported resource",
+    "notes": "Imported resource should return MEDIUM confidence with explanatory note"
+  }
+}

--- a/test/fixtures/cloudwatch/Pulumi.yaml
+++ b/test/fixtures/cloudwatch/Pulumi.yaml
@@ -1,0 +1,8 @@
+name: fixture-cloudwatch
+runtime: yaml
+description: A basic CloudWatch Log Group for cost estimation testing
+resources:
+  my-log-group:
+    type: aws:cloudwatch/logGroup:LogGroup
+    properties:
+      retentionInDays: 30

--- a/test/fixtures/dynamodb/Pulumi.yaml
+++ b/test/fixtures/dynamodb/Pulumi.yaml
@@ -1,0 +1,12 @@
+name: fixture-dynamodb
+runtime: yaml
+description: A basic DynamoDB table for cost estimation testing
+resources:
+  my-table:
+    type: aws:dynamodb/table:Table
+    properties:
+      attributes:
+        - name: id
+          type: S
+      hashKey: id
+      billingMode: PAY_PER_REQUEST

--- a/test/fixtures/ebs/Pulumi.yaml
+++ b/test/fixtures/ebs/Pulumi.yaml
@@ -1,0 +1,10 @@
+name: fixture-ebs
+runtime: yaml
+description: A basic EBS volume for cost estimation testing
+resources:
+  data-volume:
+    type: aws:ebs/volume:Volume
+    properties:
+      availabilityZone: us-east-1a
+      size: 100
+      type: gp3

--- a/test/fixtures/ec2/Pulumi.yaml
+++ b/test/fixtures/ec2/Pulumi.yaml
@@ -1,0 +1,9 @@
+name: fixture-ec2
+runtime: yaml
+description: A basic EC2 instance for cost estimation testing
+resources:
+  web-server:
+    type: aws:ec2/instance:Instance
+    properties:
+      instanceType: t3.micro
+      ami: ami-0c55b159cbfafe1f0 # Example AMI

--- a/test/fixtures/eks/Pulumi.yaml
+++ b/test/fixtures/eks/Pulumi.yaml
@@ -1,0 +1,10 @@
+name: fixture-eks
+runtime: yaml
+description: A basic EKS cluster for cost estimation testing
+resources:
+  my-cluster:
+    type: aws:eks/cluster:Cluster
+    properties:
+      roleArn: arn:aws:iam::123456789012:role/eks-role
+      vpcConfig:
+        subnetIds: ["subnet-12345678"]

--- a/test/fixtures/elb/Pulumi.yaml
+++ b/test/fixtures/elb/Pulumi.yaml
@@ -1,0 +1,9 @@
+name: fixture-elb
+runtime: yaml
+description: A basic ALB for cost estimation testing
+resources:
+  my-alb:
+    type: aws:lb/loadbalancer:LoadBalancer
+    properties:
+      loadBalancerType: application
+      subnets: ["subnet-12345678", "subnet-87654321"]

--- a/test/fixtures/lambda/Pulumi.yaml
+++ b/test/fixtures/lambda/Pulumi.yaml
@@ -1,0 +1,13 @@
+name: fixture-lambda
+runtime: yaml
+description: A basic Lambda function for cost estimation testing
+resources:
+  my-function:
+    type: aws:lambda/function:Function
+    properties:
+      handler: index.handler
+      role: arn:aws:iam::123456789012:role/lambda-role
+      runtime: nodejs18.x
+      code: 
+        s3Bucket: my-bucket
+        s3Key: my-code.zip

--- a/test/fixtures/natgw/Pulumi.yaml
+++ b/test/fixtures/natgw/Pulumi.yaml
@@ -1,0 +1,9 @@
+name: fixture-natgw
+runtime: yaml
+description: A basic NAT Gateway for cost estimation testing
+resources:
+  my-natgw:
+    type: aws:ec2/natGateway:NatGateway
+    properties:
+      allocationId: eipalloc-12345678
+      subnetId: subnet-12345678

--- a/test/fixtures/rds/Pulumi.yaml
+++ b/test/fixtures/rds/Pulumi.yaml
@@ -1,0 +1,10 @@
+name: fixture-rds
+runtime: yaml
+description: A basic RDS instance for cost estimation testing (stub)
+resources:
+  my-db:
+    type: aws:rds/instance:Instance
+    properties:
+      instanceClass: db.t3.micro
+      engine: postgres
+      allocatedStorage: 20

--- a/test/fixtures/s3/Pulumi.yaml
+++ b/test/fixtures/s3/Pulumi.yaml
@@ -1,0 +1,8 @@
+name: fixture-s3
+runtime: yaml
+description: A basic S3 bucket for cost estimation testing
+resources:
+  my-bucket:
+    type: aws:s3/bucketV2:BucketV2
+    properties:
+      forceDestroy: true


### PR DESCRIPTION
## Summary

Enhances `GetActualCost` to automatically detect resource runtime from Pulumi state metadata when explicit timestamps are not provided. This enables zero-configuration cost calculation for resources managed by Pulumi by using `pulumi:created` timestamps and detecting imported resources via `pulumi:external` tags.

Key capabilities:
- Timestamp resolution priority: explicit > pulumi:created > error
- Confidence levels (HIGH/MEDIUM/LOW) encoded in source field
- Imported resource detection with appropriate confidence downgrade
- Full backward compatibility with existing explicit timestamp callers

## Test plan

- [x] `make lint` passes with zero issues
- [x] `make test` passes (12 new tests added)
- [x] `go build -tags=region_use1` compiles successfully
- [x] Code review completed with no blocking issues

## Changes

### New files

- `test/fixtures/actual-cost/*.json` - Test fixtures for timestamp scenarios
- `specs/016-runtime-actual-cost/*` - Feature specification and planning docs

### Modified files

- `internal/plugin/actual.go` - Added `ConfidenceLevel`, `TimestampResolution` types, `extractPulumiCreated()`, `isImportedResource()`, `formatSourceWithConfidence()`, `mergeTagsFromRequest()`, `resolveTimestamps()`, `determineConfidence()` functions
- `internal/plugin/actual_test.go` - Added 12 new test functions covering helper functions, resolution logic, and end-to-end integration
- `internal/plugin/validation.go` - Updated `ValidateActualCostRequest()` to return `TimestampResolution` and call timestamp resolution before validation
- `internal/plugin/validation_test.go` - Fixed tests for new return signature
- `internal/plugin/plugin.go` - Updated `GetActualCost()` to use confidence level in response source field

Closes #196