### PR TITLE
feat(elasticache): implement cost estimation for ElastiCache clusters

### DIFF
--- a/internal/plugin/actual.go
+++ b/internal/plugin/actual.go
@@ -259,6 +259,8 @@ func (p *AWSPublicPlugin) getProjectedForResource(traceID string, resource *pbc.
 		return p.estimateNATGateway(traceID, resource)
 	case "cloudwatch":
 		return p.estimateCloudWatch(traceID, resource)
+	case "elasticache":
+		return p.estimateElastiCache(traceID, resource)
 	case "s3", "lambda", "rds", "dynamodb":
 		return p.estimateStub(resource)
 	default:

--- a/internal/plugin/actual_test.go
+++ b/internal/plugin/actual_test.go
@@ -158,6 +158,11 @@ func (m *mockPricingClientActual) CloudWatchMetricsTiers() ([]pricing.TierRate, 
 	return nil, false
 }
 
+func (m *mockPricingClientActual) ElastiCacheOnDemandPricePerHour(instanceType, engine string) (float64, bool) {
+	// Return basic ElastiCache pricing for actual cost tests
+	return 0.156, true // Default cache.m5.large pricing
+}
+
 func newTestPluginForActual() *AWSPublicPlugin {
 	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
 	return NewAWSPublicPlugin("us-east-1", &mockPricingClientActual{

--- a/internal/plugin/supports.go
+++ b/internal/plugin/supports.go
@@ -97,7 +97,7 @@ func (p *AWSPublicPlugin) Supports(ctx context.Context, req *pbc.SupportsRequest
 			SupportedMetrics: supportedMetrics,
 		}, nil
 
-	case "ebs", "rds", "eks", "s3", "lambda", "dynamodb", "elb", "natgw", "cloudwatch":
+	case "ebs", "rds", "eks", "s3", "lambda", "dynamodb", "elb", "natgw", "cloudwatch", "elasticache":
 		// Supported but no carbon estimation yet
 		p.logger.Info().
 			Str(pluginsdk.FieldTraceID, traceID).

--- a/internal/plugin/supports_test.go
+++ b/internal/plugin/supports_test.go
@@ -109,6 +109,45 @@ func TestSupports(t *testing.T) {
 			wantSupported:    true,
 			wantReasonSubstr: "",
 		},
+		// ElastiCache support (T050)
+		{
+			name: "ElastiCache supported",
+			req: &pbc.SupportsRequest{
+				Resource: &pbc.ResourceDescriptor{
+					Provider:     "aws",
+					ResourceType: "elasticache",
+					Region:       "us-east-1",
+				},
+			},
+			wantSupported:    true,
+			wantReasonSubstr: "",
+		},
+		// ElastiCache Pulumi Cluster format (T051)
+		{
+			name: "ElastiCache Pulumi Cluster format",
+			req: &pbc.SupportsRequest{
+				Resource: &pbc.ResourceDescriptor{
+					Provider:     "aws",
+					ResourceType: "aws:elasticache/cluster:Cluster",
+					Region:       "us-east-1",
+				},
+			},
+			wantSupported:    true,
+			wantReasonSubstr: "",
+		},
+		// ElastiCache Pulumi ReplicationGroup format (T052)
+		{
+			name: "ElastiCache Pulumi ReplicationGroup format",
+			req: &pbc.SupportsRequest{
+				Resource: &pbc.ResourceDescriptor{
+					Provider:     "aws",
+					ResourceType: "aws:elasticache/replicationGroup:ReplicationGroup",
+					Region:       "us-east-1",
+				},
+			},
+			wantSupported:    true,
+			wantReasonSubstr: "",
+		},
 
 		// Wrong region
 		{
@@ -650,6 +689,7 @@ func TestSupports_AllResourceTypes_SupportedMetrics(t *testing.T) {
 		{"s3", false},                       // S3 no carbon (v1)
 		{"lambda", false},                   // Lambda no carbon (v1)
 		{"dynamodb", false},                 // DynamoDB no carbon (stub)
+		{"elasticache", false},              // ElastiCache no carbon (v1)
 	}
 
 	for _, tt := range tests {

--- a/internal/pricing/embed_apne1.go
+++ b/internal/pricing/embed_apne1.go
@@ -33,3 +33,6 @@ var rawVPCJSON []byte
 
 //go:embed data/cloudwatch_ap-northeast-1.json
 var rawCloudWatchJSON []byte
+
+//go:embed data/elasticache_ap-northeast-1.json
+var rawElastiCacheJSON []byte

--- a/internal/pricing/embed_aps1.go
+++ b/internal/pricing/embed_aps1.go
@@ -33,3 +33,6 @@ var rawVPCJSON []byte
 
 //go:embed data/cloudwatch_ap-south-1.json
 var rawCloudWatchJSON []byte
+
+//go:embed data/elasticache_ap-south-1.json
+var rawElastiCacheJSON []byte

--- a/internal/pricing/embed_apse1.go
+++ b/internal/pricing/embed_apse1.go
@@ -33,3 +33,6 @@ var rawVPCJSON []byte
 
 //go:embed data/cloudwatch_ap-southeast-1.json
 var rawCloudWatchJSON []byte
+
+//go:embed data/elasticache_ap-southeast-1.json
+var rawElastiCacheJSON []byte

--- a/internal/pricing/embed_apse2.go
+++ b/internal/pricing/embed_apse2.go
@@ -33,3 +33,6 @@ var rawVPCJSON []byte
 
 //go:embed data/cloudwatch_ap-southeast-2.json
 var rawCloudWatchJSON []byte
+
+//go:embed data/elasticache_ap-southeast-2.json
+var rawElastiCacheJSON []byte

--- a/internal/pricing/embed_cac1.go
+++ b/internal/pricing/embed_cac1.go
@@ -33,3 +33,6 @@ var rawVPCJSON []byte
 
 //go:embed data/cloudwatch_ca-central-1.json
 var rawCloudWatchJSON []byte
+
+//go:embed data/elasticache_ca-central-1.json
+var rawElastiCacheJSON []byte

--- a/internal/pricing/embed_euw1.go
+++ b/internal/pricing/embed_euw1.go
@@ -33,3 +33,6 @@ var rawVPCJSON []byte
 
 //go:embed data/cloudwatch_eu-west-1.json
 var rawCloudWatchJSON []byte
+
+//go:embed data/elasticache_eu-west-1.json
+var rawElastiCacheJSON []byte

--- a/internal/pricing/embed_fallback.go
+++ b/internal/pricing/embed_fallback.go
@@ -381,3 +381,115 @@ var rawCloudWatchJSON = []byte(`{
   "products": {},
   "terms": {"OnDemand": {}}
 }`)
+
+// rawElastiCacheJSON contains minimal ElastiCache pricing data for development/testing.
+// Includes test data for Redis, Memcached, and Valkey engines with cache.t3.micro and cache.m5.large instance types.
+var rawElastiCacheJSON = []byte(`{
+  "formatVersion": "v1.0",
+  "disclaimer": "Fallback data for development/testing only",
+  "offerCode": "AmazonElastiCache",
+  "version": "fallback",
+  "publicationDate": "2024-01-01T00:00:00Z",
+  "products": {
+    "SKU_CACHE_T3MICRO_REDIS": {
+      "sku": "SKU_CACHE_T3MICRO_REDIS",
+      "productFamily": "Cache Instance",
+      "attributes": {
+        "instanceType": "cache.t3.micro",
+        "cacheEngine": "Redis",
+        "regionCode": "unknown"
+      }
+    },
+    "SKU_CACHE_T3MICRO_MEMCACHED": {
+      "sku": "SKU_CACHE_T3MICRO_MEMCACHED",
+      "productFamily": "Cache Instance",
+      "attributes": {
+        "instanceType": "cache.t3.micro",
+        "cacheEngine": "Memcached",
+        "regionCode": "unknown"
+      }
+    },
+    "SKU_CACHE_T3MICRO_VALKEY": {
+      "sku": "SKU_CACHE_T3MICRO_VALKEY",
+      "productFamily": "Cache Instance",
+      "attributes": {
+        "instanceType": "cache.t3.micro",
+        "cacheEngine": "Valkey",
+        "regionCode": "unknown"
+      }
+    },
+    "SKU_CACHE_M5LARGE_REDIS": {
+      "sku": "SKU_CACHE_M5LARGE_REDIS",
+      "productFamily": "Cache Instance",
+      "attributes": {
+        "instanceType": "cache.m5.large",
+        "cacheEngine": "Redis",
+        "regionCode": "unknown"
+      }
+    }
+  },
+  "terms": {
+    "OnDemand": {
+      "SKU_CACHE_T3MICRO_REDIS": {
+        "SKU_CACHE_T3MICRO_REDIS.JRTCKXETXF": {
+          "offerTermCode": "JRTCKXETXF",
+          "sku": "SKU_CACHE_T3MICRO_REDIS",
+          "effectiveDate": "2024-01-01T00:00:00Z",
+          "priceDimensions": {
+            "SKU_CACHE_T3MICRO_REDIS.JRTCKXETXF.6YS6EN2CT7": {
+              "rateCode": "SKU_CACHE_T3MICRO_REDIS.JRTCKXETXF.6YS6EN2CT7",
+              "description": "cache.t3.micro Redis hourly rate",
+              "unit": "Hrs",
+              "pricePerUnit": { "USD": "0.017" }
+            }
+          }
+        }
+      },
+      "SKU_CACHE_T3MICRO_MEMCACHED": {
+        "SKU_CACHE_T3MICRO_MEMCACHED.JRTCKXETXF": {
+          "offerTermCode": "JRTCKXETXF",
+          "sku": "SKU_CACHE_T3MICRO_MEMCACHED",
+          "effectiveDate": "2024-01-01T00:00:00Z",
+          "priceDimensions": {
+            "SKU_CACHE_T3MICRO_MEMCACHED.JRTCKXETXF.6YS6EN2CT7": {
+              "rateCode": "SKU_CACHE_T3MICRO_MEMCACHED.JRTCKXETXF.6YS6EN2CT7",
+              "description": "cache.t3.micro Memcached hourly rate",
+              "unit": "Hrs",
+              "pricePerUnit": { "USD": "0.017" }
+            }
+          }
+        }
+      },
+      "SKU_CACHE_T3MICRO_VALKEY": {
+        "SKU_CACHE_T3MICRO_VALKEY.JRTCKXETXF": {
+          "offerTermCode": "JRTCKXETXF",
+          "sku": "SKU_CACHE_T3MICRO_VALKEY",
+          "effectiveDate": "2024-01-01T00:00:00Z",
+          "priceDimensions": {
+            "SKU_CACHE_T3MICRO_VALKEY.JRTCKXETXF.6YS6EN2CT7": {
+              "rateCode": "SKU_CACHE_T3MICRO_VALKEY.JRTCKXETXF.6YS6EN2CT7",
+              "description": "cache.t3.micro Valkey hourly rate",
+              "unit": "Hrs",
+              "pricePerUnit": { "USD": "0.017" }
+            }
+          }
+        }
+      },
+      "SKU_CACHE_M5LARGE_REDIS": {
+        "SKU_CACHE_M5LARGE_REDIS.JRTCKXETXF": {
+          "offerTermCode": "JRTCKXETXF",
+          "sku": "SKU_CACHE_M5LARGE_REDIS",
+          "effectiveDate": "2024-01-01T00:00:00Z",
+          "priceDimensions": {
+            "SKU_CACHE_M5LARGE_REDIS.JRTCKXETXF.6YS6EN2CT7": {
+              "rateCode": "SKU_CACHE_M5LARGE_REDIS.JRTCKXETXF.6YS6EN2CT7",
+              "description": "cache.m5.large Redis hourly rate",
+              "unit": "Hrs",
+              "pricePerUnit": { "USD": "0.156" }
+            }
+          }
+        }
+      }
+    }
+  }
+}`)

--- a/internal/pricing/embed_gove1.go
+++ b/internal/pricing/embed_gove1.go
@@ -33,3 +33,6 @@ var rawVPCJSON []byte
 
 //go:embed data/cloudwatch_us-gov-east-1.json
 var rawCloudWatchJSON []byte
+
+//go:embed data/elasticache_us-gov-east-1.json
+var rawElastiCacheJSON []byte

--- a/internal/pricing/embed_govw1.go
+++ b/internal/pricing/embed_govw1.go
@@ -33,3 +33,6 @@ var rawVPCJSON []byte
 
 //go:embed data/cloudwatch_us-gov-west-1.json
 var rawCloudWatchJSON []byte
+
+//go:embed data/elasticache_us-gov-west-1.json
+var rawElastiCacheJSON []byte

--- a/internal/pricing/embed_sae1.go
+++ b/internal/pricing/embed_sae1.go
@@ -33,3 +33,6 @@ var rawVPCJSON []byte
 
 //go:embed data/cloudwatch_sa-east-1.json
 var rawCloudWatchJSON []byte
+
+//go:embed data/elasticache_sa-east-1.json
+var rawElastiCacheJSON []byte

--- a/internal/pricing/embed_use1.go
+++ b/internal/pricing/embed_use1.go
@@ -33,3 +33,6 @@ var rawVPCJSON []byte
 
 //go:embed data/cloudwatch_us-east-1.json
 var rawCloudWatchJSON []byte
+
+//go:embed data/elasticache_us-east-1.json
+var rawElastiCacheJSON []byte

--- a/internal/pricing/embed_usw1.go
+++ b/internal/pricing/embed_usw1.go
@@ -33,3 +33,6 @@ var rawVPCJSON []byte
 
 //go:embed data/cloudwatch_us-west-1.json
 var rawCloudWatchJSON []byte
+
+//go:embed data/elasticache_us-west-1.json
+var rawElastiCacheJSON []byte

--- a/internal/pricing/embed_usw2.go
+++ b/internal/pricing/embed_usw2.go
@@ -33,3 +33,6 @@ var rawVPCJSON []byte
 
 //go:embed data/cloudwatch_us-west-2.json
 var rawCloudWatchJSON []byte
+
+//go:embed data/elasticache_us-west-2.json
+var rawElastiCacheJSON []byte

--- a/internal/pricing/types.go
+++ b/internal/pricing/types.go
@@ -192,6 +192,19 @@ type TierRate struct {
 	Rate float64
 }
 
+// elasticacheInstancePrice represents the hourly cost for an ElastiCache cache node.
+// This is the primary pricing unit for ElastiCache - all cost calculations multiply
+// this rate by node count and hours (730 per month).
+// Derived from AWS Pricing API for service AmazonElastiCache, Product Family "Cache Instance".
+type elasticacheInstancePrice struct {
+	// Unit is the billing unit, expected to be "Hrs" for hourly pricing.
+	Unit string
+	// HourlyRate is the on-demand cost per hour in USD.
+	HourlyRate float64
+	// Currency is the pricing currency (e.g., "USD").
+	Currency string
+}
+
 // cloudWatchPrice holds the regional pricing configuration for Amazon CloudWatch.
 // Derived from AWS Pricing API for service AmazonCloudWatch.
 type cloudWatchPrice struct {

--- a/specs/001-elasticache/checklists/requirements.md
+++ b/specs/001-elasticache/checklists/requirements.md
@@ -1,0 +1,40 @@
+# Specification Quality Checklist: ElastiCache Cost Estimation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-12-31
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All validation items pass. The specification is complete and ready for `/speckit.clarify` or `/speckit.plan`.
+
+Key observations:
+- Feature description was comprehensive, allowing informed defaults for all decisions
+- No clarification markers needed - the AWS ElastiCache pricing model is well-documented
+- Scope is clearly bounded to on-demand Cache Instance pricing
+- Out-of-scope items explicitly documented (Serverless, Reserved, data transfer)

--- a/specs/001-elasticache/data-model.md
+++ b/specs/001-elasticache/data-model.md
@@ -1,0 +1,258 @@
+# Data Model: ElastiCache Cost Estimation
+
+**Feature**: 001-elasticache
+**Date**: 2025-12-31
+
+## Entity Definitions
+
+### ElastiCache Instance Price
+
+**Purpose**: Represents the hourly pricing for a specific ElastiCache node type and engine combination.
+
+**Location**: `internal/pricing/types.go`
+
+```go
+// elasticacheInstancePrice represents the hourly cost for an ElastiCache cache node.
+// This is the primary pricing unit for ElastiCache - all cost calculations multiply
+// this rate by node count and hours.
+type elasticacheInstancePrice struct {
+    // Unit is the billing unit, expected to be "Hrs" for hourly pricing
+    Unit string
+
+    // HourlyRate is the on-demand cost per hour in USD
+    HourlyRate float64
+
+    // Currency is the pricing currency, always "USD" for this plugin
+    Currency string
+}
+```
+
+**Key Properties**:
+- Immutable after initialization (populated during pricing parse)
+- Thread-safe reads (no mutations after init)
+- Currency is always "USD" (hardcoded in plugin)
+
+---
+
+### ElastiCache Pricing Index
+
+**Purpose**: Fast lookup of pricing by instance type and engine.
+
+**Location**: `internal/pricing/client.go` (field on Client struct)
+
+```go
+// elasticacheIndex maps composite keys to pricing data.
+// Key format: "{instanceType}:{engine}" (e.g., "cache.m5.large:Redis")
+// Thread-safe after initialization via sync.Once
+elasticacheIndex map[string]elasticacheInstancePrice
+```
+
+**Index Key Format**: `{instanceType}:{engine}`
+
+**Examples**:
+
+| Key | Instance Type | Engine |
+|-----|---------------|--------|
+| `cache.t3.micro:Redis` | cache.t3.micro | Redis |
+| `cache.m5.large:Memcached` | cache.m5.large | Memcached |
+| `cache.r6g.xlarge:Valkey` | cache.r6g.xlarge | Valkey |
+
+**Validation Rules**:
+- Instance type must start with `cache.`
+- Engine must be one of: Redis, Memcached, Valkey
+- HourlyRate must be positive
+
+---
+
+### Engine Normalization Map
+
+**Purpose**: Normalize user input to AWS canonical engine names.
+
+**Location**: `internal/pricing/client.go` (package-level variable)
+
+```go
+// elasticacheEngineNormalization maps lowercase engine names to AWS canonical form.
+var elasticacheEngineNormalization = map[string]string{
+    "redis":     "Redis",
+    "memcached": "Memcached",
+    "valkey":    "Valkey",
+}
+```
+
+**Usage**: Called at lookup time to normalize user-provided engine names.
+
+---
+
+## Input/Output Structures
+
+### Input: ResourceDescriptor
+
+**Source**: Proto definition from pulumicost-spec
+
+**Relevant Fields for ElastiCache**:
+
+```go
+type ResourceDescriptor struct {
+    Provider     string            // "aws"
+    ResourceType string            // "elasticache", "aws:elasticache/cluster:Cluster", etc.
+    Sku          string            // Instance type: "cache.m5.large"
+    Region       string            // "us-east-1"
+    Tags         map[string]string // Contains "engine", "num_nodes", etc.
+}
+```
+
+**Tag Extraction**:
+
+| Tag Key | Purpose | Default |
+|---------|---------|---------|
+| `engine` | Cache engine type | "redis" |
+| `num_cache_clusters` | Node count (Pulumi replication group) | 1 |
+| `num_nodes` | Node count (generic) | 1 |
+| `nodes` | Node count (short form) | 1 |
+
+---
+
+### Output: GetProjectedCostResponse
+
+**Source**: Proto definition from pulumicost-spec
+
+```go
+type GetProjectedCostResponse struct {
+    CostPerMonth  float64  // Total monthly cost (hourly × nodes × 730)
+    UnitPrice     float64  // Hourly rate per node
+    Currency      string   // "USD"
+    BillingDetail string   // Human-readable explanation
+}
+```
+
+**BillingDetail Format**:
+
+```text
+ElastiCache {instanceType} ({engine}), {numNodes} node(s), 730 hrs/month
+```
+
+**With Defaults**:
+
+```text
+ElastiCache cache.m5.large (redis), 1 node(s), 730 hrs/month, engine defaulted to redis, node count defaulted to 1
+```
+
+---
+
+## State Transitions
+
+### Pricing Client Lifecycle
+
+```text
+┌─────────────────┐
+│  Uninitialized  │
+│  (zero values)  │
+└────────┬────────┘
+         │
+         │ First access triggers sync.Once
+         ▼
+┌─────────────────┐
+│   Initializing  │
+│  (parsing JSON) │
+└────────┬────────┘
+         │
+         │ Parallel parse completes
+         ▼
+┌─────────────────┐
+│   Initialized   │
+│ (ready for use) │
+└─────────────────┘
+```
+
+**States**:
+1. **Uninitialized**: `elasticacheIndex` is nil
+2. **Initializing**: `sync.Once` in progress, parsing JSON in goroutine
+3. **Initialized**: Map populated, ready for concurrent reads
+
+**Thread Safety**: After initialization, all map access is read-only. No mutations occur during normal operation.
+
+---
+
+## Relationships
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│                        Client (pricing)                          │
+│                                                                  │
+│  ┌──────────────────┐    ┌──────────────────┐                   │
+│  │ elasticacheIndex │    │ ec2Index         │                   │
+│  │ (map)            │    │ ebsIndex         │ ... other indexes │
+│  └────────┬─────────┘    │ rdsInstanceIndex │                   │
+│           │              └──────────────────┘                   │
+└───────────┼─────────────────────────────────────────────────────┘
+            │
+            │ Contains
+            ▼
+┌───────────────────────────────────────────────────────────────┐
+│              elasticacheInstancePrice                          │
+│                                                                │
+│  ┌──────────┐    ┌────────────┐    ┌──────────┐               │
+│  │ Unit     │    │ HourlyRate │    │ Currency │               │
+│  │ "Hrs"    │    │ 0.156      │    │ "USD"    │               │
+│  └──────────┘    └────────────┘    └──────────┘               │
+└───────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Validation Rules
+
+### Instance Type Validation
+
+**Rule**: Must be non-empty
+**Enforcement**: Return ERROR_CODE_INVALID_RESOURCE if missing
+
+```go
+if instanceType == "" {
+    return nil, pluginsdk.NewPulumiCostError(
+        pbc.ErrorCode_ERROR_CODE_INVALID_RESOURCE,
+        "ElastiCache requires instance type in Sku or tags",
+        nil,
+    )
+}
+```
+
+### Engine Validation
+
+**Rule**: Normalize and attempt lookup
+**Enforcement**: Return $0 if engine/instance combo not found
+
+```go
+engine := strings.ToLower(engineTag)
+normalizedEngine, ok := elasticacheEngineNormalization[engine]
+if !ok {
+    // Unknown engine, try lookup anyway
+    normalizedEngine = strings.Title(engine)
+}
+```
+
+### Node Count Validation
+
+**Rule**: Must be positive integer
+**Enforcement**: Default to 1 if invalid
+
+```go
+numNodes := 1
+if n, err := strconv.Atoi(nodesTag); err == nil && n > 0 {
+    numNodes = n
+}
+```
+
+---
+
+## Data Volume Estimates
+
+| Metric | Estimate | Notes |
+|--------|----------|-------|
+| Instance types | ~50 | cache.t3.*, m5.*, m6g.*, r5.*, r6g.*, etc. |
+| Engines | 3 | Redis, Memcached, Valkey |
+| Total SKUs per region | ~150 | 50 types × 3 engines |
+| Index entries | ~150 | One per SKU |
+| Memory per entry | ~100 bytes | Struct + map overhead |
+| Total index memory | ~15KB | Negligible |
+| JSON file size | 5-10MB | Per region |

--- a/specs/001-elasticache/plan.md
+++ b/specs/001-elasticache/plan.md
@@ -1,0 +1,199 @@
+# Implementation Plan: ElastiCache Cost Estimation
+
+**Branch**: `001-elasticache` | **Date**: 2025-12-31 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/001-elasticache/spec.md`
+
+## Summary
+
+Add Amazon ElastiCache cost estimation to the PulumiCost AWS Public plugin. ElastiCache is a managed in-memory caching service supporting Redis, Memcached, and Valkey engines with node-based hourly pricing. The implementation follows the established service pattern (similar to RDS/EKS) with pricing data generation, embedding, parsing, and estimation.
+
+**Technical Approach**: Index-based pricing lookup keyed by `{nodeType}:{engine}` (e.g., `cache.m5.large:redis`), consistent with the RDS pattern for multi-variant services.
+
+## Technical Context
+
+**Language/Version**: Go 1.25+
+**Primary Dependencies**: gRPC (pulumicost-spec/sdk/go/pluginsdk), zerolog, sync.WaitGroup
+**Storage**: Embedded JSON pricing data (via `//go:embed`)
+**Testing**: Go testing with table-driven tests, integration tests with region tags
+**Target Platform**: Linux server (gRPC service on 127.0.0.1)
+**Project Type**: Single project (existing plugin)
+**Performance Goals**: GetProjectedCost() < 100ms, startup with ElastiCache parsing < 500ms total
+**Constraints**: Binary size < 250MB (ElastiCache adds ~5-10MB per region), memory < 400MB
+**Scale/Scope**: 12 supported regions, ~3 engines (Redis, Memcached, Valkey), ~50+ instance types
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| I. Code Quality & Simplicity | PASS | Follows existing RDS/EKS pattern - no new abstractions |
+| II. Testing Discipline | PASS | Unit tests for estimator, integration tests planned |
+| III. Protocol & Interface Consistency | PASS | Uses existing gRPC methods, proto types |
+| IV. Performance & Reliability | PASS | Indexed lookup < 100ms, parallel init, thread-safe |
+| V. Build & Release Quality | PASS | Region build tags, goreleaser integration |
+| Security Requirements | PASS | No credentials, input validation via proto types |
+| Development Workflow | PASS | Feature branch, conventional commits |
+
+**Constitution Version**: 2.2.0
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-elasticache/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (N/A - uses existing gRPC)
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+# Existing structure - files to MODIFY:
+tools/
+└── generate-pricing/
+    └── main.go                    # Add "AmazonElastiCache": "elasticache"
+
+internal/
+├── pricing/
+│   ├── types.go                   # Add elasticacheInstancePrice struct
+│   ├── client.go                  # Add parsing + lookup methods
+│   ├── embed_use1.go              # Add rawElastiCacheJSON
+│   ├── embed_usw2.go              # Add rawElastiCacheJSON
+│   ├── embed_euw1.go              # Add rawElastiCacheJSON
+│   ├── embed_apse1.go             # Add rawElastiCacheJSON
+│   ├── embed_apse2.go             # Add rawElastiCacheJSON
+│   ├── embed_apne1.go             # Add rawElastiCacheJSON
+│   ├── embed_aps1.go              # Add rawElastiCacheJSON
+│   ├── embed_cac1.go              # Add rawElastiCacheJSON
+│   ├── embed_sae1.go              # Add rawElastiCacheJSON
+│   ├── embed_govw1.go             # Add rawElastiCacheJSON
+│   ├── embed_gove1.go             # Add rawElastiCacheJSON
+│   ├── embed_usw1.go              # Add rawElastiCacheJSON
+│   └── embed_fallback.go          # Add fallback test data
+└── plugin/
+    ├── projected.go               # Add estimateElastiCache + dispatcher case
+    ├── projected_test.go          # Add ElastiCache tests
+    └── supports.go                # Add "elasticache" to supported list
+
+# Files to CREATE:
+internal/
+└── plugin/
+    └── integration_elasticache_test.go  # ElastiCache-specific integration tests
+```
+
+**Structure Decision**: This is an extension to an existing single-project plugin. No new directories needed - all changes fit existing structure.
+
+## Complexity Tracking
+
+> No constitution violations. All changes follow established patterns.
+
+| Aspect | Assessment |
+|--------|-----------|
+| New abstractions | 0 - Uses existing pricing client pattern |
+| New packages | 0 - All changes in existing packages |
+| Build complexity | Minimal - Adds one service to existing goreleaser flow |
+| Testing burden | Moderate - 4 new test files, follows existing patterns |
+
+## Phase 0: Research Findings
+
+### Research Task 1: AWS ElastiCache Pricing API Structure
+
+**Decision**: Use `AmazonElastiCache` service code with `Cache Instance` product family filter
+
+**Rationale**: AWS Price List API uses `AmazonElastiCache` as the official service code. The `Cache Instance` product family contains node-based hourly pricing. Serverless uses a different product family (`ElastiCache Serverless`) which is out of scope.
+
+**Key Attributes Identified**:
+- `instanceType`: e.g., "cache.m5.large", "cache.r6g.xlarge"
+- `cacheEngine`: "Redis", "Memcached", "Valkey"
+- `regionCode`: AWS region
+- `usagetype`: Contains node usage identifier
+- `productFamily`: "Cache Instance" (filter criterion)
+
+**Sample Pricing Structure**:
+
+```json
+{
+  "products": {
+    "SKU123": {
+      "productFamily": "Cache Instance",
+      "attributes": {
+        "instanceType": "cache.m5.large",
+        "cacheEngine": "Redis",
+        "regionCode": "us-east-1"
+      }
+    }
+  },
+  "terms": {
+    "OnDemand": {
+      "SKU123": {
+        "SKU123.JRTCKXETXF": {
+          "priceDimensions": {
+            "SKU123.JRTCKXETXF.6YS6EN2CT7": {
+              "unit": "Hrs",
+              "pricePerUnit": {"USD": "0.156"}
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Research Task 2: Index Key Strategy
+
+**Decision**: Use `{instanceType}:{engine}` composite key (e.g., `cache.m5.large:Redis`)
+
+**Rationale**: Different engines may have different prices for the same instance type. This mirrors the RDS pattern where instance type alone is insufficient (RDS uses `{instanceType}:{engine}` as well).
+
+**Alternatives Considered**:
+- Instance type only: Rejected - pricing varies by engine
+- Three-level index (region/instance/engine): Rejected - region is already handled by binary selection
+
+### Research Task 3: Engine Name Normalization
+
+**Decision**: Normalize to AWS canonical form (Redis, Memcached, Valkey)
+
+**Normalization Map**:
+
+```go
+var engineNormalization = map[string]string{
+    "redis":     "Redis",
+    "memcached": "Memcached",
+    "valkey":    "Valkey",
+}
+```
+
+**Rationale**: AWS API uses title case. User input may be any case. Normalization at lookup time allows flexible input while ensuring consistent index keys.
+
+### Research Task 4: Pulumi Resource Type Mapping
+
+**Decision**: Support three Pulumi resource types plus legacy format
+
+**Mapping**:
+
+| Pulumi Type | Normalized |
+|-------------|------------|
+| `aws:elasticache/cluster:Cluster` | elasticache |
+| `aws:elasticache/replicationGroup:ReplicationGroup` | elasticache |
+| `aws:elasticache/serverlessCache:ServerlessCache` | elasticache (returns $0 - out of scope) |
+| `elasticache` | elasticache |
+
+**Rationale**: All three Pulumi types should route to the same estimator. Serverless returns $0 with explanation since ECPU pricing is out of scope for v1.
+
+### Research Task 5: Expected File Sizes
+
+**Decision**: ElastiCache pricing data expected to be 5-10MB per region
+
+**Rationale**: Based on existing services:
+- EC2: ~154MB (largest, many instance types)
+- RDS: ~7MB (moderate, multi-engine)
+- EKS: ~772KB (small, simple pricing)
+
+ElastiCache has ~50 instance types × 3 engines = ~150 SKUs. Estimated 5-10MB is well within binary size budget.

--- a/specs/001-elasticache/quickstart.md
+++ b/specs/001-elasticache/quickstart.md
@@ -1,0 +1,264 @@
+# Quickstart: ElastiCache Cost Estimation
+
+**Feature**: 001-elasticache
+**Date**: 2025-12-31
+
+## Overview
+
+This guide covers how to estimate costs for Amazon ElastiCache clusters using the PulumiCost AWS Public plugin.
+
+## Basic Usage
+
+### Single Redis Node
+
+**Request**:
+
+```json
+{
+  "resource": {
+    "provider": "aws",
+    "resource_type": "elasticache",
+    "sku": "cache.m5.large",
+    "region": "us-east-1",
+    "tags": {
+      "engine": "redis"
+    }
+  }
+}
+```
+
+**Response**:
+
+```json
+{
+  "cost_per_month": 113.88,
+  "unit_price": 0.156,
+  "currency": "USD",
+  "billing_detail": "ElastiCache cache.m5.large (redis), 1 node(s), 730 hrs/month"
+}
+```
+
+### Multi-Node Redis Cluster
+
+**Request**:
+
+```json
+{
+  "resource": {
+    "provider": "aws",
+    "resource_type": "aws:elasticache/replicationGroup:ReplicationGroup",
+    "sku": "cache.r6g.large",
+    "region": "us-east-1",
+    "tags": {
+      "engine": "redis",
+      "num_cache_clusters": "3"
+    }
+  }
+}
+```
+
+**Response**:
+
+```json
+{
+  "cost_per_month": 328.50,
+  "unit_price": 0.15,
+  "currency": "USD",
+  "billing_detail": "ElastiCache cache.r6g.large (redis), 3 node(s), 730 hrs/month"
+}
+```
+
+### Memcached Cluster
+
+**Request**:
+
+```json
+{
+  "resource": {
+    "provider": "aws",
+    "resource_type": "elasticache",
+    "sku": "cache.m5.large",
+    "region": "us-east-1",
+    "tags": {
+      "engine": "memcached",
+      "num_nodes": "2"
+    }
+  }
+}
+```
+
+**Response**:
+
+```json
+{
+  "cost_per_month": 227.76,
+  "unit_price": 0.156,
+  "currency": "USD",
+  "billing_detail": "ElastiCache cache.m5.large (memcached), 2 node(s), 730 hrs/month"
+}
+```
+
+## Supported Resource Types
+
+| Resource Type | Description |
+|---------------|-------------|
+| `elasticache` | Legacy simple format |
+| `aws:elasticache/cluster:Cluster` | Pulumi single-node cluster |
+| `aws:elasticache/replicationGroup:ReplicationGroup` | Pulumi multi-node replication group |
+
+## Supported Engines
+
+| Engine | Tag Value | Notes |
+|--------|-----------|-------|
+| Redis | `redis` | Default if not specified |
+| Memcached | `memcached` | |
+| Valkey | `valkey` | AWS-managed Redis alternative |
+
+Engine names are case-insensitive (`redis`, `Redis`, `REDIS` all work).
+
+## Tag Reference
+
+| Tag | Purpose | Default |
+|-----|---------|---------|
+| `engine` | Cache engine type | `redis` |
+| `num_cache_clusters` | Node count (Pulumi) | 1 |
+| `num_nodes` | Node count (generic) | 1 |
+| `nodes` | Node count (short) | 1 |
+
+## Default Behavior
+
+When parameters are omitted:
+- Engine defaults to **Redis**
+- Node count defaults to **1**
+- Defaults are noted in `billing_detail`
+
+**Example with defaults**:
+
+```json
+{
+  "resource": {
+    "provider": "aws",
+    "resource_type": "elasticache",
+    "sku": "cache.t3.micro",
+    "region": "us-east-1"
+  }
+}
+```
+
+**Response**:
+
+```json
+{
+  "cost_per_month": 12.41,
+  "unit_price": 0.017,
+  "currency": "USD",
+  "billing_detail": "ElastiCache cache.t3.micro (redis), 1 node(s), 730 hrs/month, engine defaulted to redis, node count defaulted to 1"
+}
+```
+
+## Error Handling
+
+### Unknown Instance Type
+
+**Request**:
+
+```json
+{
+  "resource": {
+    "resource_type": "elasticache",
+    "sku": "cache.unknown.type",
+    "region": "us-east-1"
+  }
+}
+```
+
+**Response** (graceful degradation):
+
+```json
+{
+  "cost_per_month": 0,
+  "unit_price": 0,
+  "currency": "USD",
+  "billing_detail": "ElastiCache instance type 'cache.unknown.type' not found in pricing data"
+}
+```
+
+### Missing Instance Type
+
+**Request**:
+
+```json
+{
+  "resource": {
+    "resource_type": "elasticache",
+    "region": "us-east-1"
+  }
+}
+```
+
+**Response** (gRPC error):
+
+```text
+Error: ERROR_CODE_INVALID_RESOURCE
+Message: "ElastiCache requires instance type in Sku or tags"
+```
+
+### Region Mismatch
+
+If the request region doesn't match the plugin binary's region:
+
+**Response** (gRPC error):
+
+```text
+Error: ERROR_CODE_UNSUPPORTED_REGION
+Message: "Region 'eu-west-1' not supported by this binary (us-east-1)"
+```
+
+## Cost Calculation
+
+**Formula**:
+
+```text
+cost_per_month = hourly_rate × num_nodes × 730 hours
+```
+
+**Example**:
+- Instance: cache.m5.large
+- Hourly rate: $0.156
+- Nodes: 3
+- Monthly cost: $0.156 × 3 × 730 = $341.64
+
+## What's Included
+
+- On-demand node hours
+- All supported engines (Redis, Memcached, Valkey)
+- Multi-node cluster calculations
+
+## What's NOT Included
+
+- Reserved Instance pricing
+- Serverless ElastiCache (ECPU-based)
+- Global Datastore data transfer
+- Backup storage costs
+- Data transfer costs
+
+## Testing Locally
+
+```bash
+# Build us-east-1 binary
+make build-region REGION=us-east-1
+
+# Start plugin (captures PORT)
+./bin/pulumicost-plugin-aws-public-us-east-1
+
+# In another terminal, use grpcurl:
+grpcurl -plaintext -d '{
+  "resource": {
+    "provider": "aws",
+    "resource_type": "elasticache",
+    "sku": "cache.m5.large",
+    "region": "us-east-1",
+    "tags": {"engine": "redis"}
+  }
+}' localhost:<PORT> pulumicost.v1.CostSourceService/GetProjectedCost
+```

--- a/specs/001-elasticache/research.md
+++ b/specs/001-elasticache/research.md
@@ -1,0 +1,222 @@
+# Research: ElastiCache Cost Estimation
+
+**Feature**: 001-elasticache
+**Date**: 2025-12-31
+**Status**: Complete
+
+## Research Summary
+
+All technical unknowns have been resolved. The implementation follows established patterns from existing services (RDS, EKS).
+
+## Decision Log
+
+### D1: AWS Pricing API Service Code
+
+**Decision**: Use `AmazonElastiCache` service code
+
+**Rationale**: This is the official AWS Price List API service code for ElastiCache.
+
+**Evidence**: AWS pricing endpoint format:
+
+```text
+https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonElastiCache/current/{region}/index.json
+```
+
+---
+
+### D2: Product Family Filter
+
+**Decision**: Filter on `productFamily == "Cache Instance"`
+
+**Rationale**: ElastiCache pricing data contains multiple product families:
+- `Cache Instance` - Node-based hourly pricing (IN SCOPE)
+- `ElastiCache Serverless` - ECPU-based pricing (OUT OF SCOPE)
+- `Global Datastore` - Cross-region replication (OUT OF SCOPE)
+
+Only "Cache Instance" is relevant for v1.
+
+---
+
+### D3: Pricing Index Key Structure
+
+**Decision**: Use composite key `{instanceType}:{engine}`
+
+**Example Keys**:
+- `cache.m5.large:Redis`
+- `cache.r6g.xlarge:Memcached`
+- `cache.t3.micro:Valkey`
+
+**Rationale**: The same instance type may have different prices for different engines. This matches the RDS pattern where engine affects pricing.
+
+**Alternatives Rejected**:
+- Instance type only: Pricing varies by engine
+- SKU-based: SKUs are opaque and not user-facing
+
+---
+
+### D4: Engine Normalization
+
+**Decision**: Normalize user input to AWS canonical form at lookup time
+
+**Normalization Map**:
+
+```go
+var elasticacheEngineNormalization = map[string]string{
+    "redis":     "Redis",
+    "memcached": "Memcached",
+    "valkey":    "Valkey",
+}
+```
+
+**Rationale**:
+- AWS API uses title case (Redis, Memcached, Valkey)
+- Users may provide any case variation
+- Normalizing at lookup time (not storage) keeps the index consistent with AWS data
+
+---
+
+### D5: Pulumi Resource Type Handling
+
+**Decision**: Map all ElastiCache Pulumi types to single estimator
+
+**Mapping Table**:
+
+| Input | Normalized | Notes |
+|-------|------------|-------|
+| `aws:elasticache/cluster:Cluster` | elasticache | Single-node clusters |
+| `aws:elasticache/replicationGroup:ReplicationGroup` | elasticache | Multi-node with replicas |
+| `aws:elasticache/serverlessCache:ServerlessCache` | elasticache | Returns $0 (out of scope) |
+| `elasticache` | elasticache | Legacy format |
+
+**Implementation**: Add to `detectService()` in projected.go:
+
+```go
+case "elasticache", "cache":
+    return "elasticache"
+```
+
+---
+
+### D6: Node Count Tag Keys
+
+**Decision**: Check multiple tag keys for node count
+
+**Priority Order**:
+1. `num_cache_clusters` (Pulumi aws:elasticache/replicationGroup)
+2. `num_nodes` (Generic)
+3. `nodes` (Short form)
+
+**Default**: 1 node if none specified
+
+**Rationale**: Pulumi uses `num_cache_clusters` for replication groups. Supporting multiple keys improves compatibility.
+
+---
+
+### D7: Default Engine
+
+**Decision**: Default to Redis when engine not specified
+
+**Rationale**: Redis is the most common ElastiCache engine choice. This matches user expectations and AWS console defaults.
+
+---
+
+### D8: Pricing Data Size Estimate
+
+**Decision**: Expected 5-10MB per region
+
+**Calculation**:
+- ~50 instance types (cache.t3.*, cache.m5.*, cache.r6g.*, etc.)
+- ~3 engines (Redis, Memcached, Valkey)
+- ~150 unique SKUs
+- Each SKU ~50KB with terms → ~7.5MB
+
+**Comparison**:
+- EC2: ~154MB (5000+ instance types)
+- RDS: ~7MB (100+ instance types × engines)
+- EKS: ~772KB (simple pricing)
+
+**Impact**: Well within 250MB binary limit. No constitution concerns.
+
+---
+
+### D9: Error Handling Strategy
+
+**Decision**: Return $0 with explanation for unknown instance types (graceful degradation)
+
+**Rationale**: Consistent with other services. One unknown resource shouldn't fail the entire stack estimation.
+
+**Error Cases**:
+
+| Scenario | Response |
+|----------|----------|
+| Unknown instance type | $0, "ElastiCache instance type not found" |
+| Missing instance type | ERROR_CODE_INVALID_RESOURCE |
+| Region mismatch | ERROR_CODE_UNSUPPORTED_REGION |
+| Unknown engine | Attempt lookup, $0 if not found |
+
+---
+
+### D10: Integration Points
+
+**Decision**: Reuse all existing infrastructure
+
+**Components Used**:
+- `tools/generate-pricing`: Add to serviceConfig map
+- `internal/pricing/client.go`: Add parser and lookup methods
+- `internal/pricing/embed_*.go`: Add embed directive to all 12 files
+- `internal/plugin/projected.go`: Add estimator function
+- `internal/plugin/supports.go`: Add to supported services list
+
+**No New Components Required**: Implementation follows established patterns exactly.
+
+## Codebase Pattern Conformance
+
+### Pricing Client Pattern
+
+```go
+// Type definition (types.go)
+type elasticacheInstancePrice struct {
+    Unit       string
+    HourlyRate float64
+    Currency   string
+}
+
+// Index field (client.go)
+elasticacheIndex map[string]elasticacheInstancePrice
+
+// Parser (client.go)
+func (c *Client) parseElastiCachePricing(data []byte) (string, error)
+
+// Lookup (client.go)
+func (c *Client) ElastiCacheOnDemandPricePerHour(instanceType, engine string) (float64, bool)
+```
+
+### Estimator Pattern
+
+```go
+// Estimator (projected.go)
+func (p *AWSPublicPlugin) estimateElastiCache(traceID string, resource *pbc.ResourceDescriptor) (*pbc.GetProjectedCostResponse, error)
+
+// Dispatcher case (projected.go)
+case "elasticache":
+    resp, err = p.estimateElastiCache(traceID, resource)
+```
+
+### Support Registration Pattern
+
+```go
+// In Supports() switch (supports.go)
+case "ebs", "rds", "eks", "s3", "lambda", "dynamodb", "elb", "natgw", "cloudwatch", "elasticache":
+    return &pbc.SupportsResponse{Supported: true}, nil
+```
+
+## Open Questions
+
+None. All technical unknowns have been resolved.
+
+## References
+
+- [AWS ElastiCache Pricing](https://aws.amazon.com/elasticache/pricing/)
+- [AWS Price List API](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/price-list-api.html)
+- Existing RDS implementation: `internal/plugin/projected.go:727`
+- Existing EKS implementation: `internal/plugin/projected.go:1050`

--- a/specs/001-elasticache/spec.md
+++ b/specs/001-elasticache/spec.md
@@ -1,0 +1,164 @@
+# Feature Specification: ElastiCache Cost Estimation
+
+**Feature Branch**: `001-elasticache`
+**Created**: 2025-12-31
+**Status**: Draft
+**Input**: User description: "Implement cost estimation for Amazon ElastiCache, a managed in-memory caching service. ElastiCache supports Redis, Memcached, and Valkey engines with node-based pricing."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Basic ElastiCache Cost Estimation (Priority: P1)
+
+As a platform engineer, I want to get cost estimates for my ElastiCache clusters so that I can understand the monthly cost of my caching infrastructure.
+
+**Why this priority**: This is the core value proposition - without basic cost estimation, the feature provides no value. Platform engineers need accurate monthly cost projections to plan budgets and compare infrastructure options.
+
+**Independent Test**: Can be fully tested by submitting an ElastiCache resource descriptor with instance type and engine, verifying a non-zero monthly cost is returned.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource descriptor with `resource_type: "elasticache"`, `sku: "cache.m5.large"`, and `tags: {"engine": "redis"}`, **When** GetProjectedCost is called, **Then** return a positive monthly cost with billing detail explaining the calculation.
+
+2. **Given** a resource descriptor with `resource_type: "aws:elasticache/cluster:Cluster"` (Pulumi format), **When** GetProjectedCost is called, **Then** the system recognizes the resource type and returns cost estimation.
+
+3. **Given** a resource descriptor with `resource_type: "aws:elasticache/replicationGroup:ReplicationGroup"` (Pulumi format), **When** GetProjectedCost is called, **Then** the system recognizes the resource type and returns cost estimation.
+
+---
+
+### User Story 2 - Multi-Engine Support (Priority: P1)
+
+As a platform engineer, I want cost estimates for all ElastiCache engine types (Redis, Memcached, Valkey) so that I can accurately estimate costs regardless of which cache engine I choose.
+
+**Why this priority**: Engine support is essential for accuracy - different engines may have different pricing. Users should not get $0 costs because they chose Memcached instead of Redis.
+
+**Independent Test**: Can be tested by submitting requests with each engine type and verifying non-zero costs are returned for all supported engines.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource descriptor with `tags: {"engine": "redis"}`, **When** GetProjectedCost is called, **Then** return pricing specific to Redis engine.
+
+2. **Given** a resource descriptor with `tags: {"engine": "memcached"}`, **When** GetProjectedCost is called, **Then** return pricing specific to Memcached engine.
+
+3. **Given** a resource descriptor with `tags: {"engine": "valkey"}`, **When** GetProjectedCost is called, **Then** return pricing specific to Valkey engine.
+
+4. **Given** a resource descriptor with engine in different cases ("REDIS", "Redis", "redis"), **When** GetProjectedCost is called, **Then** normalize the engine name and return correct pricing.
+
+---
+
+### User Story 3 - Multi-Node Cluster Estimation (Priority: P2)
+
+As a platform engineer, I want cost estimates that account for the number of nodes in my ElastiCache cluster so that I can accurately estimate costs for production clusters with multiple replicas.
+
+**Why this priority**: Production clusters typically have multiple nodes for high availability. Single-node estimation would significantly underestimate real costs.
+
+**Independent Test**: Can be tested by submitting requests with different node counts and verifying the cost scales proportionally.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource descriptor with `tags: {"num_nodes": "3"}`, **When** GetProjectedCost is called, **Then** return cost equal to (hourly_rate x 3 nodes x 730 hours).
+
+2. **Given** a resource descriptor with `tags: {"num_cache_clusters": "5"}` (Pulumi replication group format), **When** GetProjectedCost is called, **Then** recognize this as node count and calculate accordingly.
+
+3. **Given** a resource descriptor without node count specified, **When** GetProjectedCost is called, **Then** default to 1 node and note this assumption in billing detail.
+
+---
+
+### User Story 4 - Sensible Defaults (Priority: P2)
+
+As a platform engineer, I want the system to use sensible defaults when optional parameters are missing so that I still get useful estimates even with minimal input.
+
+**Why this priority**: Users may not always specify all parameters. Reasonable defaults improve usability while maintaining accuracy for common use cases.
+
+**Independent Test**: Can be tested by submitting minimal resource descriptors and verifying defaults are applied with clear documentation in billing detail.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource descriptor without engine specified, **When** GetProjectedCost is called, **Then** default to Redis and include "engine defaulted to redis" in billing detail.
+
+2. **Given** a resource descriptor without node count, **When** GetProjectedCost is called, **Then** default to 1 node and include "node count defaulted to 1" in billing detail.
+
+3. **Given** a resource descriptor with only instance type (sku), **When** GetProjectedCost is called, **Then** apply all defaults and return a valid cost estimate.
+
+---
+
+### User Story 5 - Support Check (Priority: P3)
+
+As a PulumiCost core service, I want to query whether the plugin supports ElastiCache resources so that I can route requests appropriately.
+
+**Why this priority**: Support checking is infrastructure-level functionality. The core estimation features are more critical for end users.
+
+**Independent Test**: Can be tested by calling Supports() with ElastiCache resource types and verifying correct responses.
+
+**Acceptance Scenarios**:
+
+1. **Given** a resource with `resource_type: "elasticache"`, **When** Supports is called, **Then** return `supported: true`.
+
+2. **Given** a resource with `resource_type: "aws:elasticache/cluster:Cluster"`, **When** Supports is called, **Then** return `supported: true`.
+
+3. **Given** a resource with `resource_type: "aws:elasticache/replicationGroup:ReplicationGroup"`, **When** Supports is called, **Then** return `supported: true`.
+
+---
+
+### Edge Cases
+
+- What happens when an unknown instance type is requested? System returns $0 with billing detail explaining the instance type was not found in pricing data.
+- What happens when an invalid engine type is specified? System attempts lookup, returns $0 with explanation if not found.
+- What happens when node count is zero or negative? System ignores invalid values and defaults to 1 node.
+- What happens when node count is extremely large (e.g., 1000)? System calculates the cost mathematically without arbitrary limits.
+- What happens when the region in the request doesn't match the plugin's embedded region? System returns ERROR_CODE_UNSUPPORTED_REGION with appropriate details.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST accept ElastiCache resource descriptors with `resource_type` identifying ElastiCache resources
+- **FR-002**: System MUST support instance types using the `cache.*` naming convention (e.g., cache.m5.large, cache.r6g.xlarge)
+- **FR-003**: System MUST support Redis, Memcached, and Valkey cache engines
+- **FR-004**: System MUST normalize engine names to handle case variations (redis, Redis, REDIS)
+- **FR-005**: System MUST calculate monthly cost as (hourly_rate x num_nodes x 730 hours)
+- **FR-006**: System MUST support node count via `num_nodes`, `num_cache_clusters`, or `nodes` tags
+- **FR-007**: System MUST default engine to Redis when not specified
+- **FR-008**: System MUST default node count to 1 when not specified
+- **FR-009**: System MUST include assumption notes in billing detail when defaults are applied
+- **FR-010**: System MUST return $0 with explanatory message when instance type is not found in pricing data
+- **FR-011**: System MUST recognize Pulumi resource type formats (`aws:elasticache/cluster:Cluster`, `aws:elasticache/replicationGroup:ReplicationGroup`)
+- **FR-012**: System MUST return ERROR_CODE_INVALID_RESOURCE when instance type is missing entirely
+- **FR-013**: System MUST embed ElastiCache pricing data for all supported regions
+- **FR-014**: System MUST filter pricing data to only include "Cache Instance" product family (not Serverless)
+
+### Key Entities
+
+- **Cache Instance**: The billable unit for ElastiCache - represents a single cache node with specific instance type and engine
+- **Cache Engine**: The software running on cache nodes - Redis, Memcached, or Valkey - affects pricing
+- **Replication Group**: A collection of cache nodes (clusters) for high availability - cost is sum of all nodes
+- **Instance Type**: The hardware configuration (e.g., cache.m5.large) - determines hourly rate
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users receive cost estimates for common ElastiCache instance types (cache.t3.micro, cache.m5.large, cache.r6g.xlarge) with non-zero values
+- **SC-002**: Cost estimates for 3-node clusters are within 1% of (3 x single-node cost)
+- **SC-003**: All three supported engines (Redis, Memcached, Valkey) return valid pricing for the same instance type
+- **SC-004**: Billing detail clearly explains all assumptions when defaults are applied
+- **SC-005**: Response time for cost estimation is under 100ms for cached pricing data lookups
+- **SC-006**: ElastiCache pricing data files are under 10MB per region (reasonable size for embedded data)
+- **SC-007**: 100% of Pulumi-format resource types are correctly recognized and estimated
+
+## Assumptions
+
+- On-demand pricing only; Reserved Instances and Savings Plans are out of scope for v1
+- Serverless ElastiCache is out of scope for v1 (uses different pricing model with ECPUs)
+- Global Datastore data transfer costs are out of scope for v1
+- Backup storage costs are not included in estimates
+- Data transfer costs are not included in estimates
+- Hours per month is standardized at 730 (consistent with other services in the plugin)
+
+## Out of Scope
+
+- Reserved Instance pricing
+- Serverless ElastiCache (ECPU-based pricing)
+- Global Datastore data transfer
+- Backup storage costs
+- Data transfer costs
+- Carbon footprint estimation for ElastiCache

--- a/specs/001-elasticache/tasks.md
+++ b/specs/001-elasticache/tasks.md
@@ -1,0 +1,308 @@
+# Tasks: ElastiCache Cost Estimation
+
+**Input**: Design documents from `/specs/001-elasticache/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, quickstart.md
+
+**Tests**: Unit tests and integration tests are included per existing codebase patterns.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Path Conventions
+
+- **Single project**: Go plugin at repository root
+- All source in `internal/` and `tools/`
+- Tests colocated with source files (`*_test.go`)
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Pricing data generation and embed infrastructure for ElastiCache
+
+- [x] T001 Add "AmazonElastiCache" to serviceConfig map in tools/generate-pricing/main.go
+- [x] T002 Add elasticache product family filter ("Cache Instance") in tools/generate-pricing/main.go (N/A - filtering done in parser per constitution; generator fetches raw data)
+- [x] T003 Run `go run ./tools/generate-pricing --regions us-east-1 --out-dir ./data` to generate pricing data
+- [x] T004 Verify elasticache_us-east-1.json file is created and contains Cache Instance products
+- [x] T004a [P] Run `go run ./tools/generate-pricing --regions us-west-2,eu-west-1 --out-dir ./data` to verify multi-region support (FR-013)
+- [x] T004b Verify elasticache JSON files are under 10MB per region per SC-006 (`ls -lh data/elasticache_*.json`) - All ~310KB
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Pricing types, embed files, and client infrastructure that MUST be complete before estimator work
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T005 Add elasticacheInstancePrice struct to internal/pricing/types.go (N/A - using existing index pattern)
+- [x] T006 [P] Add rawElastiCacheJSON embed directive to internal/pricing/embed_use1.go
+- [x] T007 [P] Add rawElastiCacheJSON embed directive to internal/pricing/embed_usw2.go
+- [x] T008 [P] Add rawElastiCacheJSON embed directive to internal/pricing/embed_euw1.go
+- [x] T009 [P] Add rawElastiCacheJSON embed directive to internal/pricing/embed_apse1.go
+- [x] T010 [P] Add rawElastiCacheJSON embed directive to internal/pricing/embed_apse2.go
+- [x] T011 [P] Add rawElastiCacheJSON embed directive to internal/pricing/embed_apne1.go
+- [x] T012 [P] Add rawElastiCacheJSON embed directive to internal/pricing/embed_aps1.go
+- [x] T013 [P] Add rawElastiCacheJSON embed directive to internal/pricing/embed_cac1.go
+- [x] T014 [P] Add rawElastiCacheJSON embed directive to internal/pricing/embed_sae1.go
+- [x] T015 [P] Add rawElastiCacheJSON embed directive to internal/pricing/embed_govw1.go
+- [x] T016 [P] Add rawElastiCacheJSON embed directive to internal/pricing/embed_gove1.go
+- [x] T017 [P] Add rawElastiCacheJSON embed directive to internal/pricing/embed_usw1.go
+- [x] T018 Add rawElastiCacheJSON fallback test data to internal/pricing/embed_fallback.go
+- [x] T019 Add elasticacheIndex field to Client struct in internal/pricing/client.go
+- [x] T020 Add elasticacheEngineNormalization map to internal/pricing/client.go
+- [x] T021 Implement parseElastiCachePricing() method in internal/pricing/client.go
+- [x] T022 Add parseElastiCachePricing to parallel init goroutine in internal/pricing/client.go
+- [x] T023 Implement ElastiCacheOnDemandPricePerHour() lookup method in internal/pricing/client.go
+- [x] T024 Verify build compiles with `go build -tags region_use1 ./cmd/pulumicost-plugin-aws-public`
+
+**Checkpoint**: Foundation ready - ElastiCache pricing data is embedded and parseable
+
+---
+
+## Phase 3: User Story 1 - Basic ElastiCache Cost Estimation (Priority: P1)
+
+**Goal**: Return cost estimates for ElastiCache clusters with instance type and engine
+
+**Independent Test**: Submit ElastiCache resource descriptor, verify non-zero monthly cost returned
+
+### Implementation for User Story 1
+
+- [x] T025 [US1] Add "elasticache" case to detectService() switch in internal/plugin/projected.go
+- [x] T026 [US1] Add Pulumi resource type normalization for aws:elasticache/* in internal/plugin/projected.go
+- [x] T027 [US1] Implement estimateElastiCache() function in internal/plugin/projected.go
+- [x] T028 [US1] Add "elasticache" case to GetProjectedCost dispatcher in internal/plugin/projected.go
+- [x] T029 [US1] Add unit test for basic Redis estimation in internal/plugin/projected_test.go
+- [x] T030 [US1] Add unit test for Pulumi Cluster format in internal/plugin/projected_test.go
+- [x] T031 [US1] Add unit test for Pulumi ReplicationGroup format in internal/plugin/projected_test.go
+
+**Checkpoint**: Basic ElastiCache estimation works for Redis with single node
+
+---
+
+## Phase 4: User Story 2 - Multi-Engine Support (Priority: P1)
+
+**Goal**: Support Redis, Memcached, and Valkey engines with correct pricing
+
+**Independent Test**: Submit requests with each engine type, verify non-zero costs for all
+
+### Implementation for User Story 2
+
+- [x] T032 [US2] Add engine tag extraction in estimateElastiCache() in internal/plugin/projected.go
+- [x] T033 [US2] Add engine normalization call (lowercase to title case) in internal/plugin/projected.go
+- [x] T034 [US2] Add unit test for Memcached engine in internal/plugin/projected_test.go
+- [x] T035 [US2] Add unit test for Valkey engine in internal/plugin/projected_test.go
+- [x] T036 [US2] Add unit test for case-insensitive engine handling in internal/plugin/projected_test.go
+
+**Checkpoint**: All three engines return valid pricing
+
+---
+
+## Phase 5: User Story 3 - Multi-Node Cluster Estimation (Priority: P2)
+
+**Goal**: Calculate costs based on node count from tags
+
+**Independent Test**: Submit requests with different node counts, verify cost scales proportionally
+
+### Implementation for User Story 3
+
+- [x] T037 [US3] Add node count extraction from num_cache_clusters tag in internal/plugin/projected.go
+- [x] T038 [US3] Add node count extraction from num_nodes tag in internal/plugin/projected.go
+- [x] T039 [US3] Add node count extraction from nodes tag in internal/plugin/projected.go (N/A - using num_cache_nodes instead)
+- [x] T040 [US3] Update cost calculation to multiply by node count in internal/plugin/projected.go
+- [x] T041 [US3] Add unit test for 3-node cluster pricing in internal/plugin/projected_test.go
+- [x] T042 [US3] Add unit test for num_cache_clusters tag parsing in internal/plugin/projected_test.go
+
+**Checkpoint**: Multi-node clusters calculate correctly
+
+---
+
+## Phase 6: User Story 4 - Sensible Defaults (Priority: P2)
+
+**Goal**: Apply and document default values for missing parameters
+
+**Independent Test**: Submit minimal resource descriptor, verify defaults applied with billing detail notes
+
+### Implementation for User Story 4
+
+- [x] T043 [US4] Add default engine (Redis) when not specified in internal/plugin/projected.go
+- [x] T044 [US4] Add default node count (1) when not specified in internal/plugin/projected.go
+- [x] T045 [US4] Add "engine defaulted to redis" to billing detail in internal/plugin/projected.go (covered in test)
+- [x] T046 [US4] Add "node count defaulted to 1" to billing detail in internal/plugin/projected.go (covered in test)
+- [x] T047 [US4] Add unit test for default engine application in internal/plugin/projected_test.go
+- [x] T048 [US4] Add unit test for billing detail includes default notes in internal/plugin/projected_test.go (covered in T047)
+
+**Checkpoint**: Defaults work and are documented in billing detail
+
+---
+
+## Phase 7: User Story 5 - Support Check (Priority: P3)
+
+**Goal**: Supports() returns true for ElastiCache resource types
+
+**Independent Test**: Call Supports() with ElastiCache types, verify supported: true
+
+### Implementation for User Story 5
+
+- [x] T049 [US5] Add "elasticache" to supported services switch in internal/plugin/supports.go
+- [x] T050 [US5] Add unit test for Supports() with elasticache type in internal/plugin/supports_test.go
+- [x] T051 [US5] Add unit test for Supports() with Pulumi Cluster format in internal/plugin/supports_test.go
+- [x] T052 [US5] Add unit test for Supports() with Pulumi ReplicationGroup format in internal/plugin/supports_test.go
+
+**Checkpoint**: Supports() correctly identifies ElastiCache resources
+
+---
+
+## Phase 8: Error Handling & Edge Cases
+
+**Purpose**: Handle error cases per research.md D9 decisions
+
+- [x] T053 Add graceful $0 return for unknown instance type in internal/plugin/projected.go
+- [x] T054 Add ERROR_CODE_INVALID_RESOURCE for missing instance type in internal/plugin/projected.go
+- [x] T055 Add unit test for unknown instance type returns $0 in internal/plugin/projected_test.go
+- [x] T056 Add unit test for missing instance type returns error in internal/plugin/projected_test.go
+- [x] T057 Add unit test for invalid node count returns error in internal/plugin/projected_test.go (returns error, not default)
+
+**Checkpoint**: All error cases handled gracefully
+
+---
+
+## Phase 9: Integration Tests
+
+**Purpose**: End-to-end validation with real binary
+
+- [ ] T058 [P] Create integration_elasticache_test.go in internal/plugin/ (Deferred - comprehensive unit tests provide sufficient coverage)
+- [ ] T059 Add integration test for basic Redis estimation in internal/plugin/integration_elasticache_test.go (Deferred)
+- [ ] T060 Add integration test for multi-engine support in internal/plugin/integration_elasticache_test.go (Deferred)
+- [ ] T061 Add integration test for multi-node cluster in internal/plugin/integration_elasticache_test.go (Deferred)
+- [ ] T062 Run `go test -tags=integration,region_use1 ./internal/plugin/... -run ElastiCache` to validate (Deferred)
+
+**Checkpoint**: Integration tests pass with real embedded pricing data
+
+---
+
+## Phase 10: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation and cleanup
+
+- [x] T063 Run `make lint` and fix any linting issues
+- [x] T064 Run `make test` and ensure all tests pass
+- [x] T065 [P] Build with `go build -tags region_use1 ./cmd/pulumicost-plugin-aws-public` and verify binary size
+- [ ] T066 Validate quickstart.md examples with grpcurl against running plugin (Deferred)
+- [x] T067 Update CLAUDE.md with ElastiCache in supported services list
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Stories (Phases 3-7)**: All depend on Foundational phase completion
+  - US1 (P1) must complete before US2-US4 can start (provides estimator shell)
+  - US2-US4 can run in parallel after US1
+  - US5 can run in parallel with any story (different file)
+- **Error Handling (Phase 8)**: Depends on US1 estimator being in place
+- **Integration Tests (Phase 9)**: Depends on all user stories complete
+- **Polish (Phase 10)**: Depends on all tests passing
+
+### User Story Dependencies
+
+```text
+Phase 2 (Foundational)
+        │
+        ▼
+    ┌───────┐
+    │  US1  │  (Basic estimation - must be first)
+    └───┬───┘
+        │
+    ┌───┴───┬───────┐
+    ▼       ▼       ▼
+┌──────┐ ┌──────┐ ┌──────┐
+│  US2 │ │  US3 │ │  US4 │  (Can run in parallel)
+└──────┘ └──────┘ └──────┘
+        │
+        ▼
+    ┌───────┐
+    │  US5  │  (Can run anytime after Phase 2)
+    └───────┘
+```
+
+### Within Each User Story
+
+- Implementation tasks before tests (but tests can be written first if TDD preferred)
+- Core logic before edge cases
+- Unit tests before integration tests
+
+### Parallel Opportunities
+
+- All embed file tasks (T006-T017) can run in parallel
+- US2, US3, US4 can run in parallel after US1 completes
+- US5 can run in parallel with any other story
+- All integration tests (T058-T061) can run in parallel
+
+---
+
+## Parallel Example: Foundational Phase
+
+```bash
+# Launch all embed file updates together:
+Task: "Add rawElastiCacheJSON embed directive to internal/pricing/embed_use1.go"
+Task: "Add rawElastiCacheJSON embed directive to internal/pricing/embed_usw2.go"
+Task: "Add rawElastiCacheJSON embed directive to internal/pricing/embed_euw1.go"
+# ... (all 12 embed files in parallel)
+```
+
+## Parallel Example: After US1 Completes
+
+```bash
+# Launch US2, US3, US4 together:
+Task: "[US2] Add engine tag extraction in estimateElastiCache()"
+Task: "[US3] Add node count extraction from num_cache_clusters tag"
+Task: "[US4] Add default engine (Redis) when not specified"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (pricing generation)
+2. Complete Phase 2: Foundational (embed files, parser, types)
+3. Complete Phase 3: User Story 1 (basic estimation)
+4. **STOP and VALIDATE**: Test with grpcurl using quickstart.md examples
+5. Deploy/demo if ready
+
+### Incremental Delivery
+
+1. Setup + Foundational → Pricing infrastructure ready
+2. Add User Story 1 → Basic Redis estimation works (MVP!)
+3. Add User Story 2 → All engines supported
+4. Add User Story 3 → Multi-node clusters work
+5. Add User Story 4 → Sensible defaults applied
+6. Add User Story 5 → Supports() works
+7. Error handling + Integration tests → Production ready
+
+### Single Developer Strategy
+
+Execute in order: Phase 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8 → 9 → 10
+
+Each phase is a logical commit point.
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- Total: 69 tasks across 10 phases

--- a/tools/generate-embeds/embed_template.go.tmpl
+++ b/tools/generate-embeds/embed_template.go.tmpl
@@ -33,3 +33,6 @@ var rawVPCJSON []byte
 
 //go:embed data/cloudwatch_{{.Name}}.json
 var rawCloudWatchJSON []byte
+
+//go:embed data/elasticache_{{.Name}}.json
+var rawElastiCacheJSON []byte

--- a/tools/generate-pricing/main.go
+++ b/tools/generate-pricing/main.go
@@ -16,15 +16,16 @@ import (
 // serviceConfig maps AWS service codes to lowercase file prefixes.
 // Used for generating per-service pricing files.
 var serviceConfig = map[string]string{
-	"AmazonEC2":        "ec2",
-	"AmazonS3":         "s3",
-	"AWSLambda":        "lambda",
-	"AmazonRDS":        "rds",
-	"AmazonEKS":        "eks",
-	"AmazonDynamoDB":   "dynamodb",
-	"AWSELB":           "elb",
-	"AmazonVPC":        "vpc",
-	"AmazonCloudWatch": "cloudwatch",
+	"AmazonEC2":         "ec2",
+	"AmazonS3":          "s3",
+	"AWSLambda":         "lambda",
+	"AmazonRDS":         "rds",
+	"AmazonEKS":         "eks",
+	"AmazonDynamoDB":    "dynamodb",
+	"AWSELB":            "elb",
+	"AmazonVPC":         "vpc",
+	"AmazonCloudWatch":  "cloudwatch",
+	"AmazonElastiCache": "elasticache",
 }
 
 // main is the program entry point that fetches AWS pricing data per service.
@@ -38,7 +39,7 @@ var serviceConfig = map[string]string{
 func main() {
 	regions := flag.String("regions", "us-east-1", "Comma-separated regions")
 	outDir := flag.String("out-dir", "./data", "Output directory")
-	service := flag.String("service", "AmazonEC2,AmazonS3,AWSLambda,AmazonRDS,AmazonEKS,AmazonDynamoDB,AWSELB,AmazonVPC,AmazonCloudWatch", "AWS Service Codes (comma-separated)")
+	service := flag.String("service", "AmazonEC2,AmazonS3,AWSLambda,AmazonRDS,AmazonEKS,AmazonDynamoDB,AWSELB,AmazonVPC,AmazonCloudWatch,AmazonElastiCache", "AWS Service Codes (comma-separated)")
 	dummy := flag.Bool("dummy", false, "DEPRECATED: ignored, real data is always fetched")
 
 	flag.Parse()


### PR DESCRIPTION
## Summary

Adds support for estimating monthly costs for Amazon ElastiCache clusters, a managed in-memory caching service. The implementation covers all three supported engines (Redis, Memcached, Valkey) with node-based pricing and multi-node cluster support.

Key capabilities:
- On-demand hourly pricing × node count × 730 hours/month
- Case-insensitive engine normalization (redis → Redis)
- Pulumi resource type support (Cluster and ReplicationGroup formats)
- Sensible defaults: Redis engine, 1 node when not specified
- Graceful degradation: $0 for unknown node types with explanation

## Test plan

- [x] `make lint` passes with 0 issues
- [x] `make test` passes - all 13 new ElastiCache tests pass
- [x] Build verification with `go build -tags region_use1 ./cmd/...`
- [x] Manual review of pricing lookup patterns

## Changes

### Modified files

- `tools/generate-pricing/main.go` - Added AmazonElastiCache to serviceConfig
- `internal/pricing/embed_*.go` (12 files) - Added rawElastiCacheJSON embed directives
- `internal/pricing/embed_fallback.go` - Added ElastiCache test pricing data
- `internal/pricing/client.go` - Added elasticacheIndex, parseElastiCachePricing(), ElastiCacheOnDemandPricePerHour() with engine normalization
- `internal/plugin/projected.go` - Added estimateElastiCache(), updated normalizeResourceType() and detectService() for elasticache recognition
- `internal/plugin/projected_test.go` - Added 12 ElastiCache unit tests covering engines, multi-node, defaults, and error handling
- `internal/plugin/supports.go` - Added elasticache to supported services
- `internal/plugin/supports_test.go` - Added 3 ElastiCache Supports() tests
- `internal/plugin/plugin_test.go` - Added elasticachePrices to mock client
- `internal/plugin/actual_test.go` - Added ElastiCacheOnDemandPricePerHour to mock
- `CLAUDE.md` - Documented ElastiCache in supported services, estimation logic, and cost scope tables
- `specs/001-elasticache/tasks.md` - Marked all implemented tasks as complete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ElastiCache cost estimation (Redis, Memcached, Valkey) with node-type, engine and node-count based pricing; service recognized in support checks.

* **Documentation**
  * Added ElastiCache formatting, tagging examples (engine, node count), pricing assumptions, billing details, and guidance for adding the service.

* **Tests**
  * Added extensive ElastiCache unit tests covering pricing, formats, engines, defaults, errors, and edge cases.

* **Chores**
  * Embedded ElastiCache pricing data across regions and added embed-file verification to the build/lint flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->