### PR TITLE
feat(config): expose CORS and health settings via env vars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1066,6 +1066,28 @@ This fetches real AWS pricing data and ensures pricing files exist before embedd
 
 ## Configuration (v1)
 
+### Environment Variables for Configuration
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `FINFOCUS_PLUGIN_PORT` | int | ephemeral | Port to serve gRPC/Web (replaces `PORT`) |
+| `FINFOCUS_LOG_LEVEL` | string | "info" | Log level (debug, info, warn, error, fatal) |
+| `FINFOCUS_PLUGIN_WEB_ENABLED` | bool | false | Enable HTTP/Web serving (Connect/gRPC-Web) |
+| `FINFOCUS_CORS_ALLOWED_ORIGINS` | string | "" | Comma-separated list of allowed CORS origins (e.g., `*` or `http://localhost:3000`). Empty/unset disables CORS headers. |
+| `FINFOCUS_CORS_ALLOW_CREDENTIALS` | bool | false | Allow credentials in CORS requests (cannot be true if origin is `*`) |
+| `FINFOCUS_CORS_MAX_AGE` | int | 86400 | Max age for CORS preflight cache (seconds). Invalid or negative values fall back to default. |
+| `FINFOCUS_PLUGIN_HEALTH_ENDPOINT` | bool | false | Enable `/healthz` HTTP endpoint (returns 200 OK) |
+
+**Usage Example:**
+```bash
+# Typical configuration for local development with a frontend
+export FINFOCUS_PLUGIN_WEB_ENABLED=true
+export FINFOCUS_CORS_ALLOWED_ORIGINS="http://localhost:3000,http://localhost:5173"
+export FINFOCUS_CORS_ALLOW_CREDENTIALS=true
+export FINFOCUS_PLUGIN_HEALTH_ENDPOINT=true
+./finfocus-plugin-aws-public-us-east-1
+```
+
 Current configuration is minimal:
 - Currency: `USD` (hardcoded default)
 - Account discount factor: `1.0` (no discount)

--- a/cmd/finfocus-plugin-aws-public/config.go
+++ b/cmd/finfocus-plugin-aws-public/config.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/rs/zerolog"
+	"github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
+)
+
+// parseWebConfig parses environment variables to configure the web server.
+// It returns a WebConfig struct and an error if the configuration is invalid.
+func parseWebConfig(enabled bool, logger zerolog.Logger) (pluginsdk.WebConfig, error) {
+	if !enabled {
+		return pluginsdk.WebConfig{}, nil
+	}
+
+	config := pluginsdk.WebConfig{
+		Enabled: true,
+	}
+
+	// FR-001: Allowed Origins
+	hasWildcard := false
+	if origins := os.Getenv("FINFOCUS_CORS_ALLOWED_ORIGINS"); origins != "" {
+		rawOrigins := strings.Split(origins, ",")
+		for _, o := range rawOrigins {
+			trimmed := strings.TrimSpace(o)
+			if trimmed == "*" {
+				hasWildcard = true
+				continue
+			}
+			if trimmed != "" {
+				config.AllowedOrigins = append(config.AllowedOrigins, trimmed)
+			}
+		}
+
+		if hasWildcard {
+			// FR-003: Warn on wildcard
+			logger.Warn().Msg("CORS wildcard origin (*) is insecure; use specific origins in production")
+		}
+	}
+
+	// FR-004: Allow Credentials
+	if strings.ToLower(os.Getenv("FINFOCUS_CORS_ALLOW_CREDENTIALS")) == "true" {
+		config.AllowCredentials = true
+	}
+
+	// FR-006: Health Endpoint
+	if strings.ToLower(os.Getenv("FINFOCUS_PLUGIN_HEALTH_ENDPOINT")) == "true" {
+		config.EnableHealthEndpoint = true
+	}
+
+	// FR-005: Fatal error on Wildcard + Credentials
+	if hasWildcard && config.AllowCredentials {
+		return pluginsdk.WebConfig{}, fmt.Errorf("cannot enable credentials with wildcard origin (*); security risk")
+	}
+
+	// FR-007 & FR-008: Max Age
+	maxAge := 86400 // Default
+	if maxAgeStr := os.Getenv("FINFOCUS_CORS_MAX_AGE"); maxAgeStr != "" {
+		if parsed, err := strconv.Atoi(maxAgeStr); err == nil && parsed >= 0 {
+			maxAge = parsed
+		} else {
+			logger.Warn().Str("value", maxAgeStr).Msg("invalid FINFOCUS_CORS_MAX_AGE, using default")
+		}
+	}
+	config.MaxAge = &maxAge
+
+	// FR-009: Log configuration
+	logger.Debug().
+		Strs("allowed_origins", config.AllowedOrigins).
+		Int("max_age", maxAge).
+		Msg("CORS configuration applied")
+
+	return config, nil
+}

--- a/cmd/finfocus-plugin-aws-public/config_test.go
+++ b/cmd/finfocus-plugin-aws-public/config_test.go
@@ -1,0 +1,186 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseWebConfig(t *testing.T) {
+	logger := zerolog.New(zerolog.NewConsoleWriter())
+
+	tests := []struct {
+		name          string
+		enabled       bool
+		env           map[string]string
+		expectedError string
+		validate      func(t *testing.T, config pluginsdk.WebConfig)
+	}{
+		{
+			name:    "Disabled",
+			enabled: false,
+			env:     nil,
+			validate: func(t *testing.T, config pluginsdk.WebConfig) {
+				assert.False(t, config.Enabled)
+				assert.Empty(t, config.AllowedOrigins)
+				assert.False(t, config.AllowCredentials)
+				assert.Nil(t, config.MaxAge)
+				assert.False(t, config.EnableHealthEndpoint)
+			},
+		},
+		{
+			name:    "Enabled Default",
+			enabled: true,
+			env:     nil,
+			validate: func(t *testing.T, config pluginsdk.WebConfig) {
+				assert.True(t, config.Enabled)
+			},
+		},
+		{
+			name:    "Allowed Origins - Specific",
+			enabled: true,
+			env: map[string]string{
+				"FINFOCUS_CORS_ALLOWED_ORIGINS": "http://localhost:3000,https://app.example.com",
+			},
+			validate: func(t *testing.T, config pluginsdk.WebConfig) {
+				assert.Equal(t, []string{"http://localhost:3000", "https://app.example.com"}, config.AllowedOrigins)
+			},
+		},
+		{
+			name:    "Allowed Origins - Wildcard",
+			enabled: true,
+			env: map[string]string{
+				"FINFOCUS_CORS_ALLOWED_ORIGINS": "*",
+			},
+			validate: func(t *testing.T, config pluginsdk.WebConfig) {
+				assert.Empty(t, config.AllowedOrigins)
+			},
+		},
+		{
+			name:    "Allowed Origins - Mixed Wildcard",
+			enabled: true,
+			env: map[string]string{
+				"FINFOCUS_CORS_ALLOWED_ORIGINS": "foo.com, *, bar.com",
+			},
+			validate: func(t *testing.T, config pluginsdk.WebConfig) {
+				assert.Equal(t, []string{"foo.com", "bar.com"}, config.AllowedOrigins)
+			},
+		},
+		{
+			name:    "Allowed Origins - Whitespace",
+			enabled: true,
+			env: map[string]string{
+				"FINFOCUS_CORS_ALLOWED_ORIGINS": " a.com , b.com ",
+			},
+			validate: func(t *testing.T, config pluginsdk.WebConfig) {
+				assert.Equal(t, []string{"a.com", "b.com"}, config.AllowedOrigins)
+			},
+		},
+		{
+			name:    "Max Age - Valid",
+			enabled: true,
+			env: map[string]string{
+				"FINFOCUS_CORS_MAX_AGE": "3600",
+			},
+			validate: func(t *testing.T, config pluginsdk.WebConfig) {
+				require.NotNil(t, config.MaxAge)
+				assert.Equal(t, 3600, *config.MaxAge)
+			},
+		},
+		{
+			name:    "Max Age - Invalid",
+			enabled: true,
+			env: map[string]string{
+				"FINFOCUS_CORS_MAX_AGE": "invalid",
+			},
+			validate: func(t *testing.T, config pluginsdk.WebConfig) {
+				require.NotNil(t, config.MaxAge)
+				assert.Equal(t, 86400, *config.MaxAge) // Default
+			},
+		},
+		{
+			name:    "Credentials - True",
+			enabled: true,
+			env: map[string]string{
+				"FINFOCUS_CORS_ALLOW_CREDENTIALS": "true",
+			},
+			validate: func(t *testing.T, config pluginsdk.WebConfig) {
+				assert.True(t, config.AllowCredentials)
+			},
+		},
+		{
+			name:    "Credentials - False",
+			enabled: true,
+			env: map[string]string{
+				"FINFOCUS_CORS_ALLOW_CREDENTIALS": "false",
+			},
+			validate: func(t *testing.T, config pluginsdk.WebConfig) {
+				assert.False(t, config.AllowCredentials)
+			},
+		},
+		{
+			name:    "Credentials - Case Insensitive",
+			enabled: true,
+			env: map[string]string{
+				"FINFOCUS_CORS_ALLOW_CREDENTIALS": "TRUE",
+			},
+			validate: func(t *testing.T, config pluginsdk.WebConfig) {
+				assert.True(t, config.AllowCredentials)
+			},
+		},
+		{
+			name:    "Fatal - Wildcard + Credentials",
+			enabled: true,
+			env: map[string]string{
+				"FINFOCUS_CORS_ALLOWED_ORIGINS":   "*",
+				"FINFOCUS_CORS_ALLOW_CREDENTIALS": "true",
+			},
+			expectedError: "cannot enable credentials with wildcard origin",
+		},
+		{
+			name:    "Health Endpoint - True",
+			enabled: true,
+			env: map[string]string{
+				"FINFOCUS_PLUGIN_HEALTH_ENDPOINT": "true",
+			},
+			validate: func(t *testing.T, config pluginsdk.WebConfig) {
+				assert.True(t, config.EnableHealthEndpoint)
+			},
+		},
+		{
+			name:    "Health Endpoint - False",
+			enabled: true,
+			env: map[string]string{
+				"FINFOCUS_PLUGIN_HEALTH_ENDPOINT": "false",
+			},
+			validate: func(t *testing.T, config pluginsdk.WebConfig) {
+				assert.False(t, config.EnableHealthEndpoint)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			// Execute
+			config, err := parseWebConfig(tt.enabled, logger)
+
+			// Validate
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				require.NoError(t, err)
+				if tt.validate != nil {
+					tt.validate(t, config)
+				}
+			}
+		})
+	}
+}

--- a/cmd/finfocus-plugin-aws-public/main.go
+++ b/cmd/finfocus-plugin-aws-public/main.go
@@ -128,10 +128,12 @@ func run() error {
 	}
 
 	// Enable web serving if requested (supports browser access via connect-go)
-	if webEnabled {
-		config.Web = pluginsdk.WebConfig{
-			Enabled: true,
-		}
+	webConfig, err := parseWebConfig(webEnabled, logger)
+	if err != nil {
+		logger.Fatal().Err(err).Msg("failed to parse web configuration")
+	}
+	if webConfig.Enabled {
+		config.Web = webConfig
 		logger.Info().Msg("web serving enabled with multi-protocol support")
 	}
 	if err := pluginsdk.Serve(ctx, config); err != nil {

--- a/internal/plugin/testmode_test.go
+++ b/internal/plugin/testmode_test.go
@@ -2,7 +2,6 @@ package plugin
 
 import (
 	"bytes"
-	"os"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -53,22 +52,8 @@ func TestIsTestMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Save and restore original value
-			original := os.Getenv(testModeEnvVar)
-			defer func() {
-				if original == "" {
-					_ = os.Unsetenv(testModeEnvVar)
-				} else {
-					_ = os.Setenv(testModeEnvVar, original)
-				}
-			}()
-
 			// Set test value
-			if tt.envValue == "" {
-				_ = os.Unsetenv(testModeEnvVar)
-			} else {
-				_ = os.Setenv(testModeEnvVar, tt.envValue)
-			}
+			t.Setenv(testModeEnvVar, tt.envValue)
 
 			got := IsTestMode()
 			if got != tt.want {
@@ -123,22 +108,8 @@ func TestValidateTestModeEnv(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Save and restore original value
-			original := os.Getenv(testModeEnvVar)
-			defer func() {
-				if original == "" {
-					_ = os.Unsetenv(testModeEnvVar)
-				} else {
-					_ = os.Setenv(testModeEnvVar, original)
-				}
-			}()
-
 			// Set test value
-			if tt.envValue == "" {
-				_ = os.Unsetenv(testModeEnvVar)
-			} else {
-				_ = os.Setenv(testModeEnvVar, tt.envValue)
-			}
+			t.Setenv(testModeEnvVar, tt.envValue)
 
 			// Capture log output
 			var buf bytes.Buffer

--- a/specs/031-expose-cors-config/checklists/requirements.md
+++ b/specs/031-expose-cors-config/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Expose CORS configuration via environment variables
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-01-13
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Spec passed validation.

--- a/specs/031-expose-cors-config/plan.md
+++ b/specs/031-expose-cors-config/plan.md
@@ -1,0 +1,131 @@
+# Implementation Plan - Expose CORS configuration via environment variables
+
+**Feature Branch**: `031-expose-cors-config`
+**Feature Spec**: `specs/031-expose-cors-config/spec.md`
+**Status**: Draft
+**Phase**: 1 - Design
+
+## Technical Context
+
+<!--
+  Analyze the codebase and document technical choices/constraints.
+  Mark unknowns as [NEEDS CLARIFICATION].
+-->
+
+### Architecture & Patterns
+
+- **Application Type**: gRPC Service (Plugin)
+- **Framework**: connect-go + pluginsdk (v0.5.0 verified)
+- **Configuration Pattern**: Environment variables -> `main.go` -> `pluginsdk.WebConfig`
+- **Existing CORS Support**: `pluginsdk` provides `WebConfig` struct. We need to populate it.
+- **Entry Point**: `cmd/finfocus-plugin-aws-public/main.go` uses `pluginsdk.Serve`.
+
+### Dependencies
+
+- **pluginsdk**: `github.com/rshade/finfocus-spec/sdk/go/pluginsdk` (Local path in current `go.mod` context). Verified via `main.go` import.
+- **standard library**: `os`, `strings`, `strconv` for env parsing.
+
+### Code Locations
+
+- **Entry Point**: `cmd/finfocus-plugin-aws-public/main.go`
+- **Config Handling**: Inside `run()` function in `main.go`. Will extract to private `parseWebConfig` in `main.go` to keep `run()` clean.
+- **Tests**: `cmd/finfocus-plugin-aws-public/main_test.go` (needs creation/expansion for unit tests).
+- **Integration**: `test/integration/cors_test.go` (new file, modeled after `test/integration/web_server_test.go`).
+
+## Constitution Check
+
+<!--
+  Validate the plan against the project constitution (.specify/memory/constitution.md).
+-->
+
+| Principle | Check | Notes |
+|-----------|-------|-------|
+| **I. Code Quality & Simplicity** | [x] | Keep parsing logic simple, single function `parseWebConfig`. |
+| **II. Testing Discipline** | [x] | Unit tests for parser, integration for headers. |
+| **III. Protocol Consistency** | [x] | No changes to gRPC protocol, just HTTP wrapper config. |
+| **IV. Performance** | [x] | Env parsing only at startup (<1ms), no runtime impact. |
+| **V. Build Quality** | [x] | Linting required, no new deps. |
+| **Security** | [x] | Fail fast on insecure config (wildcard + creds). Warn on wildcard. |
+
+## Gates & Checks
+
+- [x] **Constitution Compliance**: Does this plan violate any core principles? (No)
+- [x] **Spec Coverage**: Does the plan cover all FRs and SCs? (Yes)
+- [x] **Unknowns Resolution**: Are all [NEEDS CLARIFICATION] items resolved? (Yes)
+
+## Phase 0: Research & Decisions
+
+<!--
+  Document decisions made during research.
+-->
+
+### Decisions
+
+- **Environment Parsing Strategy**:
+  - **Decision**: Implement `parseWebConfig(enabled bool, logger zerolog.Logger) (pluginsdk.WebConfig, error)` in `main.go`.
+  - **Rationale**: Keeps logic co-located with usage but testable. `run()` remains clean.
+  
+- **Error Handling**:
+  - `parseWebConfig` returns error on fatal config (wildcard + creds).
+  - `main` logs fatal and exits.
+  - Warnings logged directly via zerolog within parser.
+
+- **Testing Strategy**:
+  - **Unit**: New `cmd/finfocus-plugin-aws-public/config_test.go` (or `main_test.go` if appropriate) testing `parseWebConfig` with table-driven tests.
+  - **Integration**: New `test/integration/cors_test.go` following `web_server_test.go` pattern: build binary, start with env vars, verify headers via `http.Client`.
+
+## Phase 1: Design & Contracts
+
+<!--
+  Define data models and API contracts.
+-->
+
+### Data Model
+
+*No persistent data model changes.*
+
+### Configuration Model (Runtime)
+
+```go
+type WebConfig struct {
+    Enabled              bool
+    AllowedOrigins       []string
+    AllowCredentials     bool
+    MaxAge               *int
+    EnableHealthEndpoint bool
+}
+```
+
+### API Contracts
+
+- **Health Endpoint**:
+  - `GET /healthz` -> 200 OK
+  - Other methods -> 405/404 (handled by SDK/Connect-Go)
+
+## Phase 2: Implementation Plan
+
+<!--
+  Break down implementation into phases/steps.
+-->
+
+### Step 1: Configuration Parsing Logic
+- Create `cmd/finfocus-plugin-aws-public/config.go` to hold `parseWebConfig` logic.
+- Implement `FR-001` to `FR-008`.
+- Add unit tests in `cmd/finfocus-plugin-aws-public/config_test.go`.
+
+### Step 2: Main Entry Integration
+- Update `main.go` to call `parseWebConfig` instead of hardcoded struct.
+- Wire up `pluginsdk.Serve`.
+- Implement fatal error handling for `FR-005` (exit on error).
+
+### Step 3: Integration Testing
+- Create `test/integration/cors_test.go`.
+- Test cases:
+  - `TestCORS_AllowedOrigins`: Verify `Access-Control-Allow-Origin`.
+  - `TestCORS_NoHeaders`: Verify no headers for non-matching origin.
+  - `TestCORS_Credentials`: Verify `Access-Control-Allow-Credentials`.
+  - `TestHealthEndpoint`: Verify `GET /healthz`.
+  - `TestFatalConfig`: Verify process exits with error code when config is invalid (wildcard + creds).
+
+### Step 4: Documentation
+- Update `CLAUDE.md` with new env vars.

--- a/specs/031-expose-cors-config/spec.md
+++ b/specs/031-expose-cors-config/spec.md
@@ -1,0 +1,91 @@
+# Feature Specification: Expose CORS configuration via environment variables
+
+**Feature Branch**: `031-expose-cors-config`
+**Created**: 2026-01-13
+**Status**: Draft
+
+## Clarifications
+
+### Session 2026-01-13
+- Q: Conflict Behavior (Wildcard + Credentials) → A: Log a fatal error and exit (Fail Fast).
+- Q: Health Endpoint Method → A: GET only.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Configure Cross-Origin Access for Web Frontend (Priority: P1)
+
+A developer or administrator wants to allow their web-based frontend application (hosted on a different domain) to communicate directly with the FinFocus AWS Public plugin.
+
+**Why this priority**: Without this, browser-based integrations are impossible due to browser security policies (CORS).
+
+**Independent Test**: Can be tested by starting the plugin with `FINFOCUS_CORS_ALLOWED_ORIGINS` set and making a cross-origin request using `curl` or a browser console.
+
+**Acceptance Scenarios**:
+
+1. **Given** the plugin is configured with `FINFOCUS_CORS_ALLOWED_ORIGINS=http://localhost:3000`, **When** a request arrives with `Origin: http://localhost:3000`, **Then** the response includes `Access-Control-Allow-Origin: http://localhost:3000`.
+2. **Given** the plugin is configured with `FINFOCUS_CORS_ALLOWED_ORIGINS=http://localhost:3000`, **When** a request arrives with `Origin: http://evil.com`, **Then** the response does NOT include CORS headers for that origin.
+3. **Given** the plugin is configured with `FINFOCUS_CORS_ALLOWED_ORIGINS=*`, **When** the plugin starts, **Then** a warning log is emitted about insecure wildcard configuration.
+
+---
+
+### User Story 2 - Enable Credentials for Authenticated Requests (Priority: P2)
+
+An administrator needs to support requests that include credentials (cookies, authorization headers) from the frontend.
+
+**Why this priority**: Required for authenticated sessions or specific security contexts, though the public plugin may be less sensitive, integration with broader systems often requires this.
+
+**Independent Test**: Start plugin with credentials enabled and verify `Access-Control-Allow-Credentials` header.
+
+**Acceptance Scenarios**:
+
+1. **Given** `FINFOCUS_CORS_ALLOW_CREDENTIALS=true` and a specific allowed origin, **When** a valid request arrives, **Then** the response includes `Access-Control-Allow-Credentials: true`.
+2. **Given** `FINFOCUS_CORS_ALLOW_CREDENTIALS=true` and `FINFOCUS_CORS_ALLOWED_ORIGINS=*`, **When** the plugin starts or receives a request, **Then** the configuration is treated as invalid or secure default is enforced (credentials cannot be true with wildcard origin).
+
+---
+
+### User Story 3 - Enable Health Check Endpoint (Priority: P2)
+
+An infrastructure engineer wants to configure a readiness/liveness probe for the plugin in a containerized environment (e.g., Kubernetes).
+
+**Why this priority**: Essential for reliable deployment and orchestration.
+
+**Independent Test**: Start plugin with health endpoint enabled and curl `/healthz`.
+
+**Acceptance Scenarios**:
+
+1. **Given** `FINFOCUS_PLUGIN_HEALTH_ENDPOINT=true`, **When** a GET request is made to `/healthz`, **Then** the server returns 200 OK.
+2. **Given** `FINFOCUS_PLUGIN_HEALTH_ENDPOINT=false` (default), **When** a GET request is made to `/healthz`, **Then** the server returns 404 or does not expose the endpoint.
+
+---
+
+### Edge Cases
+
+- **Invalid Max Age**: If `FINFOCUS_CORS_MAX_AGE` is not a valid integer, the system should log a warning and use the default (86400s).
+- **Empty Origins**: If `FINFOCUS_CORS_ALLOWED_ORIGINS` is set but empty, no CORS headers should be generated.
+- **Whitespace handling**: Comma-separated origins should be trimmed of whitespace (e.g., `a.com, b.com` -> `a.com`, `b.com`).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST parse `FINFOCUS_CORS_ALLOWED_ORIGINS` environment variable as a comma-separated list of origins.
+- **FR-002**: System MUST configure the web server to return appropriate CORS headers for origins matching the parsed list.
+- **FR-003**: System MUST log a warning if `FINFOCUS_CORS_ALLOWED_ORIGINS` is set to `*` (wildcard).
+- **FR-004**: System MUST parse `FINFOCUS_CORS_ALLOW_CREDENTIALS` (case-insensitive "true"/"false") and enable credentials support if true.
+- **FR-005**: System MUST log a fatal error and terminate at startup if `FINFOCUS_CORS_ALLOW_CREDENTIALS` is true while `FINFOCUS_CORS_ALLOWED_ORIGINS` is `*`.
+- **FR-006**: System MUST parse `FINFOCUS_PLUGIN_HEALTH_ENDPOINT` (case-insensitive "true"/"false") and expose a `/healthz` endpoint returning HTTP 200 for GET requests if true. Other methods to `/healthz` MUST return 405 Method Not Allowed or 404.
+- **FR-007**: System MUST parse `FINFOCUS_CORS_MAX_AGE` as an integer (seconds) and configure the CORS preflight max age.
+- **FR-008**: System MUST fall back to a default max age of 86400 seconds if `FINFOCUS_CORS_MAX_AGE` is invalid or unset.
+- **FR-009**: System MUST log the applied CORS configuration at startup (debug level) for verification.
+
+### Key Entities
+
+- **CORS Configuration**: The set of rules (origins, credentials, max age) that determine how the system responds to cross-origin requests.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can successfully make HTTP requests to the plugin from a browser application hosted on a specified allowed origin (integration test verified).
+- **SC-002**: Kubernetes or other orchestrators can successfully probe `/healthz` when enabled.
+- **SC-003**: Invalid configurations (e.g., credentials + wildcard) are handled safely without crashing or creating security holes (secure defaults).

--- a/specs/031-expose-cors-config/tasks.md
+++ b/specs/031-expose-cors-config/tasks.md
@@ -1,0 +1,90 @@
+# Tasks: Expose CORS configuration via environment variables
+
+**Feature Branch**: `031-expose-cors-config`
+**Status**: Completed
+
+## Implementation Strategy
+
+We will implement the CORS configuration support in phases, starting with a robust parsing foundation, then incrementally adding features per user story, and validating with integration tests.
+
+- **MVP Scope**: User Story 1 (Basic CORS with Allowed Origins)
+- **Approach**: TDD-lite (Unit tests for parser first, then implementation, then integration verification)
+- **Parallelism**: Configuration parsing logic and integration test scaffold can be built in parallel.
+
+## Phase 1: Setup
+
+<!--
+  Project initialization and structural setup.
+-->
+
+- [x] T001 Create `cmd/finfocus-plugin-aws-public/config.go` for `parseWebConfig` stub
+
+## Phase 2: Foundational
+
+<!--
+  Blocking prerequisites for all user stories.
+-->
+
+- [x] T002 Implement `parseWebConfig` function signature and return type in `cmd/finfocus-plugin-aws-public/config.go`
+- [x] T003 Create `cmd/finfocus-plugin-aws-public/config_test.go` with initial test table structure
+
+## Phase 3: User Story 1 - Configure Cross-Origin Access (P1)
+
+<!--
+  Goal: Allow specific origins to access the plugin from a browser.
+  Independent Test: Curl with Origin header gets Access-Control-Allow-Origin response.
+-->
+
+- [x] T004 [US1] Add test cases for `FINFOCUS_CORS_ALLOWED_ORIGINS` parsing (valid, empty, wildcard) to `cmd/finfocus-plugin-aws-public/config_test.go`
+- [x] T005 [US1] Implement parsing logic for allowed origins in `cmd/finfocus-plugin-aws-public/config.go`
+- [x] T006 [US1] Implement wildcard warning logging in `cmd/finfocus-plugin-aws-public/config.go`
+- [x] T007 [US1] Implement `FR-007` & `FR-008` (Max Age parsing/defaults) in `cmd/finfocus-plugin-aws-public/config.go`
+- [x] T008 [US1] Update `cmd/finfocus-plugin-aws-public/main.go` to use `parseWebConfig` and set `pluginsdk.WebConfig`
+- [x] T022 [US1] Implement `FR-009` (Log applied CORS config at debug level) in `cmd/finfocus-plugin-aws-public/config.go`
+- [x] T009 [US1] Create integration test `test/integration/cors_test.go` verifying Basic CORS and Max Age
+
+## Phase 4: User Story 2 - Enable Credentials (P2)
+
+<!--
+  Goal: Support authenticated requests with credentials.
+  Independent Test: Start with creds=true, verify Access-Control-Allow-Credentials header.
+-->
+
+- [x] T010 [US2] Add test cases for `FINFOCUS_CORS_ALLOW_CREDENTIALS` (true/false, case-insensitivity) to `cmd/finfocus-plugin-aws-public/config_test.go`
+- [x] T011 [US2] Add test case for Fatal Error on Wildcard + Credentials to `cmd/finfocus-plugin-aws-public/config_test.go`
+- [x] T012 [US2] Implement credentials parsing logic in `cmd/finfocus-plugin-aws-public/config.go`
+- [x] T013 [US2] Implement fatal error validation (wildcard + creds) in `cmd/finfocus-plugin-aws-public/config.go`
+- [x] T014 [US2] Implement fatal error handling (exit process) in `cmd/finfocus-plugin-aws-public/main.go`
+- [x] T015 [US2] Update `test/integration/cors_test.go` to verify Credentials header and Fatal Error exit
+
+## Phase 5: User Story 3 - Health Endpoint (P2)
+
+<!--
+  Goal: Expose /healthz for orchestration probes.
+  Independent Test: Curl /healthz returns 200 OK.
+-->
+
+- [x] T016 [US3] Add test cases for `FINFOCUS_PLUGIN_HEALTH_ENDPOINT` parsing to `cmd/finfocus-plugin-aws-public/config_test.go`
+- [x] T017 [US3] Implement health endpoint parsing logic in `cmd/finfocus-plugin-aws-public/config.go`
+- [x] T018 [US3] Update `test/integration/cors_test.go` to verify `/healthz` endpoint availability
+
+## Phase 6: Polish & Cross-Cutting
+
+<!--
+  Documentation, cleanup, and final verification.
+-->
+
+- [x] T019 Update `CLAUDE.md` with new environment variables documentation
+- [x] T020 Run `make lint` and fix any new linting issues
+- [x] T021 Run `make test` to ensure no regressions in existing suites
+
+## Dependencies
+
+- **US1** must complete before **US2** (credentials build on basic CORS config structure)
+- **US3** is independent of US1/US2 logic but shares the same config struct
+- **T008** (Main integration) blocks all integration tests (T009, T015, T018)
+
+## Parallel Execution Opportunities
+
+- **T009**, **T015**, **T018** (Integration Tests) can be written in parallel with Implementation tasks, though they require the binary to pass.
+- **US3** (Health Endpoint) logic can be implemented in parallel with **US1**/**US2** if multiple developers were involved (editing same file `config.go` but different struct fields).

--- a/test/integration/cors_test.go
+++ b/test/integration/cors_test.go
@@ -1,0 +1,212 @@
+//go:build integration
+
+package integration
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// waitForPort parses PORT=XXXX from the reader
+func waitForPort(t *testing.T, r io.Reader) string {
+	scanner := bufio.NewScanner(r)
+	timeout := time.After(10 * time.Second)
+	found := make(chan string)
+
+	go func() {
+		for scanner.Scan() {
+			line := scanner.Text()
+			// t.Logf("Plugin Output: %s", line) // Debug logging
+			if strings.Contains(line, "PORT=") {
+				re := regexp.MustCompile(`PORT=(\d+)`)
+				matches := re.FindStringSubmatch(line)
+				if len(matches) > 1 {
+					found <- matches[1]
+					return
+				}
+			}
+		}
+	}()
+
+	select {
+	case port := <-found:
+		return port
+	case <-timeout:
+		return ""
+	}
+}
+
+func TestCORS(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	// Build the plugin binary
+	tempDir := t.TempDir()
+	binaryPath := filepath.Join(tempDir, "plugin-server")
+	rootDir, err := filepath.Abs("../..")
+	require.NoError(t, err)
+
+	cmdBuild := exec.Command("go", "build", "-tags", "region_use1", "-o", binaryPath, "./cmd/finfocus-plugin-aws-public")
+	cmdBuild.Dir = rootDir
+	output, err := cmdBuild.CombinedOutput()
+	require.NoError(t, err, "Build failed: %s", string(output))
+
+	tests := []struct {
+		name              string
+		env               []string
+		origin            string
+		expectCors        bool
+		expectOrigin      string
+		expectMaxAge      string
+		expectCredentials bool
+	}{
+		{
+			name: "Basic CORS Success",
+			env: []string{
+				"FINFOCUS_PLUGIN_WEB_ENABLED=true",
+				"FINFOCUS_CORS_ALLOWED_ORIGINS=http://localhost:3000",
+			},
+			origin:       "http://localhost:3000",
+			expectCors:   true,
+			expectOrigin: "http://localhost:3000",
+			expectMaxAge: "86400", // Default
+		},
+		{
+			name: "CORS No Match",
+			env: []string{
+				"FINFOCUS_PLUGIN_WEB_ENABLED=true",
+				"FINFOCUS_CORS_ALLOWED_ORIGINS=http://localhost:3000",
+			},
+			origin:     "http://evil.com",
+			expectCors: false,
+		},
+		{
+			name: "Custom Max Age",
+			env: []string{
+				"FINFOCUS_PLUGIN_WEB_ENABLED=true",
+				"FINFOCUS_CORS_ALLOWED_ORIGINS=http://localhost:3000",
+				"FINFOCUS_CORS_MAX_AGE=60",
+			},
+			origin:       "http://localhost:3000",
+			expectCors:   true,
+			expectOrigin: "http://localhost:3000",
+			expectMaxAge: "60",
+		},
+		{
+			name: "Credentials Success",
+			env: []string{
+				"FINFOCUS_PLUGIN_WEB_ENABLED=true",
+				"FINFOCUS_CORS_ALLOWED_ORIGINS=http://localhost:3000",
+				"FINFOCUS_CORS_ALLOW_CREDENTIALS=true",
+			},
+			origin:            "http://localhost:3000",
+			expectCors:        true,
+			expectOrigin:      "http://localhost:3000",
+			expectCredentials: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Start plugin with specific env
+			cmd := exec.Command(binaryPath)
+			cmd.Env = append(os.Environ(), tt.env...)
+
+			stdout, err := cmd.StdoutPipe()
+			require.NoError(t, err)
+
+			err = cmd.Start()
+			require.NoError(t, err)
+
+			defer func() {
+				_ = cmd.Process.Kill()
+			}()
+
+			// Wait for port
+			port := waitForPort(t, stdout)
+			require.NotEmpty(t, port, "failed to get port")
+
+			// Make OPTIONS Request (Preflight)
+			url := fmt.Sprintf("http://localhost:%s/finfocus.v1.CostSourceService/GetProjectedCost", port)
+			req, err := http.NewRequest("OPTIONS", url, nil)
+			require.NoError(t, err)
+			req.Header.Set("Origin", tt.origin)
+			req.Header.Set("Access-Control-Request-Method", "POST")
+
+			client := &http.Client{Timeout: 2 * time.Second}
+			resp, err := client.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			// Verify Headers
+			if tt.expectCors {
+				assert.Equal(t, tt.expectOrigin, resp.Header.Get("Access-Control-Allow-Origin"))
+				if tt.expectMaxAge != "" {
+					assert.Equal(t, tt.expectMaxAge, resp.Header.Get("Access-Control-Max-Age"))
+				}
+				// Verify credentials
+				if tt.expectCredentials {
+					assert.Equal(t, "true", resp.Header.Get("Access-Control-Allow-Credentials"))
+				} else {
+					assert.Empty(t, resp.Header.Get("Access-Control-Allow-Credentials"))
+				}
+			} else {
+				assert.Empty(t, resp.Header.Get("Access-Control-Allow-Origin"))
+			}
+		})
+	}
+
+	t.Run("Fatal Error Wildcard + Credentials", func(t *testing.T) {
+		cmd := exec.Command(binaryPath)
+		cmd.Env = append(os.Environ(),
+			"FINFOCUS_PLUGIN_WEB_ENABLED=true",
+			"FINFOCUS_CORS_ALLOWED_ORIGINS=*",
+			"FINFOCUS_CORS_ALLOW_CREDENTIALS=true",
+		)
+
+		output, err := cmd.CombinedOutput()
+		assert.Error(t, err, "process should have failed")
+		assert.Contains(t, string(output), "cannot enable credentials with wildcard origin")
+	})
+
+	t.Run("Health Endpoint Enabled", func(t *testing.T) {
+		cmd := exec.Command(binaryPath)
+		cmd.Env = append(os.Environ(),
+			"FINFOCUS_PLUGIN_WEB_ENABLED=true",
+			"FINFOCUS_PLUGIN_HEALTH_ENDPOINT=true",
+		)
+
+		stdout, err := cmd.StdoutPipe()
+		require.NoError(t, err)
+
+		err = cmd.Start()
+		require.NoError(t, err)
+
+		defer func() {
+			_ = cmd.Process.Kill()
+		}()
+
+		port := waitForPort(t, stdout)
+		require.NotEmpty(t, port, "failed to get port")
+
+		url := fmt.Sprintf("http://localhost:%s/healthz", port)
+		resp, err := http.Get(url)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}

--- a/test/integration/web_server_test.go
+++ b/test/integration/web_server_test.go
@@ -54,9 +54,7 @@ func TestWebServer(t *testing.T) {
 	t.Log("Starting plugin server...")
 	cmd := exec.Command(binaryPath)
 	cmd.Env = append(os.Environ(), "FINFOCUS_PLUGIN_WEB_ENABLED=true")
-	stdout, err := cmd.StdoutPipe()
-	require.NoError(t, err)
-
+	
 	stdoutR, stdoutW := io.Pipe()
 	stderrR, stderrW := io.Pipe()
 	cmd.Stdout = stdoutW


### PR DESCRIPTION
## Summary

- Expose `pluginsdk.WebConfig` CORS settings (Allowed Origins, Credentials, Max Age) via environment variables.
- Enable the `/healthz` HTTP endpoint via `FINFOCUS_PLUGIN_HEALTH_ENDPOINT` for orchestration probes.
- Implement secure default validation: the plugin will now log a fatal error and exit if credentials are enabled with a wildcard origin (`*`).
- Add debug logging for the applied CORS configuration at startup.

## Test plan

- [x] 14 unit test cases added to `config_test.go` covering parsing permutations and error states.
- [x] 6 integration test cases added to `cors_test.go` verifying actual HTTP headers and health endpoint availability.
- [x] `make lint` passes with zero issues.
- [x] `make test` passes all suites (unit and integration).

## Changes

### New files

- `cmd/finfocus-plugin-aws-public/config.go` - Logic for parsing web-related environment variables.
- `cmd/finfocus-plugin-aws-public/config_test.go` - Unit tests for the configuration parser.
- `test/integration/cors_test.go` - End-to-end tests for CORS headers and the `/healthz` endpoint.

### Modified files

- `cmd/finfocus-plugin-aws-public/main.go` - Integrated new config parsing and fatal error handling.
- `test/integration/web_server_test.go` - Fixed a pre-existing unused variable linting error.
- `CLAUDE.md` - Documented new configuration environment variables.

Closes #243

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Web server settings are now configurable via environment variables (CORS allowed origins, max age, credentials, health endpoint toggle)
  
* **Documentation**
  * Added environment variable reference guide for configuration options

* **Tests**
  * Added CORS and health endpoint integration tests

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->