### PR TITLE
docs: add missing docstrings and carbon estimation documentation

### DIFF
--- a/internal/carbon/elasticache_estimator.go
+++ b/internal/carbon/elasticache_estimator.go
@@ -69,9 +69,8 @@ func (e *ElastiCacheEstimator) GetBillingDetail(config ElastiCacheConfig) string
 		formatInt(int(config.Utilization*100)) + "% utilization"
 }
 
-// elasticacheToEC2InstanceType converts an ElastiCache node type to its EC2 equivalent.
-// elasticacheToEC2InstanceType returns the EC2-equivalent instance type for an ElastiCache node type by removing the leading "cache." prefix if present.
-// If the input does not have that prefix, it is returned unchanged.
+// elasticacheToEC2InstanceType converts an ElastiCache node type to its EC2 equivalent
+// by removing the "cache." prefix (e.g., "cache.m5.large" -> "m5.large").
 func elasticacheToEC2InstanceType(nodeType string) string {
 	return strings.TrimPrefix(nodeType, "cache.")
 }

--- a/internal/carbon/rds_estimator.go
+++ b/internal/carbon/rds_estimator.go
@@ -51,7 +51,10 @@ func (e *RDSEstimator) EstimateCarbonGrams(config RDSInstanceConfig) (float64, b
 		Hours:      config.Hours,
 	})
 
-	// Apply Multi-AZ multiplier (2× for both compute and storage)
+	// Apply Multi-AZ multiplier (2× for both compute and storage).
+	// Note: This assumes both AZs are in the same region with identical grid factors.
+	// Cross-region deployments (if applicable) may have different carbon footprints
+	// due to varying grid intensities between regions.
 	totalCarbon := computeCarbon + storageCarbon
 	if config.MultiAZ {
 		totalCarbon *= 2
@@ -87,7 +90,7 @@ func (e *RDSEstimator) EstimateCarbonGramsWithBreakdown(config RDSInstanceConfig
 		Hours:      config.Hours,
 	})
 
-	// Apply Multi-AZ multiplier
+	// Apply Multi-AZ multiplier (same-region assumption, see EstimateCarbonGrams).
 	if config.MultiAZ {
 		computeCarbon *= 2
 		storageCarbon *= 2

--- a/internal/carbon/types.go
+++ b/internal/carbon/types.go
@@ -28,6 +28,18 @@ type EmbodiedCarbonConfig struct {
 
 // DefaultEmbodiedCarbonConfig returns the default embodied carbon configuration
 // based on CCF methodology.
+//
+// Embodied carbon is disabled by default for several reasons:
+//   - Conservative estimates: Only operational carbon is reported by default since it can
+//     be measured with higher confidence (actual power consumption × grid factor)
+//   - Comparability: Most carbon calculators (AWS Customer Carbon Footprint Tool, Google)
+//     report only operational (Scope 2) emissions, making comparison easier
+//   - User expectation: Enterprise users typically expect operational-only baselines
+//   - Uncertainty: Embodied carbon values (1000 kgCO2e/server) are rough estimates that
+//     vary significantly by manufacturer and server configuration
+//
+// To include embodied carbon, set Enabled: true in the configuration.
+// See docs/carbon-estimation.md for more details on enabling embodied carbon.
 func DefaultEmbodiedCarbonConfig() EmbodiedCarbonConfig {
 	return EmbodiedCarbonConfig{
 		Enabled:                 false,

--- a/test/integration/docker_test.go
+++ b/test/integration/docker_test.go
@@ -18,6 +18,28 @@ const (
 	testVersion = "v0.0.3"
 )
 
+// TestDockerImageBuildAndVerification verifies Docker image build and runtime validation.
+//
+// This test validates that the multi-region Docker image builds correctly and all
+// regional binaries are embedded and executable. It also verifies that the metrics
+// aggregator builds and runs within the container, and that health/metrics endpoints
+// function correctly.
+//
+// Test workflow:
+//  1. Build Docker image with VERSION build arg (v0.0.3)
+//  2. Verify image size is within expected range (1GB-3GB)
+//  3. Run container with port mappings (8001-8012 for regions, 9090 for metrics)
+//  4. Wait for container health checks to pass (2 minute timeout)
+//  5. Verify health endpoint responds at localhost:8001/healthz
+//  6. Verify metrics endpoint responds at localhost:9090/metrics with Prometheus format
+//  7. Verify container logs contain injected region field ("region":"us-east-1")
+//  8. Cleanup: remove container
+//
+// Prerequisites:
+//   - Docker daemon running and accessible
+//   - Dockerfile located at docker/Dockerfile relative to project root
+//
+// Run with: go test -tags=integration -run TestDockerImageBuildAndVerification ./test/integration/...
 func TestDockerImageBuildAndVerification(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")

--- a/test/integration/kind_test.go
+++ b/test/integration/kind_test.go
@@ -13,6 +13,28 @@ import (
 
 const imageName = "finfocus-aws:test"
 
+// TestKubernetesDeploymentWithKind verifies the plugin deploys and runs correctly on a local Kubernetes cluster.
+//
+// This test validates end-to-end Kubernetes deployment, including cluster creation,
+// image loading, pod readiness, port forwarding, and health endpoint verification.
+// It ensures the containerized plugin integrates correctly with Kubernetes orchestration.
+//
+// Test workflow:
+//  1. Check if kind and kubectl CLIs are available (skip if not)
+//  2. Create a Kind cluster (test-aws-cluster)
+//  3. Load the finfocus-aws Docker image into the cluster
+//  4. Deploy the application using kubectl apply on test/k8s/deployment.yaml
+//  5. Wait for pod to be Running and Ready (2 minute timeout)
+//  6. Set up port forwarding (8001:8001, 9090:9090)
+//  7. Verify health endpoint responds via port-forward
+//  8. Cleanup: delete the Kind cluster
+//
+// Prerequisites:
+//   - kind CLI available and accessible in PATH
+//   - kubectl CLI available and accessible in PATH
+//   - Docker image finfocus-aws:test already built and available locally
+//
+// Run with: go test -tags=integration -run TestKubernetesDeploymentWithKind ./test/integration/...
 func TestKubernetesDeploymentWithKind(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")


### PR DESCRIPTION
## Summary

- Add comprehensive Go doc comments to integration tests following CLAUDE.md guidelines (numbered workflows, prerequisites, run commands)
- Fix duplicate docstring in elasticacheToEC2InstanceType helper function
- Document same-region assumption for RDS Multi-AZ carbon calculations
- Explain rationale for embodied carbon being disabled by default with guidance on how to enable it

## Test plan

- [x] `make lint` passes with zero issues
- [x] `make test` passes
- [x] `npx markdownlint docs/carbon-estimation.md` passes

## Changes

### Modified files

- `test/integration/kind_test.go` - Added comprehensive docstring to TestKubernetesDeploymentWithKind with 8-step workflow
- `test/integration/docker_test.go` - Added comprehensive docstring to TestDockerImageBuildAndVerification with 8-step workflow
- `internal/carbon/elasticache_estimator.go` - Consolidated duplicate docstring into single concise comment
- `internal/carbon/rds_estimator.go` - Added inline comments noting same-region assumption for Multi-AZ carbon multiplier
- `internal/carbon/types.go` - Added rationale explaining why embodied carbon is disabled by default
- `docs/carbon-estimation.md` - Added "RDS Multi-AZ Limitations" section and expanded "Embodied Carbon" section with enablement instructions

Closes #225
Closes #226
Closes #254
Closes #255
Closes #256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded carbon estimation guides with detailed embodied carbon sections: why it's disabled by default, enabling instructions, pricing and formula details, and RDS Multi-AZ regional limitations.

* **Improvements**
  * Updated internal documentation and default configuration values for embodied carbon handling.

* **Tests**
  * Added integration tests for Docker image builds and Kubernetes deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->