### PR TITLE
feat(plugin): add zero-cost resource handling and expand carbon metri…

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,9 +39,15 @@ security overhead of cloud credentials.
   - Lambda functions (vCPU-equivalent + ARM64 efficiency adjustment)
   - DynamoDB tables (storage-based with 3× SSD replication)
   - EKS clusters (control plane guidance, worker nodes as EC2)
+  - ElastiCache nodes (EC2-equivalent mapping for cache node types)
   - Embodied carbon (server manufacturing amortization per CCF)
   - GPU-specific power specs for P/G series instances
   - Storage specs embedded from CCF cloud-carbon-coefficients
+- **Multi-Region Docker:** Single Docker image containing all 9 regional
+  binaries with tini init and Prometheus metrics aggregation.
+- **Zero-Cost Resource Handling:** Graceful handling for AWS resources
+  with no direct cost (VPC, Security Groups, Subnets) - return $0 estimates
+  instead of SKU errors (#237).
 
 ---
 
@@ -51,8 +57,6 @@ security overhead of cloud credentials.
   - **Route53:** Hosted zones and basic query volume estimation.
   - **CloudFront:** Basic data transfer and request pricing (based on regional
     estimates).
-- **[Planned] ElastiCache Carbon Estimation:** Extend CCF methodology to cache
-  node types for comprehensive carbon footprint coverage.
 
 ---
 
@@ -77,6 +81,13 @@ security overhead of cloud credentials.
   - **Lineage Metadata:** Populate `ParentResourceID` for dependent resources
     (e.g., EBS Volumes attached to Instances, NAT Gateways attached to VPCs) to
     support "Blast Radius" visualization.
+- **[Planned] Capability Discovery Enhancements:**
+  - **Dual-Layer Discovery:** Service-level and resource-level capability
+    introspection for richer client integration (#258).
+  - **Carbon Metrics Advertisement:** Update `getSupportedMetrics` to accurately
+    reflect carbon estimation availability per service (#257).
+- **[Planned] Multi-Region Router:** Single-port request routing for the Docker
+  image to simplify client integration (#245).
 
 ---
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,10 +2,10 @@
 # Stage 1: Download and prepare regional binaries
 FROM alpine:3.19 AS downloader
 
-# Install dependencies
+# Install dependencies (no version pinning for security packages)
 RUN apk add --no-cache \
-    ca-certificates=20241121-r1 \
-    curl=8.5.0-r0
+    ca-certificates \
+    curl
 
 # Set working directory
 WORKDIR /tmp
@@ -13,10 +13,11 @@ WORKDIR /tmp
 # Define build arguments
 ARG VERSION=v0.1.0
 
-# Define regions
-ENV REGIONS="us-east-1 us-west-2 eu-west-1 ap-southeast-1 ap-southeast-2 ap-northeast-1 ap-south-1 ca-central-1 sa-east-1 us-gov-west-1 us-gov-east-1 us-west-1"
+# Define regions (must match available release assets)
+ENV REGIONS="us-east-1 us-west-2 eu-west-1 ap-southeast-1 ap-southeast-2 ap-northeast-1 ap-south-1 ca-central-1 sa-east-1"
 
 # Download checksums and regional binaries with verification
+# Note: VERSION arg includes 'v' prefix (e.g., "v0.1.2") but tarball names don't (e.g., "0.1.2")
 RUN set -ex; \
     arch=$(uname -m); \
     case "$arch" in \
@@ -24,16 +25,17 @@ RUN set -ex; \
         aarch64) release_arch="arm64" ;; \
         *) echo "Unsupported architecture: ${arch}"; exit 1 ;; \
     esac; \
+    VERSION_NO_V=$(echo "${VERSION}" | sed 's/^v//'); \
     cd /tmp; \
     echo "Downloading checksums for ${VERSION}..."; \
-    curl -L -o SHA256SUMS "https://github.com/rshade/finfocus-plugin-aws-public/releases/download/${VERSION}/SHA256SUMS"; \
+    curl -fL -o checksums.txt "https://github.com/rshade/finfocus-plugin-aws-public/releases/download/${VERSION}/checksums.txt"; \
     for region in $REGIONS; do \
-        tarball="finfocus-plugin-aws-public_${VERSION}_Linux_${release_arch}_${region}.tar.gz"; \
+        tarball="finfocus-plugin-aws-public_${VERSION_NO_V}_Linux_${release_arch}_${region}.tar.gz"; \
         echo "Downloading ${region} binary..."; \
-        curl -L -o "/tmp/${tarball}" \
+        curl -fL -o "/tmp/${tarball}" \
             "https://github.com/rshade/finfocus-plugin-aws-public/releases/download/${VERSION}/${tarball}"; \
         echo "Verifying checksum for ${region}..."; \
-        sha256sum -c SHA256SUMS 2>/dev/null | grep "${tarball}" || { \
+        sha256sum -c checksums.txt 2>/dev/null | grep "${tarball}" || { \
             echo "Error: Checksum verification failed for ${tarball}"; \
             exit 1; \
         }; \
@@ -46,7 +48,7 @@ RUN set -ex; \
         fi; \
         chmod +x "$binary"; \
     done; \
-    rm -f /tmp/SHA256SUMS; \
+    rm -f /tmp/checksums.txt; \
     echo "Successfully downloaded and verified all regional binaries"
 
 # Stage 2: Build metrics-aggregator
@@ -66,11 +68,11 @@ RUN go build -o /tmp/metrics-aggregator ./cmd/metrics-aggregator
 # Stage 3: Final runtime image
 FROM alpine:3.19
 
-# Install runtime dependencies
+# Install runtime dependencies (no version pinning for security packages)
 RUN apk add --no-cache \
-    ca-certificates=20241121-r1 \
-    curl=8.5.0-r0 \
-    tini=0.19.0-r2
+    ca-certificates \
+    curl \
+    tini
 
 WORKDIR /app
 
@@ -89,7 +91,7 @@ RUN chmod +x /entrypoint.sh /healthcheck.sh
 
 # Verify all regional binaries exist
 RUN set -ex; \
-    for region in us-east-1 us-west-2 eu-west-1 ap-southeast-1 ap-southeast-2 ap-northeast-1 ap-south-1 ca-central-1 sa-east-1 us-gov-west-1 us-gov-east-1 us-west-1; do \
+    for region in us-east-1 us-west-2 eu-west-1 ap-southeast-1 ap-southeast-2 ap-northeast-1 ap-south-1 ca-central-1 sa-east-1; do \
         if [ ! -f "/usr/local/bin/finfocus-plugin-aws-public-${region}" ]; then \
             echo "ERROR: Binary for ${region} not found in final image"; \
             exit 1; \
@@ -101,15 +103,15 @@ RUN set -ex; \
 RUN addgroup -g 65532 -S plugin && \
     adduser -u 65532 -S plugin -G plugin
 
-# Expose ports
-EXPOSE 8001 8002 8003 8004 8005 8006 8007 8008 8009 8010 8011 8012 9090
+# Expose ports (9 regional endpoints + metrics)
+EXPOSE 8001 8002 8003 8004 8005 8006 8007 8008 8009 9090
 
 # Set default environment variables
 ENV FINFOCUS_PLUGIN_WEB_ENABLED=true
 ENV FINFOCUS_PLUGIN_HEALTH_ENDPOINT=true
 
 # Health check
-# Verifies all 12 regional endpoints respond within 10s.
+# Verifies all 9 regional endpoints respond within 10s.
 # Total time to mark unhealthy: 30s (start-period) + 3×30s (interval×retries) = ~120s (2 minutes)
 # This allows time for slow region startups while still detecting failures reasonably quickly.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,11 +2,11 @@
 set -e
 
 # Entrypoint script for finfocus-plugin-aws-public multi-region container
-# Starts all 12 regional binaries and manages their lifecycle
+# Starts all 9 regional binaries and manages their lifecycle
 
-# Define regions and ports
-declare -a regions=("us-east-1" "us-west-2" "eu-west-1" "ap-southeast-1" "ap-southeast-2" "ap-northeast-1" "ap-south-1" "ca-central-1" "sa-east-1" "us-gov-west-1" "us-gov-east-1" "us-west-1")
-declare -a ports=(8001 8002 8003 8004 8005 8006 8007 8008 8009 8010 8011 8012)
+# Define regions and ports (must match available release assets)
+declare -a regions=("us-east-1" "us-west-2" "eu-west-1" "ap-southeast-1" "ap-southeast-2" "ap-northeast-1" "ap-south-1" "ca-central-1" "sa-east-1")
+declare -a ports=(8001 8002 8003 8004 8005 8006 8007 8008 8009)
 
 # start_binary starts the region-specific finfocus-plugin-aws-public binary in the background, prefixes non-JSON output with the region, injects a `"region"` field into JSON log lines, and writes the background PID to /tmp/pid_<region>.
 start_binary() {

--- a/docker/healthcheck.sh
+++ b/docker/healthcheck.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Health check script for finfocus-plugin-aws-public multi-region container
-# Verifies that all 12 regional HTTP endpoints are responding
+# Verifies that all 9 regional HTTP endpoints are responding
 #
 # Optional environment variables:
 #   QUIET_HEALTHCHECK - When set to 1/true, suppresses verbose output
@@ -11,8 +11,8 @@
 
 set -e
 
-# Define ports
-declare -a ports=(8001 8002 8003 8004 8005 8006 8007 8008 8009 8010 8011 8012)
+# Define ports (must match available release assets: 9 regions)
+declare -a ports=(8001 8002 8003 8004 8005 8006 8007 8008 8009)
 
 # Check quiet mode
 quiet="${QUIET_HEALTHCHECK:-0}"

--- a/docs/carbon-estimation.md
+++ b/docs/carbon-estimation.md
@@ -19,6 +19,7 @@ methodology to calculate operational carbon emissions (gCO2e) for AWS resources.
 | Lambda | ✅ Full | vCPU equivalent × duration × grid factor |
 | RDS | ✅ Full | Compute + storage carbon |
 | DynamoDB | ✅ Full | Storage-based (SSD × 3× replication) |
+| ElastiCache | ✅ Full | EC2-equivalent node carbon × cluster size |
 | EKS | ⚠️ Control plane only | Returns 0 (shared infrastructure) |
 
 ## Carbon Formula
@@ -217,8 +218,8 @@ generation mixes:
 | ap-southeast-1 (Singapore) | 0.000408 | Above average |
 | ap-south-1 (Mumbai) | 0.000708 | High (coal) |
 
-**Implication:** Running the same workload in eu-north-1 vs ap-south-1 can result
-in **80× less carbon emissions**.
+**Implication:** Running the same workload in eu-north-1 (~0.0000088 tCO2e/kWh, hydro)
+vs ap-south-1 (~0.000708 tCO2e/kWh, coal) can result in **80× less carbon emissions**.
 
 ## Utilization
 
@@ -283,6 +284,12 @@ monthlyEmbodiedCarbon = (1000 kgCO2e / 48 months) × (instanceVCPUs / maxFamilyV
 
 The vCPU scaling factor accounts for shared server resources—a smaller instance
 consumes a proportionally smaller share of the server's embodied carbon.
+
+**API Note:** The `EC2InstanceConfig` struct has a top-level `IncludeEmbodiedCarbon`
+boolean for convenience. When `true`, the `EmbodiedConfig.Enabled` field is
+automatically honored. Use `IncludeEmbodiedCarbon: true` as the primary toggle;
+the nested `EmbodiedConfig` struct allows overriding default values (lifespan,
+carbon per server) when needed.
 
 ## Limitations
 

--- a/internal/plugin/constants.go
+++ b/internal/plugin/constants.go
@@ -32,3 +32,30 @@ const RelationshipWithin = "within"
 
 // RelationshipManagedBy represents a management relationship (ELB → EC2).
 const RelationshipManagedBy = "managed_by"
+
+// ZeroCostServices is the canonical set of AWS resource types that have no direct charges.
+// These resources (VPC, Security Groups, Subnets) are "free tier" networking infrastructure.
+// Use IsZeroCostService() for membership checks.
+//
+// When adding new zero-cost resources:
+// 1. Add the canonical service name here
+// 2. Add the Pulumi pattern to ZeroCostPulumiPatterns below
+var ZeroCostServices = map[string]bool{
+	"vpc":           true,
+	"securitygroup": true,
+	"subnet":        true,
+}
+
+// ZeroCostPulumiPatterns maps Pulumi resource type path segments to canonical service names.
+// Used by normalizeResourceType() to detect zero-cost resources from Pulumi format.
+// Example: "ec2/vpc" in "aws:ec2/vpc:Vpc" maps to "vpc"
+var ZeroCostPulumiPatterns = map[string]string{
+	"ec2/vpc":           "vpc",
+	"ec2/securitygroup": "securitygroup",
+	"ec2/subnet":        "subnet",
+}
+
+// IsZeroCostService returns true if the canonical service name has no direct AWS charges.
+func IsZeroCostService(service string) bool {
+	return ZeroCostServices[service]
+}


### PR DESCRIPTION
…cs advertisement

## Summary

- VPC, Security Groups, and Subnets now return $0 estimates with helpful billing details instead of erroring due to missing SKU
- `getSupportedMetrics()` now advertises carbon footprint for all 8 services that have carbon estimation implemented (was only EC2 + ElastiCache)
- Documentation updated with actual grid factor values (eu-north-1 vs ap-south-1) and clarification on embodied carbon configuration fields

## Test plan

- [x] `make lint` passes with zero issues
- [x] `go build -tags region_use1 ./...` compiles successfully
- [x] `go test -tags region_use1 ./internal/plugin/...` passes
- [x] Markdown validation passes for ROADMAP.md and docs/carbon-estimation.md

## Changes

### Modified files

- `internal/plugin/validation.go` - Added `isZeroCostResource()` to bypass SKU requirement for VPC/SecurityGroup/Subnet resource types
- `internal/plugin/projected.go` - Added `normalizeResourceType()` handling for zero-cost resources and `estimateZeroCostResource()` function
- `internal/plugin/supports.go` - Added zero-cost resource case and expanded `getSupportedMetrics()` to include EBS, S3, Lambda, RDS, DynamoDB, EKS
- `internal/plugin/supports_test.go` - Updated tests to expect carbon support for all services that have estimation implemented
- `docs/carbon-estimation.md` - Added actual grid factor values, ElastiCache to supported services table, and API note on embodied carbon config
- `ROADMAP.md` - Added ElastiCache carbon and multi-region Docker to Done, added zero-cost handling to Immediate Focus

Closes #237
Closes #257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Roadmap updated with new milestones and planned multi-region and discovery items; documentation now lists ElastiCache in supported services.

* **Behavior Changes**
  * VPC, Security Groups, and Subnets return $0 estimates and no-SKU validation; Docker runtime exposes and health-checks 9 regional endpoints.

* **Documentation**
  * Carbon docs updated with regional energy intensities and an embodied-carbon toggle; roadmap reorganized.

* **Tests**
  * Added tests covering zero-cost resources and validation/metrics behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->