### PR TITLE
chore: streamline CLAUDE.md and fix docker-publish permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -11,6 +11,10 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Reduced CLAUDE.md from 1168 to 732 lines (37% reduction) by removing redundant sections that duplicated README.md content. Added a Quick Reference section at the top for faster onboarding. Updated carbon estimation documentation to reflect completed comprehensive support across all services (EC2, EBS, S3, Lambda, RDS, DynamoDB, ElastiCache).

Fixed docker-publish workflow failing with "installation not allowed to Create organization package" by adding the missing `permissions` block with `packages: write`.

## Test plan

- [x] `make lint` passes
- [x] `make test` passes
- [x] markdownlint on CLAUDE.md (pre-existing issues only)
- [ ] Docker publish workflow succeeds on next release

## Changes

### Modified files

- `CLAUDE.md` - Removed 466 lines of redundancy, added Quick Reference section, updated carbon estimation table to show comprehensive support
- `.github/workflows/docker-publish.yml` - Added `permissions` block with `contents: read` and `packages: write`