### PR TITLE
fix: release us-west-1

### DIFF
--- a/scripts/release-region.sh
+++ b/scripts/release-region.sh
@@ -23,6 +23,7 @@ fi
 # Map region to build tag
 declare -A REGION_TAGS=(
     ["us-east-1"]="region_use1"
+    ["us-west-1"]="region_usw1"
     ["us-west-2"]="region_usw2"
     ["eu-west-1"]="region_euw1"
     ["ap-southeast-1"]="region_apse1"


### PR DESCRIPTION
This pull request updates the region-to-build tag mapping in the `scripts/release-region.sh` script to support an additional AWS region.

Region mapping update:

* Added support for the `us-west-1` region by mapping it to the `region_usw1` build tag in the `REGION_TAGS` associative array.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Extended release process to support builds for the us-west-1 region, enabling service deployment to an additional AWS region.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->