### PR TITLE
chore: lock go at 1.25

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
 
 language: en-US
-tone_instructions: "Focus on Go 1.25.5 best practices and modern Go idioms"
+tone_instructions: "Focus on Go 1.25.8 best practices and modern Go idioms"
 early_access: false
 enable_free_tier: true
 reviews:
@@ -42,20 +42,20 @@ reviews:
   path_instructions:
     - path: "**/*.go"
       instructions: |
-        Please ensure this Go code is compatible with Go 1.25.5.
+        Please ensure this Go code is compatible with Go 1.25.8.
         Consider using the latest Go features and best practices.
         Pay special attention to:
         - Error handling with proper error wrapping
         - Use of generics where appropriate
         - Modern Go idioms and patterns
-        - Performance optimizations available in Go 1.25.5
+        - Performance optimizations available in Go 1.25.8
         - Proper documentation for exported functions and types
         - Security vulnerabilities and best practices
     - path: "**/*_test.go"
       instructions: |
         Please ensure adequate test coverage for new functionality.
         Consider adding integration tests for complex logic.
-        Use Go 1.25.5 testing features where appropriate.
+        Use Go 1.25.8 testing features where appropriate.
         - Ensure tests cover edge cases and error conditions
         - Check for proper use of testing utilities and patterns
         - Verify test isolation and cleanup
@@ -75,7 +75,7 @@ reviews:
       instructions: |
         Please review Go module dependencies for:
         - Security vulnerabilities
-        - Compatibility with Go 1.25.5
+        - Compatibility with Go 1.25.8
         - Latest stable versions
         - Proper module structure
   abort_on_close: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,7 +63,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.5"
+          go-version: '1.25'
+          check-latest: true
 
       - name: Log in to GHCR
         uses: docker/login-action@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '1.25'
+          check-latest: true
           cache: false # Disable cache - we clean between regions to save disk
 
       # 3. Install GoReleaser

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '1.25'
+          check-latest: true
           cache: true
 
       - name: Generate pricing data
@@ -63,6 +64,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: '1.25'
+          check-latest: true
           cache: false # Disable cache - we clean between regions to save disk
 
       - name: Install GoReleaser

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,7 +52,7 @@ RUN set -ex; \
     echo "Successfully downloaded and verified all regional binaries"
 
 # Stage 2: Build metrics-aggregator
-FROM golang:1.25.5-alpine AS builder
+FROM golang:1.25.8-alpine AS builder
 
 WORKDIR /workspace
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rshade/finfocus-plugin-aws-public
 
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/goccy/go-json v0.10.6

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchDepNames": ["go"],
+      "allowedVersions": "~1.25"
+    }
   ]
 }

--- a/tools/generate-embeds/go.mod
+++ b/tools/generate-embeds/go.mod
@@ -1,6 +1,6 @@
 module github.com/rshade/finfocus-plugin-aws-public/tools/generate-embeds
 
-go 1.25.5
+go 1.25.8
 
 require github.com/rshade/finfocus-plugin-aws-public v0.1.5
 

--- a/tools/generate-goreleaser/go.mod
+++ b/tools/generate-goreleaser/go.mod
@@ -1,6 +1,6 @@
 module github.com/rshade/finfocus-plugin-aws-public/tools/generate-goreleaser
 
-go 1.25.5
+go 1.25.8
 
 require github.com/rshade/finfocus-plugin-aws-public v0.1.5
 

--- a/tools/parse-regions/go.mod
+++ b/tools/parse-regions/go.mod
@@ -1,5 +1,5 @@
 module github.com/rshade/finfocus-plugin-aws-public/tools/parse-regions
 
-go 1.25.4
+go 1.25.8
 
 require github.com/goccy/go-yaml v1.19.2


### PR DESCRIPTION
This pull request updates the project to use Go version 1.25.8 throughout the codebase, configuration, and documentation. The changes ensure consistency in Go version usage across build pipelines, Docker images, module files, and review instructions.

**Go version updates:**

* Updated the Go version in all `go.mod` files to `1.25.8` for the main module and all tooling submodules. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3) [[2]](diffhunk://#diff-996afc5d79369a774fe558c3faa09803368271e5c79548dc85596c4be104777aL3-R3) [[3]](diffhunk://#diff-f89eea8a88a9f0c5f1ea6278fe16dc671698947cd6d87ca3fe1b8a96e9503519L3-R3) [[4]](diffhunk://#diff-cbbc760464fcad02b8cb0e85feaac6a66a61b6347b653f56a2dfb75baddee8f5L3-R3)
* Changed the base image in `docker/Dockerfile` and the Go version in the GitHub Actions workflow to `1.25.8`. [[1]](diffhunk://#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcL55-R55) [[2]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L66-R66)

**Configuration and documentation:**

* Updated `.coderabbit.yaml` to reference Go 1.25.8 in tone instructions, path instructions, and review criteria. [[1]](diffhunk://#diff-c0f93b6ec1bb8a9771fe87219aa22843985ba0cd27a23689b7be274bfb7baf57L4-R4) [[2]](diffhunk://#diff-c0f93b6ec1bb8a9771fe87219aa22843985ba0cd27a23689b7be274bfb7baf57L45-R58) [[3]](diffhunk://#diff-c0f93b6ec1bb8a9771fe87219aa22843985ba0cd27a23689b7be274bfb7baf57L78-R78)
* Added a Renovate configuration rule to only allow Go versions in the `~1.25` range.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain references to 1.25.8 across build configs, Docker images, and tooling to align environments.
  * Enabled CI to check for the latest compatible Go patch during setup for smoother workflow updates.
  * Added dependency management rules to constrain automated updates to the Go 1.25.x release series.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->