### PR TITLE
docs(plugin): document parseGoMapString space limitation and add defe…

### DIFF
--- a/internal/plugin/ec2_attrs.go
+++ b/internal/plugin/ec2_attrs.go
@@ -151,6 +151,12 @@ type RootVolumeInfo struct {
 // For each space-separated token, the first colon splits key from value.
 // Values containing colons are preserved (e.g., "arn:aws:..." keeps the full ARN).
 // Returns an empty map for empty or malformed input.
+//
+// Limitation: values containing spaces are not supported and will be silently
+// mis-parsed because strings.Fields splits on all whitespace. For example,
+// "map[name:My Volume]" yields {"name": "My"} with "Volume" dropped (no colon).
+// This is sufficient for Pulumi's rootBlockDevice serialization which only
+// produces simple scalar values (type strings, booleans, integers).
 func parseGoMapString(s string) map[string]string {
 	result := make(map[string]string)
 
@@ -181,8 +187,9 @@ func parseGoMapString(s string) map[string]string {
 	return result
 }
 
-// parsePositiveIntField parses positive integer tag values used for root volume size fields.
-// It logs a warning for malformed or non-positive values.
+// parsePositiveIntField parses strictly positive (> 0) integer tag values used for root
+// volume size fields. Zero is rejected (treated as non-positive). It logs a warning
+// for malformed or non-positive values and returns (0, false).
 func parsePositiveIntField(fieldName, raw string) (int, bool) {
 	size, err := strconv.Atoi(raw)
 	if err != nil || size <= 0 {

--- a/internal/plugin/ec2_attrs_test.go
+++ b/internal/plugin/ec2_attrs_test.go
@@ -498,6 +498,15 @@ func TestParseGoMapString(t *testing.T) {
 			input: "  map[volumeSize:8 volumeType:gp2]  ",
 			want:  map[string]string{"volumeSize": "8", "volumeType": "gp2"},
 		},
+		{
+			// Documents known limitation: values with spaces are silently truncated
+			// because strings.Fields splits on whitespace. "My Volume" becomes two
+			// tokens: "name:My" (parsed as name→My) and "Volume" (no colon, skipped).
+			// This is acceptable because Pulumi's rootBlockDevice only uses scalar values.
+			name:  "space in value truncates silently",
+			input: "map[name:My Volume volumeType:gp2]",
+			want:  map[string]string{"name": "My", "volumeType": "gp2"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
…nsive test

## Summary

- Add godoc to `parseGoMapString()` explicitly noting that values containing spaces are silently mis-parsed due to `strings.Fields` splitting, and why this is acceptable for the current Pulumi rootBlockDevice use case
- Add a defensive test case that locks in the truncation behavior for space-in-value input, preventing future maintainers from accidentally relying on unsupported input
- Clarify `parsePositiveIntField()` docstring to state that zero is rejected (not just negative values)

## Test plan

- [x] `TestParseGoMapString/space_in_value_truncates_silently` passes and documents expected truncation behavior
- [x] All existing `TestParseGoMapString` subtests continue to pass (9 total)
- [x] `TestExtractRootVolumeFromTags` suite passes
- [ ] `make lint` passes
- [ ] `make test` passes

## Changes

### Modified files

- `internal/plugin/ec2_attrs.go` — Added space-limitation godoc to `parseGoMapString()` and clarified `parsePositiveIntField()` docstring (zero is non-positive)
- `internal/plugin/ec2_attrs_test.go` — Added `space_in_value_truncates_silently` test case documenting truncation behavior

Closes #315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced EC2 attribute parsing validation to enforce strictly positive values and provide clearer error messages for invalid inputs with field details.

* **Documentation**
  * Documented known limitation in EC2 attribute string parsing: values containing spaces are silently truncated during parsing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->