### PR TITLE
fix(plugin): make allowEmptyRegion service-aware in parseResourceFromRequest

### DIFF
--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -533,9 +533,12 @@ func (p *AWSPublicPlugin) parseResourceFromRequest(req *pbc.GetActualCostRequest
 	}
 
 	// Validate required fields.
-	// Region may be empty for tag-derived requests so global services (S3/IAM)
-	// can use plugin-region fallback during validation.
-	allowEmptyRegion := len(req.GetTags()) > 0
+	// Region may be empty only for global services (S3/IAM) and zero-cost resources,
+	// which use plugin-region fallback during downstream validation.
+	// Regional services (EC2/EBS/RDS/etc.) must always specify a region.
+	normalizedType := normalizeResourceType(resource.GetResourceType())
+	service := detectService(normalizedType)
+	allowEmptyRegion := service == serviceS3 || service == serviceIAM || IsZeroCostService(service)
 	if resource.GetProvider() == "" || resource.GetResourceType() == "" || resource.GetSku() == "" ||
 		(!allowEmptyRegion && resource.GetRegion() == "") {
 		return nil, status.Error(

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -706,3 +706,115 @@ func TestNewAWSPublicPlugin_DeprecatedEnvVars(t *testing.T) {
 		})
 	}
 }
+
+// TestParseResourceFromRequest_ServiceAwareRegionValidation verifies that
+// parseResourceFromRequest uses service-aware logic for region validation.
+//
+// Previously, the function allowed empty region for ANY tag-derived request
+// (allowEmptyRegion := len(req.GetTags()) > 0). This was too broad — regional
+// services like EC2/EBS/RDS should require a region even when tags are present.
+// Only truly global services (S3, IAM) and zero-cost services should be allowed
+// to omit region.
+//
+// Bug: https://github.com/rshade/finfocus-plugin-aws-public/issues/324
+func TestParseResourceFromRequest_ServiceAwareRegionValidation(t *testing.T) {
+	logger := zerolog.Nop()
+	p := NewAWSPublicPlugin("us-east-1", "test-version", nil, logger)
+
+	tests := []struct {
+		name      string
+		tags      map[string]string
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "EC2 with tags but no region should fail",
+			tags: map[string]string{
+				"provider":      "aws",
+				"resource_type": "ec2",
+				"sku":           "t3.micro",
+			},
+			wantErr:   true,
+			errSubstr: "resource information incomplete",
+		},
+		{
+			name: "EBS with tags but no region should fail",
+			tags: map[string]string{
+				"provider":      "aws",
+				"resource_type": "ebs",
+				"sku":           "gp3",
+			},
+			wantErr:   true,
+			errSubstr: "resource information incomplete",
+		},
+		{
+			name: "RDS with tags but no region should fail",
+			tags: map[string]string{
+				"provider":      "aws",
+				"resource_type": "rds",
+				"sku":           "db.t3.micro",
+			},
+			wantErr:   true,
+			errSubstr: "resource information incomplete",
+		},
+		{
+			name: "S3 with tags but no region should succeed",
+			tags: map[string]string{
+				"provider":      "aws",
+				"resource_type": "s3",
+				"sku":           "STANDARD",
+			},
+			wantErr: false,
+		},
+		{
+			name: "IAM with tags but no region should succeed",
+			tags: map[string]string{
+				"provider":      "aws",
+				"resource_type": "iam",
+				"sku":           "role",
+			},
+			wantErr: false,
+		},
+		{
+			name: "VPC (zero-cost) with tags but no region should succeed",
+			tags: map[string]string{
+				"provider":      "aws",
+				"resource_type": "vpc",
+				"sku":           "default",
+			},
+			wantErr: false,
+		},
+		{
+			name: "EC2 with tags and region should succeed",
+			tags: map[string]string{
+				"provider":      "aws",
+				"resource_type": "ec2",
+				"sku":           "t3.micro",
+				"region":        "us-east-1",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &pbc.GetActualCostRequest{
+				ResourceId: "invalid-json",
+				Tags:       tt.tags,
+			}
+
+			resource, err := p.parseResourceFromRequest(req)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil (resource: %v)", tt.errSubstr, resource)
+				} else if !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("expected error containing %q, got: %v", tt.errSubstr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION

## Summary

- Replaced the broad `len(req.GetTags()) > 0` check with service-aware
  detection using the established `normalizeResourceType` and `detectService`
  pattern, so only S3, IAM, and zero-cost services can omit region
- Regional services (EC2, EBS, RDS, EKS, Lambda, etc.) now correctly
  reject tag-derived requests that lack a region field

## Test plan

- [x] Added 7 test cases in `TestParseResourceFromRequest_ServiceAwareRegionValidation`
- [x] Verified EC2/EBS/RDS with tags but no region are rejected
- [x] Verified S3/IAM with tags but no region are accepted
- [x] Verified zero-cost resources (VPC) with tags but no region are accepted
- [x] Verified EC2 with tags and region succeeds
- [x] `make test` passes with zero failures
- [x] `make lint` passes with zero issues

## Changes

### Modified files

- `internal/plugin/plugin.go` — Replaced `allowEmptyRegion` boolean with
  service-aware logic using `normalizeResourceType`/`detectService`
- `internal/plugin/plugin_test.go` — Added table-driven test covering
  regional rejection and global/zero-cost acceptance

Closes https://github.com/rshade/finfocus-plugin-aws-public/issues/324

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved region validation logic to be service-aware. Region is now optional for S3, IAM, and zero-cost services, while remaining required for other AWS services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->