### PR TITLE
test(plugin): add direct unit test for parsePositiveIntField zero rej…

### DIFF
--- a/internal/plugin/ec2_attrs_test.go
+++ b/internal/plugin/ec2_attrs_test.go
@@ -446,6 +446,39 @@ func mustStruct(m map[string]interface{}) *structpb.Struct {
 	return s
 }
 
+// TestParsePositiveIntField verifies that parsePositiveIntField correctly rejects
+// zero, negative, and non-numeric values while accepting valid positive integers.
+// This directly tests the boundary behavior documented in the function's docstring:
+// values ≤ 0 (including zero) return (0, false) with a warning log.
+func TestParsePositiveIntField(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantVal int
+		wantOK  bool
+	}{
+		{name: "positive integer", input: "10", wantVal: 10, wantOK: true},
+		{name: "one", input: "1", wantVal: 1, wantOK: true},
+		{name: "zero is rejected", input: "0", wantVal: 0, wantOK: false},
+		{name: "negative is rejected", input: "-5", wantVal: 0, wantOK: false},
+		{name: "non-numeric is rejected", input: "abc", wantVal: 0, wantOK: false},
+		{name: "empty string is rejected", input: "", wantVal: 0, wantOK: false},
+		{name: "float is rejected", input: "10.5", wantVal: 0, wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val, ok := parsePositiveIntField("test_field", tt.input)
+			if ok != tt.wantOK {
+				t.Errorf("parsePositiveIntField(%q) ok = %v, want %v", tt.input, ok, tt.wantOK)
+			}
+			if val != tt.wantVal {
+				t.Errorf("parsePositiveIntField(%q) val = %d, want %d", tt.input, val, tt.wantVal)
+			}
+		})
+	}
+}
+
 // TestParseGoMapString verifies parsing of Go's fmt.Sprint map format strings.
 func TestParseGoMapString(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
…ection

## Summary

- Add table-driven `TestParsePositiveIntField` covering 7 edge cases: valid positive integers, zero, negative, non-numeric, empty string, and float inputs
- The docstring improvements for `parsePositiveIntField` and `parseGoMapString` were already applied in PR #329; this completes the remaining acceptance criterion from issue #317

## Test plan

- [x] `TestParsePositiveIntField` passes all 7 subtests
- [x] `make test` passes (full suite)
- [x] `make lint` passes with zero issues

## Changes

### Modified files

- `internal/plugin/ec2_attrs_test.go` - Add `TestParsePositiveIntField` with boundary-value test cases for zero, negative, non-numeric, empty, and float inputs

Closes #317

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for positive integer field parsing validation, including boundary cases.

**Note:** This is a test-focused change with no direct user-facing impact. Code review attention recommended due to duplicate test function declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->