### PR TITLE
fix(plugin): replace global logger in parsePositiveIntField

### DIFF
--- a/internal/plugin/ec2_attrs.go
+++ b/internal/plugin/ec2_attrs.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/rs/zerolog/log"
+	"github.com/rs/zerolog"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -187,17 +187,13 @@ func parseGoMapString(s string) map[string]string {
 	return result
 }
 
-// parsePositiveIntField parses strictly positive (> 0) integer tag values used for root
-// volume size fields. Zero is rejected (treated as non-positive). It logs a warning
-// for malformed or non-positive values and returns (0, false).
-func parsePositiveIntField(fieldName, raw string) (int, bool) {
+// parsePositiveInt parses strictly positive (> 0) integer values used for root
+// volume size fields. Zero is rejected (treated as non-positive). Returns (0, false)
+// for malformed or non-positive values; callers are responsible for logging with
+// trace-aware context.
+func parsePositiveInt(raw string) (int, bool) {
 	size, err := strconv.Atoi(raw)
 	if err != nil || size <= 0 {
-		log.Warn().
-			Str("field", fieldName).
-			Str("value", raw).
-			Err(err).
-			Msg("invalid root volume size value")
 		return 0, false
 	}
 	return size, true
@@ -205,6 +201,7 @@ func parsePositiveIntField(fieldName, raw string) (int, bool) {
 
 // ExtractRootVolumeFromTags extracts root EBS volume configuration from a
 // ResourceDescriptor.Tags map. This is used by the GetProjectedCost path.
+// The logger parameter enables trace-aware warning logs for invalid volume sizes.
 //
 // Tag priority:
 //  1. Individual tags "root_volume_type" and "root_volume_size" (explicit overrides)
@@ -215,7 +212,7 @@ func parsePositiveIntField(fieldName, raw string) (int, bool) {
 //   - If no root volume source found → RootVolumeInfo{Present: false} (no cost added)
 //   - If source present but missing type → defaults to "gp2"
 //   - If source present but missing/invalid size → defaults to 8 GB
-func ExtractRootVolumeFromTags(tags map[string]string) RootVolumeInfo {
+func ExtractRootVolumeFromTags(tags map[string]string, logger zerolog.Logger) RootVolumeInfo {
 	if tags == nil {
 		return RootVolumeInfo{}
 	}
@@ -233,8 +230,13 @@ func ExtractRootVolumeFromTags(tags map[string]string) RootVolumeInfo {
 				volumeType = vt
 			}
 			if vs, vsOK := rbdMap["volumeSize"]; vsOK && vs != "" {
-				if size, sizeOK := parsePositiveIntField("rootBlockDevice.volumeSize", vs); sizeOK {
+				if size, sizeOK := parsePositiveInt(vs); sizeOK {
 					sizeGB = size
+				} else {
+					logger.Warn().
+						Str("field", "rootBlockDevice.volumeSize").
+						Str("value", vs).
+						Msg("invalid root volume size value")
 				}
 			}
 		}
@@ -247,8 +249,13 @@ func ExtractRootVolumeFromTags(tags map[string]string) RootVolumeInfo {
 	}
 	if rvs, rvsOK := tags["root_volume_size"]; rvsOK && rvs != "" {
 		hasSource = true
-		if size, sizeOK := parsePositiveIntField("root_volume_size", rvs); sizeOK {
+		if size, sizeOK := parsePositiveInt(rvs); sizeOK {
 			sizeGB = size
+		} else {
+			logger.Warn().
+				Str("field", "root_volume_size").
+				Str("value", rvs).
+				Msg("invalid root volume size value")
 		}
 	}
 
@@ -273,13 +280,14 @@ func ExtractRootVolumeFromTags(tags map[string]string) RootVolumeInfo {
 
 // ExtractRootVolumeFromStruct extracts root EBS volume configuration from a
 // protobuf Struct (used in the EstimateCost path). Checks the "rootBlockDevice"
-// attribute for volume type and size.
+// attribute for volume type and size. The logger parameter enables trace-aware
+// warning logs for invalid volume sizes.
 //
 // Default behavior matches ExtractRootVolumeFromTags:
 //   - If no rootBlockDevice attribute → RootVolumeInfo{Present: false}
 //   - If present but missing type → defaults to "gp2"
 //   - If present but missing/invalid size → defaults to 8 GB
-func ExtractRootVolumeFromStruct(attrs *structpb.Struct) RootVolumeInfo {
+func ExtractRootVolumeFromStruct(attrs *structpb.Struct, logger zerolog.Logger) RootVolumeInfo {
 	if attrs == nil || attrs.GetFields() == nil {
 		return RootVolumeInfo{}
 	}
@@ -295,12 +303,12 @@ func ExtractRootVolumeFromStruct(attrs *structpb.Struct) RootVolumeInfo {
 
 	switch v := rbdVal.GetKind().(type) {
 	case *structpb.Value_StructValue:
-		volumeType, sizeGB = extractRootVolumeFromStructValue(v.StructValue)
+		volumeType, sizeGB = extractRootVolumeFromStructValue(v.StructValue, logger)
 	case *structpb.Value_ListValue:
 		// Take the first element if it's a list
 		if v.ListValue != nil && len(v.ListValue.GetValues()) > 0 {
 			if sv := v.ListValue.GetValues()[0].GetStructValue(); sv != nil {
-				volumeType, sizeGB = extractRootVolumeFromStructValue(sv)
+				volumeType, sizeGB = extractRootVolumeFromStructValue(sv, logger)
 			}
 		}
 	case *structpb.Value_StringValue:
@@ -313,8 +321,13 @@ func ExtractRootVolumeFromStruct(attrs *structpb.Struct) RootVolumeInfo {
 			volumeType = vt
 		}
 		if vs, vsOK := rbdMap["volumeSize"]; vsOK && vs != "" {
-			if size, sizeOK := parsePositiveIntField("rootBlockDevice.volumeSize", vs); sizeOK {
+			if size, sizeOK := parsePositiveInt(vs); sizeOK {
 				sizeGB = size
+			} else {
+				logger.Warn().
+					Str("field", "rootBlockDevice.volumeSize").
+					Str("value", vs).
+					Msg("invalid root volume size value")
 			}
 		}
 	default:
@@ -337,7 +350,7 @@ func ExtractRootVolumeFromStruct(attrs *structpb.Struct) RootVolumeInfo {
 }
 
 // extractRootVolumeFromStructValue extracts volume type and size from a structpb.Struct.
-func extractRootVolumeFromStructValue(s *structpb.Struct) (string, int) {
+func extractRootVolumeFromStructValue(s *structpb.Struct, logger zerolog.Logger) (string, int) {
 	if s == nil {
 		return "", 0
 	}
@@ -356,8 +369,13 @@ func extractRootVolumeFromStructValue(s *structpb.Struct) (string, int) {
 				sizeGB = int(sv.NumberValue)
 			}
 		case *structpb.Value_StringValue:
-			if size, sizeOK := parsePositiveIntField("rootBlockDevice.volumeSize", sv.StringValue); sizeOK {
+			if size, sizeOK := parsePositiveInt(sv.StringValue); sizeOK {
 				sizeGB = size
+			} else {
+				logger.Warn().
+					Str("field", "rootBlockDevice.volumeSize").
+					Str("value", sv.StringValue).
+					Msg("invalid root volume size value")
 			}
 		}
 	}

--- a/internal/plugin/ec2_attrs_test.go
+++ b/internal/plugin/ec2_attrs_test.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"testing"
 
+	"github.com/rs/zerolog"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -531,7 +532,7 @@ func TestExtractRootVolumeFromTags_GoMapFormat(t *testing.T) {
 	tags := map[string]string{
 		"rootBlockDevice": "map[volumeSize:20 volumeType:gp3]",
 	}
-	rv := ExtractRootVolumeFromTags(tags)
+	rv := ExtractRootVolumeFromTags(tags, zerolog.Nop())
 
 	if !rv.Present {
 		t.Fatal("Expected Present=true for rootBlockDevice tag")
@@ -551,7 +552,7 @@ func TestExtractRootVolumeFromTags_IndividualTags(t *testing.T) {
 		"root_volume_type": "io1",
 		"root_volume_size": "100",
 	}
-	rv := ExtractRootVolumeFromTags(tags)
+	rv := ExtractRootVolumeFromTags(tags, zerolog.Nop())
 
 	if !rv.Present {
 		t.Fatal("Expected Present=true for individual tags")
@@ -572,7 +573,7 @@ func TestExtractRootVolumeFromTags_IndividualOverridesMap(t *testing.T) {
 		"root_volume_type": "gp3",
 		"root_volume_size": "50",
 	}
-	rv := ExtractRootVolumeFromTags(tags)
+	rv := ExtractRootVolumeFromTags(tags, zerolog.Nop())
 
 	if !rv.Present {
 		t.Fatal("Expected Present=true")
@@ -601,7 +602,7 @@ func TestExtractRootVolumeFromTags_NoInfo(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rv := ExtractRootVolumeFromTags(tt.tags)
+			rv := ExtractRootVolumeFromTags(tt.tags, zerolog.Nop())
 			if rv.Present {
 				t.Errorf("Expected Present=false for tags %v", tt.tags)
 			}
@@ -664,7 +665,7 @@ func TestExtractRootVolumeFromTags_Defaults(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rv := ExtractRootVolumeFromTags(tt.tags)
+			rv := ExtractRootVolumeFromTags(tt.tags, zerolog.Nop())
 			if !rv.Present {
 				t.Fatal("Expected Present=true")
 			}
@@ -756,7 +757,7 @@ func TestExtractRootVolumeFromStruct(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rv := ExtractRootVolumeFromStruct(tt.attrs)
+			rv := ExtractRootVolumeFromStruct(tt.attrs, zerolog.Nop())
 			if rv.Present != tt.wantPresent {
 				t.Fatalf("Present = %v, want %v", rv.Present, tt.wantPresent)
 			}

--- a/internal/plugin/estimate.go
+++ b/internal/plugin/estimate.go
@@ -228,7 +228,7 @@ func (p *AWSPublicPlugin) estimateEC2FromAttrs(traceID, resourceName string, att
 	costMonthly := hourlyRate * carbon.HoursPerMonth
 
 	// Add root EBS volume cost when rootBlockDevice attribute is present
-	rootVol := ExtractRootVolumeFromStruct(attrs)
+	rootVol := ExtractRootVolumeFromStruct(attrs, *p.traceLogger(traceID, "EstimateCost"))
 	if rootVol.Present {
 		if ebsRate, ebsFound := p.pricing.EBSPricePerGBMonth(rootVol.VolumeType); ebsFound {
 			costMonthly += ebsRate * float64(rootVol.SizeGB)

--- a/internal/plugin/projected.go
+++ b/internal/plugin/projected.go
@@ -309,7 +309,7 @@ func (p *AWSPublicPlugin) estimateEC2(
 	billingDetail := fmt.Sprintf("On-demand %s, %s tenancy, 730 hrs/month", ec2Attrs.OS, ec2Attrs.Tenancy)
 
 	// Root EBS volume cost: Include root volume storage when tag info is present
-	rootVol := ExtractRootVolumeFromTags(resource.GetTags())
+	rootVol := ExtractRootVolumeFromTags(resource.GetTags(), *p.traceLogger(traceID, "GetProjectedCost"))
 	var rootVolumeCost float64
 	if rootVol.Present {
 		if ebsRate, ebsFound := p.pricing.EBSPricePerGBMonth(rootVol.VolumeType); ebsFound {


### PR DESCRIPTION

## Summary

- Removed global `zerolog/log` import from `ec2_attrs.go`, replacing it with injected `zerolog.Logger` parameters on `ExtractRootVolumeFromTags`, `ExtractRootVolumeFromStruct`, and `extractRootVolumeFromStructValue`
- Renamed `parsePositiveIntField` to `parsePositiveInt`, removing the unused `fieldName` parameter to make it a pure function with no side effects
- Warning logs for invalid root volume sizes now include `trace_id` and `operation` fields via the caller's `traceLogger`, enabling log correlation in production

## Test plan

- [x] `make test` passes — all unit tests updated with `zerolog.Nop()` for the new logger parameter
- [x] `make lint` passes with zero issues
- [x] No remaining references to `parsePositiveIntField`
- [x] No `zerolog/log` import in `ec2_attrs.go`

## Changes

### Modified files

- `internal/plugin/ec2_attrs.go` — Replaced global logger with injected `zerolog.Logger`; renamed `parsePositiveIntField` to `parsePositiveInt` (pure function)
- `internal/plugin/projected.go` — Pass trace-aware logger to `ExtractRootVolumeFromTags`
- `internal/plugin/estimate.go` — Pass trace-aware logger to `ExtractRootVolumeFromStruct`
- `internal/plugin/ec2_attrs_test.go` — Added `zerolog` import; updated all `ExtractRootVolume*` calls with `zerolog.Nop()`

Closes #323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal logging infrastructure for EC2 attribute extraction and cost estimation functions to use explicit logger parameters for improved traceability.

* **Tests**
  * Updated tests to accommodate refactored function signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->