### PR TITLE
perf(router,plugin): use RWMutex for child getters and reuse EBS

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -28,8 +28,8 @@ security overhead of cloud credentials.
     registry.go (#325) [S]
   - **Doc Clarification:** Clarify `parsePositiveIntField` and
     `parseGoMapString` limitations (#317, #315) [S]
-  - **RWMutex Optimization:** Use `RWMutex` for child getters and reuse EBS
-    estimator (#322) [S]
+  - ~~**RWMutex Optimization:** Use `RWMutex` for child getters and reuse EBS
+    estimator (#322) [S]~~ ✅
   - **Service Constants:** Use service constants in `ZeroCostServices` and
     `ZeroCostPulumiPatterns` maps (#321) [S]
   - **Lint Directives:** Replace global threshold increases with targeted

--- a/internal/plugin/ec2_attrs_test.go
+++ b/internal/plugin/ec2_attrs_test.go
@@ -447,11 +447,11 @@ func mustStruct(m map[string]interface{}) *structpb.Struct {
 	return s
 }
 
-// TestParsePositiveIntField verifies that parsePositiveIntField correctly rejects
+// TestParsePositiveInt verifies that parsePositiveInt correctly rejects
 // zero, negative, and non-numeric values while accepting valid positive integers.
 // This directly tests the boundary behavior documented in the function's docstring:
-// values ≤ 0 (including zero) return (0, false) with a warning log.
-func TestParsePositiveIntField(t *testing.T) {
+// values ≤ 0 (including zero) return (0, false).
+func TestParsePositiveInt(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string
@@ -469,12 +469,12 @@ func TestParsePositiveIntField(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			val, ok := parsePositiveIntField("test_field", tt.input)
+			val, ok := parsePositiveInt(tt.input)
 			if ok != tt.wantOK {
-				t.Errorf("parsePositiveIntField(%q) ok = %v, want %v", tt.input, ok, tt.wantOK)
+				t.Errorf("parsePositiveInt(%q) ok = %v, want %v", tt.input, ok, tt.wantOK)
 			}
 			if val != tt.wantVal {
-				t.Errorf("parsePositiveIntField(%q) val = %d, want %d", tt.input, val, tt.wantVal)
+				t.Errorf("parsePositiveInt(%q) val = %d, want %d", tt.input, val, tt.wantVal)
 			}
 		})
 	}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -28,6 +28,7 @@ type AWSPublicPlugin struct {
 	version          string
 	pricing          pricing.PricingClient
 	carbonEstimator  carbon.CarbonEstimator
+	ebsEstimator     *carbon.EBSEstimator
 	logger           zerolog.Logger // logger is immutable (copy-on-write)
 	testMode         bool           // true when FINFOCUS_TEST_MODE=true
 	maxBatchSize     int            // configured max batch size for recommendations (read-only after init)
@@ -111,6 +112,7 @@ func NewAWSPublicPlugin(
 		version:          version,
 		pricing:          pricingClient,
 		carbonEstimator:  carbon.NewEstimator(),
+		ebsEstimator:     carbon.NewEBSEstimator(),
 		logger:           logger,
 		testMode:         testMode,
 		maxBatchSize:     maxBatchSize,

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -275,6 +275,10 @@ func TestNewAWSPublicPlugin(t *testing.T) {
 	if plugin.pricing != mock {
 		t.Error("Pricing client not set correctly")
 	}
+
+	if plugin.ebsEstimator == nil {
+		t.Error("EBS estimator not initialized")
+	}
 }
 
 func TestName(t *testing.T) {

--- a/internal/plugin/projected.go
+++ b/internal/plugin/projected.go
@@ -353,8 +353,7 @@ func (p *AWSPublicPlugin) estimateEC2(
 	// Add root volume EBS carbon if applicable
 	var rootCarbonGrams float64
 	if rootVol.Present {
-		ebsEstimator := carbon.NewEBSEstimator()
-		rootCarbon, rootCarbonOK := ebsEstimator.EstimateCarbonGrams(carbon.EBSVolumeConfig{
+		rootCarbon, rootCarbonOK := p.ebsEstimator.EstimateCarbonGrams(carbon.EBSVolumeConfig{
 			VolumeType: rootVol.VolumeType,
 			SizeGB:     float64(rootVol.SizeGB),
 			Region:     resource.GetRegion(),
@@ -464,8 +463,7 @@ func (p *AWSPublicPlugin) estimateEBS(
 	}
 
 	// Carbon estimation for EBS volume
-	ebsEstimator := carbon.NewEBSEstimator()
-	carbonGrams, carbonOK := ebsEstimator.EstimateCarbonGrams(carbon.EBSVolumeConfig{
+	carbonGrams, carbonOK := p.ebsEstimator.EstimateCarbonGrams(carbon.EBSVolumeConfig{
 		VolumeType: volumeType,
 		SizeGB:     float64(sizeGB),
 		Region:     resource.GetRegion(),

--- a/internal/router/child.go
+++ b/internal/router/child.go
@@ -74,7 +74,7 @@ type ChildProcess struct {
 	client     *pluginsdk.Client
 	state      ChildState
 	cancel     context.CancelFunc // Cancels the child process context, triggering process kill
-	mu         sync.Mutex
+	mu         sync.RWMutex
 	logger     zerolog.Logger
 }
 
@@ -90,15 +90,15 @@ func NewChildProcess(region, binaryPath string, logger zerolog.Logger) *ChildPro
 
 // State returns the current lifecycle state of the child process.
 func (c *ChildProcess) State() ChildState {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	return c.state
 }
 
 // Client returns the pluginsdk.Client for delegating RPCs to this child.
 func (c *ChildProcess) Client() *pluginsdk.Client {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	return c.client
 }
 

--- a/internal/router/child_test.go
+++ b/internal/router/child_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"os/exec"
+	"sync"
 	"testing"
 	"time"
 
@@ -95,6 +96,31 @@ func TestChildProcess_HealthCheck_NilClient(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "client is nil")
 	assert.Equal(t, ChildStateUnhealthy, child.State())
+}
+
+// TestChildProcess_ConcurrentStateRead verifies that concurrent calls to State()
+// and Client() do not race. This test is meaningful under -race detection because
+// sync.RWMutex allows concurrent readers without serialization.
+func TestChildProcess_ConcurrentStateRead(t *testing.T) {
+	logger := zerolog.Nop()
+	child := NewChildProcess("us-east-1", "/usr/bin/true", logger)
+
+	const goroutines = 10
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			_ = child.State()
+		}()
+		go func() {
+			defer wg.Done()
+			_ = child.Client()
+		}()
+	}
+
+	wg.Wait()
 }
 
 // TestChildProcess_Shutdown_CancelsContext verifies that Shutdown force-kills the child


### PR DESCRIPTION

## Summary

- Switch `ChildProcess.mu` from `sync.Mutex` to `sync.RWMutex` so `State()` and `Client()` use shared read locks, allowing concurrent readers under RPC load without serialization
- Store `ebsEstimator` on the `AWSPublicPlugin` struct (initialized once in constructor), replacing two per-request `NewEBSEstimator()` allocations in `estimateEC2` and `estimateEBS`
- Fix pre-existing compilation error: `parsePositiveIntField` was renamed to `parsePositiveInt` in PR #333 but the test reference was not updated

## Test plan

- [x] Added `TestChildProcess_ConcurrentStateRead` (20 goroutines)
- [x] Added `ebsEstimator != nil` assertion in `TestNewAWSPublicPlugin`
- [x] `make test` passes (all packages, `-race` enabled)
- [x] `make lint` passes with zero issues

## Changes

### Modified files

- `internal/router/child.go` - `sync.Mutex` → `sync.RWMutex`, `State()`/`Client()` use `RLock()`/`RUnlock()`
- `internal/router/child_test.go` - Add concurrent read race test
- `internal/plugin/plugin.go` - Add `ebsEstimator` field, initialize in constructor
- `internal/plugin/projected.go` - Replace per-request `NewEBSEstimator()` with `p.ebsEstimator`
- `internal/plugin/plugin_test.go` - Assert `ebsEstimator` initialized
- `internal/plugin/ec2_attrs_test.go` - Fix `parsePositiveIntField` → `parsePositiveInt` reference (pre-existing breakage from PR #333)

### Housekeeping

- `ROADMAP.md` - Mark #322 as completed

Closes #322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Optimized concurrent access to child process state for enhanced performance under high concurrency
  * Improved consistency of EBS carbon estimation calculations across the application

* **Tests**
  * Added concurrency safety tests to verify child process operations under concurrent access patterns

* **Chores**
  * Updated roadmap to mark synchronization optimization as completed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->