### PR TITLE
fix(plugin): update TestParsePositiveIntField to match renamed function

### DIFF
--- a/internal/plugin/ec2_attrs_test.go
+++ b/internal/plugin/ec2_attrs_test.go
@@ -447,11 +447,11 @@ func mustStruct(m map[string]interface{}) *structpb.Struct {
 	return s
 }
 
-// TestParsePositiveIntField verifies that parsePositiveIntField correctly rejects
+// TestParsePositiveInt verifies that parsePositiveInt correctly rejects
 // zero, negative, and non-numeric values while accepting valid positive integers.
 // This directly tests the boundary behavior documented in the function's docstring:
-// values ≤ 0 (including zero) return (0, false) with a warning log.
-func TestParsePositiveIntField(t *testing.T) {
+// values ≤ 0 (including zero) return (0, false).
+func TestParsePositiveInt(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string
@@ -469,12 +469,12 @@ func TestParsePositiveIntField(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			val, ok := parsePositiveIntField("test_field", tt.input)
+			val, ok := parsePositiveInt(tt.input)
 			if ok != tt.wantOK {
-				t.Errorf("parsePositiveIntField(%q) ok = %v, want %v", tt.input, ok, tt.wantOK)
+				t.Errorf("parsePositiveInt(%q) ok = %v, want %v", tt.input, ok, tt.wantOK)
 			}
 			if val != tt.wantVal {
-				t.Errorf("parsePositiveIntField(%q) val = %d, want %d", tt.input, val, tt.wantVal)
+				t.Errorf("parsePositiveInt(%q) val = %d, want %d", tt.input, val, tt.wantVal)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- PR #333 renamed `parsePositiveIntField` to `parsePositiveInt`, removing the `fieldName` parameter (logging moved to callers with trace-aware context)
- The unit test `TestParsePositiveIntField` added by PR #332 was not updated to match the new signature, causing a build failure in CI on the release-please PR #306
- Updated the test function name, docstring, call site, and error messages to reference `parsePositiveInt(raw)` instead of `parsePositiveIntField(fieldName, value)`

## Test plan

- [x] `TestParsePositiveInt` passes (all 7 subcases)
- [x] `make test` passes (full suite)
- [x] `make lint` passes (0 issues)
- [x] No references to `parsePositiveIntField` remain in Go source

## Changes

### Modified files

- `internal/plugin/ec2_attrs_test.go` - Renamed test function and updated call from `parsePositiveIntField("test_field", tt.input)` to `parsePositiveInt(tt.input)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test structure and naming for code consistency.

---

**Note:** This release contains only internal testing changes with no user-visible impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->