### PR TITLE
chore(lint): upgrade golangci-lint to v2.9.0 and harden lint config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,13 +36,11 @@ jobs:
       - name: Run tests
         run: make test
 
-      - name: Install golangci-lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-
-      - name: Run linter
-        run: golangci-lint run --timeout=5m
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.9.0
+          args: --timeout=9m
 
       - name: Verify pricing data is embedded
         run: go test -tags=region_use1 -run TestEmbeddedPricing ./internal/pricing/... -v

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 # This file is licensed under the terms of the MIT license https://opensource.org/license/mit
 # Copyright (c) 2021-2025 Marat Reymers
 
-## Golden config for golangci-lint v2.5.0
+## Golden config for golangci-lint v2.9.0
 #
 # This is the best config for golangci-lint based on my experience and opinion.
 # It is very strict, but not extremely strict.
@@ -121,14 +121,16 @@ linters:
     - usetesting # reports uses of functions with replacement inside the testing package
     - wastedassign # finds wasted assignment statements
     - whitespace # detects leading and trailing whitespace
+    - zerologlint # detects wrong usage of zerolog (missing dispatch)
+    - exhaustruct # checks all structure fields are initialized
+    - godox # detects FIXME, TODO and other keywords
+    - modernize # modern Go idioms
 
     ## you may want to enable
     #- arangolint # opinionated best practices for arangodb client
     #- decorder # checks declaration order and count of types, constants, variables and functions
-    #- exhaustruct # [highly recommend to enable] checks if all structure fields are initialized
     #- ginkgolinter # [if you use ginkgo/gomega] enforces standards of using ginkgo and gomega
-    #- godox # detects usage of FIXME, TODO and other keywords inside comments
-    #- goheader # checks is file header matches to pattern
+    #- goheader # checks file header matches pattern
     #- inamedparam # [great idea, but too strict, need to ignore a lot of cases by default] reports interfaces with unnamed method parameters
     #- interfacebloat # checks the number of methods inside an interface
     #- ireturn # accept interfaces, return concrete types
@@ -137,7 +139,6 @@ linters:
     #- tagalign # checks that struct tags are well aligned
     #- varnamelen # [great idea, but too many false positives] checks that the length of a variable's name matches its scope
     #- wrapcheck # checks that errors returned from external packages are wrapped
-    #- zerologlint # detects the wrong usage of zerolog that a user forgets to dispatch zerolog.Event
 
     ## disabled
     #- containedctx # detects struct contained context.Context field
@@ -266,6 +267,21 @@ linters:
         - ^golang.org/x/tools/go/analysis.Analyzer$
         - ^google.golang.org/protobuf/.+Options$
         - ^gopkg.in/yaml.v3.Node$
+        # project proto types (generated, many optional fields)
+        - ^github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1\..+
+        # project SDK types (config structs with optional fields)
+        - ^github.com/rshade/finfocus-spec/sdk/go/pluginsdk\..+
+        # internal types with intentional zero-value defaults
+        - ^github.com/rshade/finfocus-plugin-aws-public/internal/plugin\.RootVolumeInfo$
+        - ^github.com/rshade/finfocus-plugin-aws-public/internal/plugin\.ServiceClassification$
+        - ^github.com/rshade/finfocus-plugin-aws-public/internal/plugin\.TimestampResolution$
+        - ^github.com/rshade/finfocus-plugin-aws-public/internal/plugin\.ProcessingContext$
+        - ^github.com/rshade/finfocus-plugin-aws-public/internal/plugin\.serviceResolver$
+        - ^github.com/rshade/finfocus-plugin-aws-public/internal/carbon\.StorageSpec$
+        - ^github.com/rshade/finfocus-plugin-aws-public/internal/pricing\..+
+        - ^github.com/rshade/finfocus-plugin-aws-public/internal/router\..+
+        - ^main\.Config$
+        - ^github.com/rshade/finfocus-plugin-aws-public/cmd/.+\.Config$
 
     funcorder:
       # Checks if the exported methods of a structure are placed before the non-exported ones.
@@ -276,14 +292,11 @@ linters:
       # Checks the number of lines in a function.
       # If lower than 0, disable the check.
       # Default: 60
-      # Raised to 220: estimation functions (estimateDynamoDB, estimateRDS)
-      # and pricing parsers (Client.init) are long due to multi-service
-      # dispatch and multi-field AWS pricing data extraction.
-      lines: 220
+      lines: 100
       # Checks the number of statements in a function.
       # If lower than 0, disable the check.
       # Default: 40
-      statements: 80
+      statements: 50
 
     gochecksumtype:
       # Presence of `default` case in switch statements satisfies exhaustiveness, if all members are not listed.
@@ -293,10 +306,14 @@ linters:
     gocognit:
       # Minimal code complexity to report.
       # Default: 30 (but we recommend 10-20)
-      # Raised to 80: pricing parsers (parseRDSPricing, Client.init) and
-      # estimators (estimateCloudWatch) are inherently complex due to
-      # multi-field extraction from AWS pricing data structures.
-      min-complexity: 80
+      min-complexity: 20
+
+    godox:
+      keywords:
+        - TODO
+        - FIXME
+        - BUG
+        - HACK
 
     gocritic:
       # Settings passed to gocritic.
@@ -454,9 +471,12 @@ linters:
           - bodyclose
           - dupl
           - errcheck
+          - exhaustruct
           - funlen
           - gocognit
           - goconst
+          - godox
+
           - gosec
           - govet
           - intrange
@@ -473,31 +493,34 @@ linters:
           - bodyclose
           - dupl
           - errcheck
+          - exhaustruct
           - funlen
           - gocognit
           - goconst
+          - godox
+
           - gosec
           - govet
           - intrange
           - mnd
           - noctx
           - revive
-          - staticcheck
           - testableexamples
           - testifylint
           - testpackage
           - usetesting
           - wrapcheck
-      # CLI tools legitimately use fmt.Print for user-facing output,
-      # need broader file permissions, and use domain-specific constants.
+      # CLI tools legitimately use fmt.Print for user-facing output
+      # and use domain-specific constants.
       - path: 'tools/'
         linters:
+          - exhaustruct
           - forbidigo
-          - gosec
           - gochecknoglobals
           - gochecknoinits
+          - godox
+
           - mnd
-          - govet
       # Package-level variables (maps, sync.Once, constants) are
       # intentional for configuration, caching, and lookup tables.
       - path: 'internal/'

--- a/cmd/finfocus-plugin-aws-public/config.go
+++ b/cmd/finfocus-plugin-aws-public/config.go
@@ -12,7 +12,7 @@ import (
 
 // parseWebConfig parses environment variables to configure the web server.
 // It returns a WebConfig struct and an error if the configuration is invalid.
-func parseWebConfig(enabled bool, logger zerolog.Logger) (pluginsdk.WebConfig, error) {
+func parseWebConfig(enabled bool, logger zerolog.Logger) (pluginsdk.WebConfig, error) { //nolint:gocognit
 	if !enabled {
 		return pluginsdk.WebConfig{}, nil
 	}
@@ -24,8 +24,7 @@ func parseWebConfig(enabled bool, logger zerolog.Logger) (pluginsdk.WebConfig, e
 	// FR-001: Allowed Origins
 	hasWildcard := false
 	if origins := os.Getenv("FINFOCUS_CORS_ALLOWED_ORIGINS"); origins != "" {
-		rawOrigins := strings.Split(origins, ",")
-		for _, o := range rawOrigins {
+		for o := range strings.SplitSeq(origins, ",") {
 			trimmed := strings.TrimSpace(o)
 			if trimmed == "*" {
 				hasWildcard = true

--- a/internal/plugin/actual.go
+++ b/internal/plugin/actual.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"time"
 
 	pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
@@ -103,17 +104,13 @@ func mergeTagsFromRequest(req *pbc.GetActualCostRequest) map[string]string {
 			Tags map[string]string `json:"tags"`
 		}
 		if json.Unmarshal([]byte(req.GetResourceId()), &resource) == nil && resource.Tags != nil {
-			for k, v := range resource.Tags {
-				merged[k] = v
-			}
+			maps.Copy(merged, resource.Tags)
 		}
 	}
 
 	// Then overlay req.Tags (takes precedence)
 	if req.GetTags() != nil {
-		for k, v := range req.GetTags() {
-			merged[k] = v
-		}
+		maps.Copy(merged, req.GetTags())
 	}
 
 	return merged

--- a/internal/plugin/actual_test.go
+++ b/internal/plugin/actual_test.go
@@ -181,7 +181,7 @@ func newTestPluginForActual() *AWSPublicPlugin {
 
 // makeResourceJSON creates a JSON-encoded ResourceDescriptor for testing.
 func makeResourceJSON(provider, resourceType, sku, region string, tags map[string]string) string {
-	rd := map[string]interface{}{
+	rd := map[string]any{
 		"provider":      provider,
 		"resource_type": resourceType,
 		"sku":           sku,
@@ -762,9 +762,9 @@ func TestGetActualCost_ConcurrentCalls(t *testing.T) {
 	to := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
 
 	// Launch concurrent goroutines making GetActualCost calls
-	for i := 0; i < numGoroutines; i++ {
+	for i := range numGoroutines {
 		go func(id int) {
-			for j := 0; j < callsPerGoroutine; j++ {
+			for j := range callsPerGoroutine {
 				var req *pbc.GetActualCostRequest
 
 				// Alternate between EC2 and EBS requests
@@ -799,7 +799,7 @@ func TestGetActualCost_ConcurrentCalls(t *testing.T) {
 
 	// Wait for all calls to complete
 	errorCount := 0
-	for i := 0; i < totalCalls; i++ {
+	for range totalCalls {
 		<-done
 	}
 

--- a/internal/plugin/ec2_attrs.go
+++ b/internal/plugin/ec2_attrs.go
@@ -171,14 +171,11 @@ func parseGoMapString(s string) map[string]string {
 	}
 
 	// Split by space, then split each token on first ":"
-	tokens := strings.Fields(s)
-	for _, token := range tokens {
-		idx := strings.Index(token, ":")
-		if idx < 0 {
+	for token := range strings.FieldsSeq(s) {
+		key, value, found := strings.Cut(token, ":")
+		if !found {
 			continue // No colon found, skip malformed token
 		}
-		key := token[:idx]
-		value := token[idx+1:]
 		if key != "" {
 			result[key] = value
 		}
@@ -212,7 +209,7 @@ func parsePositiveInt(raw string) (int, bool) {
 //   - If no root volume source found → RootVolumeInfo{Present: false} (no cost added)
 //   - If source present but missing type → defaults to "gp2"
 //   - If source present but missing/invalid size → defaults to 8 GB
-func ExtractRootVolumeFromTags(tags map[string]string, logger zerolog.Logger) RootVolumeInfo {
+func ExtractRootVolumeFromTags(tags map[string]string, logger zerolog.Logger) RootVolumeInfo { //nolint:gocognit
 	if tags == nil {
 		return RootVolumeInfo{}
 	}
@@ -287,7 +284,7 @@ func ExtractRootVolumeFromTags(tags map[string]string, logger zerolog.Logger) Ro
 //   - If no rootBlockDevice attribute → RootVolumeInfo{Present: false}
 //   - If present but missing type → defaults to "gp2"
 //   - If present but missing/invalid size → defaults to 8 GB
-func ExtractRootVolumeFromStruct(attrs *structpb.Struct, logger zerolog.Logger) RootVolumeInfo {
+func ExtractRootVolumeFromStruct(attrs *structpb.Struct, logger zerolog.Logger) RootVolumeInfo { //nolint:gocognit
 	if attrs == nil || attrs.GetFields() == nil {
 		return RootVolumeInfo{}
 	}

--- a/internal/plugin/ec2_attrs_test.go
+++ b/internal/plugin/ec2_attrs_test.go
@@ -291,52 +291,52 @@ func TestExtractEC2AttributesFromStruct_PlatformNormalization(t *testing.T) {
 	}{
 		{
 			name:   "windows lowercase",
-			attrs:  mustStruct(map[string]interface{}{"platform": "windows"}),
+			attrs:  mustStruct(map[string]any{"platform": "windows"}),
 			wantOS: "Windows",
 		},
 		{
 			name:   "windows uppercase",
-			attrs:  mustStruct(map[string]interface{}{"platform": "WINDOWS"}),
+			attrs:  mustStruct(map[string]any{"platform": "WINDOWS"}),
 			wantOS: "Windows",
 		},
 		{
 			name:   "linux lowercase",
-			attrs:  mustStruct(map[string]interface{}{"platform": "linux"}),
+			attrs:  mustStruct(map[string]any{"platform": "linux"}),
 			wantOS: "Linux",
 		},
 		{
 			name:   "rhel lowercase",
-			attrs:  mustStruct(map[string]interface{}{"platform": "rhel"}),
+			attrs:  mustStruct(map[string]any{"platform": "rhel"}),
 			wantOS: "RHEL",
 		},
 		{
 			name:   "rhel with version",
-			attrs:  mustStruct(map[string]interface{}{"platform": "RHEL-8"}),
+			attrs:  mustStruct(map[string]any{"platform": "RHEL-8"}),
 			wantOS: "RHEL",
 		},
 		{
 			name:   "red hat enterprise linux",
-			attrs:  mustStruct(map[string]interface{}{"platform": "Red Hat Enterprise Linux"}),
+			attrs:  mustStruct(map[string]any{"platform": "Red Hat Enterprise Linux"}),
 			wantOS: "RHEL",
 		},
 		{
 			name:   "suse lowercase",
-			attrs:  mustStruct(map[string]interface{}{"platform": "suse"}),
+			attrs:  mustStruct(map[string]any{"platform": "suse"}),
 			wantOS: "SUSE",
 		},
 		{
 			name:   "suse linux enterprise server",
-			attrs:  mustStruct(map[string]interface{}{"platform": "SUSE Linux Enterprise Server"}),
+			attrs:  mustStruct(map[string]any{"platform": "SUSE Linux Enterprise Server"}),
 			wantOS: "SUSE",
 		},
 		{
 			name:   "empty platform",
-			attrs:  mustStruct(map[string]interface{}{"platform": ""}),
+			attrs:  mustStruct(map[string]any{"platform": ""}),
 			wantOS: "Linux",
 		},
 		{
 			name:   "missing platform",
-			attrs:  mustStruct(map[string]interface{}{}),
+			attrs:  mustStruct(map[string]any{}),
 			wantOS: "Linux",
 		},
 	}
@@ -361,27 +361,27 @@ func TestExtractEC2AttributesFromStruct_TenancyNormalization(t *testing.T) {
 	}{
 		{
 			name:        "dedicated lowercase",
-			attrs:       mustStruct(map[string]interface{}{"tenancy": "dedicated"}),
+			attrs:       mustStruct(map[string]any{"tenancy": "dedicated"}),
 			wantTenancy: "Dedicated",
 		},
 		{
 			name:        "host lowercase",
-			attrs:       mustStruct(map[string]interface{}{"tenancy": "host"}),
+			attrs:       mustStruct(map[string]any{"tenancy": "host"}),
 			wantTenancy: "Host",
 		},
 		{
 			name:        "shared lowercase",
-			attrs:       mustStruct(map[string]interface{}{"tenancy": "shared"}),
+			attrs:       mustStruct(map[string]any{"tenancy": "shared"}),
 			wantTenancy: "Shared",
 		},
 		{
 			name:        "unknown value",
-			attrs:       mustStruct(map[string]interface{}{"tenancy": "unknown"}),
+			attrs:       mustStruct(map[string]any{"tenancy": "unknown"}),
 			wantTenancy: "Shared",
 		},
 		{
 			name:        "missing tenancy",
-			attrs:       mustStruct(map[string]interface{}{}),
+			attrs:       mustStruct(map[string]any{}),
 			wantTenancy: "Shared",
 		},
 	}
@@ -439,7 +439,7 @@ func TestExtractEC2AttributesFromStruct_NilAndEmpty(t *testing.T) {
 
 // mustStruct creates a structpb.Struct from a map, panicking on error.
 // This is a test helper for creating test data.
-func mustStruct(m map[string]interface{}) *structpb.Struct {
+func mustStruct(m map[string]any) *structpb.Struct {
 	s, err := structpb.NewStruct(m)
 	if err != nil {
 		panic(err)
@@ -447,11 +447,11 @@ func mustStruct(m map[string]interface{}) *structpb.Struct {
 	return s
 }
 
-// TestParsePositiveIntField verifies that parsePositiveIntField correctly rejects
+// TestParsePositiveInt verifies that parsePositiveInt correctly rejects
 // zero, negative, and non-numeric values while accepting valid positive integers.
 // This directly tests the boundary behavior documented in the function's docstring:
-// values ≤ 0 (including zero) return (0, false) with a warning log.
-func TestParsePositiveIntField(t *testing.T) {
+// values ≤ 0 (including zero) return (0, false).
+func TestParsePositiveInt(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   string
@@ -469,12 +469,12 @@ func TestParsePositiveIntField(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			val, ok := parsePositiveIntField("test_field", tt.input)
+			val, ok := parsePositiveInt(tt.input)
 			if ok != tt.wantOK {
-				t.Errorf("parsePositiveIntField(%q) ok = %v, want %v", tt.input, ok, tt.wantOK)
+				t.Errorf("parsePositiveInt(%q) ok = %v, want %v", tt.input, ok, tt.wantOK)
 			}
 			if val != tt.wantVal {
-				t.Errorf("parsePositiveIntField(%q) val = %d, want %d", tt.input, val, tt.wantVal)
+				t.Errorf("parsePositiveInt(%q) val = %d, want %d", tt.input, val, tt.wantVal)
 			}
 		})
 	}
@@ -728,13 +728,13 @@ func TestExtractRootVolumeFromStruct(t *testing.T) {
 		},
 		{
 			name:        "no rootBlockDevice",
-			attrs:       mustStruct(map[string]interface{}{"instanceType": "t3.micro"}),
+			attrs:       mustStruct(map[string]any{"instanceType": "t3.micro"}),
 			wantPresent: false,
 		},
 		{
 			name: "rootBlockDevice as struct",
-			attrs: mustStruct(map[string]interface{}{
-				"rootBlockDevice": map[string]interface{}{
+			attrs: mustStruct(map[string]any{
+				"rootBlockDevice": map[string]any{
 					"volumeType": "gp3",
 					"volumeSize": float64(20),
 				},
@@ -745,9 +745,9 @@ func TestExtractRootVolumeFromStruct(t *testing.T) {
 		},
 		{
 			name: "rootBlockDevice as list",
-			attrs: mustStruct(map[string]interface{}{
-				"rootBlockDevice": []interface{}{
-					map[string]interface{}{
+			attrs: mustStruct(map[string]any{
+				"rootBlockDevice": []any{
+					map[string]any{
 						"volumeType": "io1",
 						"volumeSize": float64(100),
 					},
@@ -759,7 +759,7 @@ func TestExtractRootVolumeFromStruct(t *testing.T) {
 		},
 		{
 			name: "rootBlockDevice as Go map string",
-			attrs: mustStruct(map[string]interface{}{
+			attrs: mustStruct(map[string]any{
 				"rootBlockDevice": "map[volumeSize:30 volumeType:gp2]",
 			}),
 			wantPresent: true,
@@ -768,8 +768,8 @@ func TestExtractRootVolumeFromStruct(t *testing.T) {
 		},
 		{
 			name: "rootBlockDevice struct with defaults",
-			attrs: mustStruct(map[string]interface{}{
-				"rootBlockDevice": map[string]interface{}{},
+			attrs: mustStruct(map[string]any{
+				"rootBlockDevice": map[string]any{},
 			}),
 			wantPresent: true,
 			wantType:    "gp2",
@@ -777,8 +777,8 @@ func TestExtractRootVolumeFromStruct(t *testing.T) {
 		},
 		{
 			name: "rootBlockDevice struct with type only",
-			attrs: mustStruct(map[string]interface{}{
-				"rootBlockDevice": map[string]interface{}{
+			attrs: mustStruct(map[string]any{
+				"rootBlockDevice": map[string]any{
 					"volumeType": "gp3",
 				},
 			}),

--- a/internal/plugin/estimate.go
+++ b/internal/plugin/estimate.go
@@ -131,32 +131,27 @@ type resourceTypeInfo struct {
 // Format: "provider:module/resource:Type" (e.g., "aws:ec2/instance:Instance").
 func parsePulumiResourceType(resourceType string) (*resourceTypeInfo, error) {
 	// Split by first ":"
-	parts := strings.SplitN(resourceType, ":", 2)
-	if len(parts) != 2 {
+	provider, rest, found := strings.Cut(resourceType, ":")
+	if !found {
 		return nil, errors.New("invalid format: expected 'provider:module/resource:Type'")
 	}
 
-	provider := parts[0]
-
 	// Split rest by "/" and ":"
-	rest := parts[1]
-	moduleParts := strings.SplitN(rest, "/", 2)
-	if len(moduleParts) != 2 {
+	moduleName, resourceAndType, found := strings.Cut(rest, "/")
+	if !found {
 		return nil, errors.New("invalid format: expected module/resource:Type")
 	}
 
-	module := moduleParts[0]
-
 	// Split resource:Type
-	resourceParts := strings.SplitN(moduleParts[1], ":", 2)
-	if len(resourceParts) != 2 {
+	_, typeName, found := strings.Cut(resourceAndType, ":")
+	if !found {
 		return nil, errors.New("invalid format: expected resource:Type")
 	}
 
 	return &resourceTypeInfo{
 		provider: provider,
-		module:   module,
-		resource: resourceParts[1],
+		module:   moduleName,
+		resource: typeName,
 	}, nil
 }
 

--- a/internal/plugin/estimate_test.go
+++ b/internal/plugin/estimate_test.go
@@ -263,7 +263,7 @@ func TestEstimateCost_EC2(t *testing.T) {
 	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
 	plugin := NewAWSPublicPlugin("us-east-1", "test-version", mock, logger)
 
-	attrs, err := structpb.NewStruct(map[string]interface{}{
+	attrs, err := structpb.NewStruct(map[string]any{
 		"instanceType": "t3.micro",
 	})
 	require.NoError(t, err)
@@ -286,7 +286,7 @@ func TestEstimateCost_EBS(t *testing.T) {
 	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
 	plugin := NewAWSPublicPlugin("us-east-1", "test-version", mock, logger)
 
-	attrs, err := structpb.NewStruct(map[string]interface{}{
+	attrs, err := structpb.NewStruct(map[string]any{
 		"type": "gp3",
 		"size": float64(100),
 	})
@@ -310,7 +310,7 @@ func TestEstimateCost_EBS_DefaultSize(t *testing.T) {
 	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
 	plugin := NewAWSPublicPlugin("us-east-1", "test-version", mock, logger)
 
-	attrs, err := structpb.NewStruct(map[string]interface{}{
+	attrs, err := structpb.NewStruct(map[string]any{
 		"type": "gp2",
 		// no size specified
 	})
@@ -333,7 +333,7 @@ func TestEstimateCost_RegionFromAvailabilityZone(t *testing.T) {
 	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
 	plugin := NewAWSPublicPlugin("us-east-1", "test-version", mock, logger)
 
-	attrs, err := structpb.NewStruct(map[string]interface{}{
+	attrs, err := structpb.NewStruct(map[string]any{
 		"instanceType":     "t3.micro",
 		"availabilityZone": "us-east-1a",
 	})
@@ -355,7 +355,7 @@ func TestEstimateCost_WrongRegion(t *testing.T) {
 	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
 	plugin := NewAWSPublicPlugin("us-east-1", "test-version", mock, logger)
 
-	attrs, err := structpb.NewStruct(map[string]interface{}{
+	attrs, err := structpb.NewStruct(map[string]any{
 		"instanceType": "t3.micro",
 		"region":       "eu-west-1", // different from plugin region
 	})
@@ -470,7 +470,7 @@ func TestEstimateCost_MissingInstanceType(t *testing.T) {
 	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
 	plugin := NewAWSPublicPlugin("us-east-1", "test-version", mock, logger)
 
-	attrs, err := structpb.NewStruct(map[string]interface{}{
+	attrs, err := structpb.NewStruct(map[string]any{
 		"ami": "ami-12345678",
 		// missing instanceType
 	})
@@ -492,7 +492,7 @@ func TestEstimateCost_UnknownInstanceType(t *testing.T) {
 	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
 	plugin := NewAWSPublicPlugin("us-east-1", "test-version", mock, logger)
 
-	attrs, err := structpb.NewStruct(map[string]interface{}{
+	attrs, err := structpb.NewStruct(map[string]any{
 		"instanceType": "unknown.type",
 	})
 	require.NoError(t, err)
@@ -515,9 +515,9 @@ func TestEstimateCost_EC2_WithRootVolume(t *testing.T) {
 	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
 	plugin := NewAWSPublicPlugin("us-east-1", "test-version", mock, logger)
 
-	attrs, err := structpb.NewStruct(map[string]interface{}{
+	attrs, err := structpb.NewStruct(map[string]any{
 		"instanceType": "t3.micro",
-		"rootBlockDevice": map[string]interface{}{
+		"rootBlockDevice": map[string]any{
 			"volumeType": "gp2",
 			"volumeSize": float64(8),
 		},
@@ -545,9 +545,9 @@ func TestEstimateCost_EC2_WithRootVolume_LargerDisk(t *testing.T) {
 	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
 	plugin := NewAWSPublicPlugin("us-east-1", "test-version", mock, logger)
 
-	attrs, err := structpb.NewStruct(map[string]interface{}{
+	attrs, err := structpb.NewStruct(map[string]any{
 		"instanceType": "m5.large",
-		"rootBlockDevice": map[string]interface{}{
+		"rootBlockDevice": map[string]any{
 			"volumeType": "gp3",
 			"volumeSize": float64(100),
 		},
@@ -575,7 +575,7 @@ func TestEstimateCost_EC2_WithoutRootVolume_BackwardCompat(t *testing.T) {
 	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
 	plugin := NewAWSPublicPlugin("us-east-1", "test-version", mock, logger)
 
-	attrs, err := structpb.NewStruct(map[string]interface{}{
+	attrs, err := structpb.NewStruct(map[string]any{
 		"instanceType": "t3.micro",
 		// No rootBlockDevice
 	})

--- a/internal/plugin/instance_type.go
+++ b/internal/plugin/instance_type.go
@@ -9,15 +9,11 @@ func parseInstanceType(instanceType string) (string, string) {
 	if strings.Count(instanceType, ".") != 1 {
 		return "", ""
 	}
-	parts := strings.SplitN(instanceType, ".", 2)
-	if len(parts) != 2 {
+	family, size, found := strings.Cut(instanceType, ".")
+	if !found || family == "" || size == "" {
 		return "", ""
 	}
-	// Validate both parts are non-empty (handles edge case like "." input)
-	if parts[0] == "" || parts[1] == "" {
-		return "", ""
-	}
-	return parts[0], parts[1]
+	return family, size
 }
 
 // generationUpgradeMap maps old instance families to newer generations.
@@ -103,11 +99,11 @@ func parseRDSInstanceType(instanceType string) (string, string) {
 	if strings.Count(trimmed, ".") != 1 {
 		return "", ""
 	}
-	parts := strings.SplitN(trimmed, ".", 2)
-	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+	family, size, found := strings.Cut(trimmed, ".")
+	if !found || family == "" || size == "" {
 		return "", ""
 	}
-	return "db." + parts[0], parts[1]
+	return "db." + family, size
 }
 
 // rdsGenerationUpgradeMap maps old RDS families to newer generations.

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -195,10 +195,7 @@ func sanitizeTagsForLogging(tags map[string]string) map[string]string {
 		return nil
 	}
 	// Pre-allocate with bounded capacity
-	capacity := len(tags)
-	if capacity > maxTagsToLog {
-		capacity = maxTagsToLog
-	}
+	capacity := min(len(tags), maxTagsToLog)
 	sanitized := make(map[string]string, capacity)
 	count := 0
 	for k, v := range tags {
@@ -306,7 +303,7 @@ func (p *AWSPublicPlugin) GetPluginInfo(
 // The proto API uses ResourceId (string) which we expect to be a JSON-encoded
 // ResourceDescriptor. If ResourceId is empty, we fall back to extracting
 // resource info from the Tags map.
-func (p *AWSPublicPlugin) GetActualCost(
+func (p *AWSPublicPlugin) GetActualCost( //nolint:funlen
 	ctx context.Context,
 	req *pbc.GetActualCostRequest,
 ) (*pbc.GetActualCostResponse, error) {

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -349,7 +349,7 @@ func TestTraceIDPropagationWithProvidedTraceID(t *testing.T) {
 	scanner := bufio.NewScanner(&logBuf)
 	found := false
 	for scanner.Scan() {
-		var logEntry map[string]interface{}
+		var logEntry map[string]any
 		if err := json.Unmarshal(scanner.Bytes(), &logEntry); err != nil {
 			continue
 		}
@@ -392,7 +392,7 @@ func TestTraceIDGenerationWhenMissing(t *testing.T) {
 	}
 
 	// Parse log output and verify a UUID-format trace_id was generated
-	var logEntry map[string]interface{}
+	var logEntry map[string]any
 	if err := json.Unmarshal(logBuf.Bytes(), &logEntry); err != nil {
 		t.Fatalf("Failed to parse log output as JSON: %v", err)
 	}
@@ -420,7 +420,7 @@ func TestConcurrentRequestsWithDifferentTraceIDs(t *testing.T) {
 	var wg sync.WaitGroup
 	results := make(chan string, numGoroutines)
 
-	for i := 0; i < numGoroutines; i++ {
+	for i := range numGoroutines {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
@@ -476,7 +476,7 @@ func TestErrorLogsContainErrorCode(t *testing.T) {
 	}
 
 	// Parse log output and verify error_code field
-	var logEntry map[string]interface{}
+	var logEntry map[string]any
 	if err := json.Unmarshal(logBuf.Bytes(), &logEntry); err != nil {
 		t.Fatalf("Failed to parse log output as JSON: %v", err)
 	}
@@ -578,7 +578,7 @@ func TestStartupLogFormat(t *testing.T) {
 		Msg("plugin started")
 
 	// Parse and verify
-	var logEntry map[string]interface{}
+	var logEntry map[string]any
 	if err := json.Unmarshal(logBuf.Bytes(), &logEntry); err != nil {
 		t.Fatalf("Failed to parse log output as JSON: %v", err)
 	}

--- a/internal/plugin/pricingspec.go
+++ b/internal/plugin/pricingspec.go
@@ -571,7 +571,9 @@ func (p *AWSPublicPlugin) natGatewayPricingSpec(resource *pbc.ResourceDescriptor
 }
 
 // cloudWatchPricingSpec returns the pricing specification for CloudWatch.
-func (p *AWSPublicPlugin) cloudWatchPricingSpec(resource *pbc.ResourceDescriptor) *pbc.PricingSpec {
+func (p *AWSPublicPlugin) cloudWatchPricingSpec( //nolint:gocognit,funlen
+	resource *pbc.ResourceDescriptor,
+) *pbc.PricingSpec {
 	sku := resource.GetSku()
 	if sku == "" {
 		sku = "logs"

--- a/internal/plugin/projected.go
+++ b/internal/plugin/projected.go
@@ -30,7 +30,7 @@ const (
 //   - "aws:ebs:Volume" -> "ebs"
 //   - "aws:ec2/vpc:Vpc" -> "vpc"
 //   - "ec2" -> "ec2"
-func normalizeResourceType(resourceType string) string {
+func normalizeResourceType(resourceType string) string { //nolint:gocognit
 	rt := strings.ToLower(resourceType)
 
 	// Pattern: aws:<service>/...:... or aws:<service>:...
@@ -141,7 +141,7 @@ var validRDSStorageTypes = map[string]bool{
 }
 
 // GetProjectedCost estimates the monthly cost for the given resource.
-func (p *AWSPublicPlugin) GetProjectedCost(
+func (p *AWSPublicPlugin) GetProjectedCost( //nolint:funlen
 	ctx context.Context,
 	req *pbc.GetProjectedCostRequest,
 ) (*pbc.GetProjectedCostResponse, error) {
@@ -271,7 +271,7 @@ func (p *AWSPublicPlugin) GetProjectedCost(
 
 // estimateEC2 calculates the projected monthly cost for an EC2 instance.
 // traceID is passed from the parent handler to ensure consistent trace correlation.
-func (p *AWSPublicPlugin) estimateEC2(
+func (p *AWSPublicPlugin) estimateEC2( //nolint:funlen
 	traceID string,
 	resource *pbc.ResourceDescriptor,
 	req *pbc.GetProjectedCostRequest,
@@ -637,7 +637,7 @@ func (p *AWSPublicPlugin) validateNonNegativeFloat64(traceID, tagName, value str
 }
 
 // estimateDynamoDB calculates projected monthly cost for DynamoDB tables.
-func (p *AWSPublicPlugin) estimateDynamoDB(
+func (p *AWSPublicPlugin) estimateDynamoDB( //nolint:gocognit,funlen
 	traceID string,
 	resource *pbc.ResourceDescriptor,
 ) (*pbc.GetProjectedCostResponse, error) {
@@ -852,7 +852,7 @@ func (p *AWSPublicPlugin) estimateDynamoDB(
 }
 
 // estimateELB calculates projected monthly cost for load balancers.
-func (p *AWSPublicPlugin) estimateELB(
+func (p *AWSPublicPlugin) estimateELB( //nolint:gocognit
 	traceID string,
 	resource *pbc.ResourceDescriptor,
 ) (*pbc.GetProjectedCostResponse, error) {
@@ -967,7 +967,7 @@ func (p *AWSPublicPlugin) estimateELB(
 
 // estimateRDS calculates the projected monthly cost for an RDS instance.
 // traceID is passed from the parent handler to ensure consistent trace correlation.
-func (p *AWSPublicPlugin) estimateRDS(
+func (p *AWSPublicPlugin) estimateRDS( //nolint:gocognit,funlen
 	traceID string,
 	resource *pbc.ResourceDescriptor,
 ) (*pbc.GetProjectedCostResponse, error) {
@@ -1283,7 +1283,7 @@ func (p *AWSPublicPlugin) estimateEKS(
 
 // estimateLambda calculates projected monthly cost for Lambda functions.
 // Uses request count and GB-seconds from resource tags.
-func (p *AWSPublicPlugin) estimateLambda(
+func (p *AWSPublicPlugin) estimateLambda( //nolint:gocognit,funlen
 	traceID string,
 	resource *pbc.ResourceDescriptor,
 ) (*pbc.GetProjectedCostResponse, error) {
@@ -1581,7 +1581,7 @@ func calculateTieredCost(quantity float64, tiers []pricing.TierRate) float64 {
 //   - log_ingestion_gb: GB of logs ingested per month
 //   - log_storage_gb: GB of logs stored
 //   - custom_metrics: Number of custom metrics
-func (p *AWSPublicPlugin) estimateCloudWatch(
+func (p *AWSPublicPlugin) estimateCloudWatch( //nolint:gocognit,funlen
 	traceID string,
 	resource *pbc.ResourceDescriptor,
 ) (*pbc.GetProjectedCostResponse, error) {
@@ -1747,7 +1747,7 @@ func (p *AWSPublicPlugin) estimateCloudWatch(
 // Optional tags:
 //   - "engine": Cache engine - "redis" (default), "memcached", or "valkey" (open-source Redis fork)
 //   - "num_nodes" or "num_cache_nodes": Number of cache nodes (default: 1)
-func (p *AWSPublicPlugin) estimateElastiCache(
+func (p *AWSPublicPlugin) estimateElastiCache( //nolint:gocognit,funlen
 	traceID string,
 	resource *pbc.ResourceDescriptor,
 ) (*pbc.GetProjectedCostResponse, error) {

--- a/internal/plugin/projected_test.go
+++ b/internal/plugin/projected_test.go
@@ -684,11 +684,11 @@ func TestGetProjectedCost_ConcurrentCalls(t *testing.T) {
 	done := make(chan bool, totalCalls)
 
 	// Launch concurrent goroutines making gRPC calls
-	for i := 0; i < numGoroutines; i++ {
+	for i := range numGoroutines {
 		go func(id int) {
-			for j := 0; j < callsPerGoroutine; j++ {
+			for j := range callsPerGoroutine {
 				// Alternate between EC2 and EBS requests
-				var resp interface{}
+				var resp any
 				var err error
 
 				if (id+j)%2 == 0 {
@@ -728,7 +728,7 @@ func TestGetProjectedCost_ConcurrentCalls(t *testing.T) {
 
 	// Wait for all calls to complete
 	errorCount := 0
-	for i := 0; i < totalCalls; i++ {
+	for range totalCalls {
 		<-done
 	}
 
@@ -789,7 +789,7 @@ func TestGetProjectedCost_RegionMismatchLatency(t *testing.T) {
 	const samples = 100
 	var totalDuration int64
 
-	for i := 0; i < samples; i++ {
+	for range samples {
 		start := time.Now()
 		_, err := plugin.GetProjectedCost(context.Background(), req)
 		duration := time.Since(start)
@@ -984,7 +984,7 @@ func TestGetProjectedCostLogsContainRequiredFields(t *testing.T) {
 	}
 
 	// Parse log output and verify required fields
-	var logEntry map[string]interface{}
+	var logEntry map[string]any
 	if err := json.Unmarshal(logBuf.Bytes(), &logEntry); err != nil {
 		t.Fatalf("Failed to parse log output as JSON: %v", err)
 	}
@@ -1072,7 +1072,7 @@ func TestDebugLogsContainInstanceTypeForEC2(t *testing.T) {
 		if len(line) == 0 {
 			continue
 		}
-		var logEntry map[string]interface{}
+		var logEntry map[string]any
 		if err := json.Unmarshal(line, &logEntry); err != nil {
 			continue // Skip invalid lines
 		}
@@ -1124,7 +1124,7 @@ func TestDebugLogsContainStorageTypeForEBS(t *testing.T) {
 		if len(line) == 0 {
 			continue
 		}
-		var logEntry map[string]interface{}
+		var logEntry map[string]any
 		if err := json.Unmarshal(line, &logEntry); err != nil {
 			continue // Skip invalid lines
 		}

--- a/internal/plugin/recommendations.go
+++ b/internal/plugin/recommendations.go
@@ -72,7 +72,7 @@ type BatchStats struct {
 // For each matching resource, it populates correlation info (Id and Name) in the recommendation
 // object by extracting the "resource_id" and "name" tags from the input ResourceDescriptor.
 // This allows the caller to correlate recommendations back to their infrastructure definitions.
-func (p *AWSPublicPlugin) GetRecommendations(
+func (p *AWSPublicPlugin) GetRecommendations( //nolint:gocognit,funlen
 	ctx context.Context,
 	req *pbc.GetRecommendationsRequest,
 ) (*pbc.GetRecommendationsResponse, error) {

--- a/internal/plugin/recommendations_bench_test.go
+++ b/internal/plugin/recommendations_bench_test.go
@@ -27,7 +27,7 @@ func BenchmarkGetRecommendations_100Resources(b *testing.B) {
 
 	// Create 100 EC2 resources for the batch
 	resources := make([]*pbc.ResourceDescriptor, 100)
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		resources[i] = &pbc.ResourceDescriptor{
 			Provider:     "aws",
 			ResourceType: "aws:ec2/instance:Instance", // Pulumi format to exercise normalization
@@ -43,7 +43,7 @@ func BenchmarkGetRecommendations_100Resources(b *testing.B) {
 	ctx := context.Background()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, err := plugin.GetRecommendations(ctx, req)
 		if err != nil {
 			b.Fatalf("GetRecommendations failed: %v", err)
@@ -79,7 +79,7 @@ func BenchmarkGetRecommendations_MixedResourceTypes(b *testing.B) {
 
 	// Create 98 resources (14 of each type to get close to 100)
 	resources := make([]*pbc.ResourceDescriptor, 0, 98)
-	for i := 0; i < 14; i++ {
+	for range 14 {
 		for _, rt := range resourceTypes {
 			resources = append(resources, &pbc.ResourceDescriptor{
 				Provider:     "aws",
@@ -97,7 +97,7 @@ func BenchmarkGetRecommendations_MixedResourceTypes(b *testing.B) {
 	ctx := context.Background()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, err := plugin.GetRecommendations(ctx, req)
 		if err != nil {
 			b.Fatalf("GetRecommendations failed: %v", err)

--- a/internal/plugin/recommendations_test.go
+++ b/internal/plugin/recommendations_test.go
@@ -26,12 +26,12 @@ var errNoLogEntries = errors.New("no log entries found in buffer")
 // parseLastLogEntry parses the last non-empty JSON line from a log buffer.
 // This handles cases where the logger emits multiple entries during a test.
 // Returns the parsed map and any error encountered.
-func parseLastLogEntry(buf *bytes.Buffer) (map[string]interface{}, error) {
+func parseLastLogEntry(buf *bytes.Buffer) (map[string]any, error) {
 	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
 	if len(lines) == 0 || lines[len(lines)-1] == "" {
 		return nil, errNoLogEntries
 	}
-	var logEntry map[string]interface{}
+	var logEntry map[string]any
 	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &logEntry); err != nil {
 		return nil, err
 	}
@@ -1130,7 +1130,7 @@ func TestGetRecommendations_SummaryLogging(t *testing.T) {
 		if line == "" {
 			continue
 		}
-		var logEntry map[string]interface{}
+		var logEntry map[string]any
 		if err := json.Unmarshal([]byte(line), &logEntry); err != nil {
 			t.Fatalf("Failed to parse log line as JSON: %v\nLine: %s", err, line)
 		}

--- a/internal/plugin/service_cache_test.go
+++ b/internal/plugin/service_cache_test.go
@@ -190,7 +190,7 @@ func TestServiceResolver_Memoization(t *testing.T) {
 	normalized1 := resolver.NormalizedType()
 
 	// Multiple subsequent accesses
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		service := resolver.ServiceType()
 		normalized := resolver.NormalizedType()
 

--- a/internal/plugin/supports.go
+++ b/internal/plugin/supports.go
@@ -10,7 +10,10 @@ import (
 )
 
 // Supports checks if this plugin can estimate costs for the given resource.
-func (p *AWSPublicPlugin) Supports(ctx context.Context, req *pbc.SupportsRequest) (*pbc.SupportsResponse, error) {
+func (p *AWSPublicPlugin) Supports( //nolint:funlen
+	ctx context.Context,
+	req *pbc.SupportsRequest,
+) (*pbc.SupportsResponse, error) {
 	start := time.Now()
 	traceID := p.getTraceID(ctx)
 

--- a/internal/plugin/supports_test.go
+++ b/internal/plugin/supports_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"slices"
 	"strings"
 	"testing"
 
@@ -397,7 +398,7 @@ func TestSupportsLogsContainRequiredFields(t *testing.T) {
 	}
 
 	// Parse log output and verify required fields
-	var logEntry map[string]interface{}
+	var logEntry map[string]any
 	if err := json.Unmarshal(logBuf.Bytes(), &logEntry); err != nil {
 		t.Fatalf("Failed to parse log output as JSON: %v", err)
 	}
@@ -676,15 +677,7 @@ func TestSupports_EC2_SupportedMetrics(t *testing.T) {
 		t.Fatal("SupportedMetrics should not be empty for EC2")
 	}
 
-	foundCarbon := false
-	for _, m := range resp.GetSupportedMetrics() {
-		if m == pb.MetricKind_METRIC_KIND_CARBON_FOOTPRINT {
-			foundCarbon = true
-			break
-		}
-	}
-
-	if !foundCarbon {
+	if !slices.Contains(resp.GetSupportedMetrics(), pb.MetricKind_METRIC_KIND_CARBON_FOOTPRINT) {
 		t.Errorf("SupportedMetrics should contain METRIC_KIND_CARBON_FOOTPRINT, got %v", resp.GetSupportedMetrics())
 	}
 }
@@ -713,14 +706,7 @@ func TestSupports_DynamoDB_HasCarbonSupport(t *testing.T) {
 	}
 
 	// DynamoDB has carbon estimation (storage-based, SSD × 3× replication)
-	hasCarbon := false
-	for _, m := range resp.GetSupportedMetrics() {
-		if m == pb.MetricKind_METRIC_KIND_CARBON_FOOTPRINT {
-			hasCarbon = true
-			break
-		}
-	}
-	if !hasCarbon {
+	if !slices.Contains(resp.GetSupportedMetrics(), pb.MetricKind_METRIC_KIND_CARBON_FOOTPRINT) {
 		t.Errorf("SupportedMetrics should include CARBON_FOOTPRINT for DynamoDB, got %v", resp.GetSupportedMetrics())
 	}
 }
@@ -764,13 +750,7 @@ func TestSupports_AllResourceTypes_SupportedMetrics(t *testing.T) {
 				t.Fatalf("Supports() returned error: %v", err)
 			}
 
-			hasCarbon := false
-			for _, m := range resp.GetSupportedMetrics() {
-				if m == pb.MetricKind_METRIC_KIND_CARBON_FOOTPRINT {
-					hasCarbon = true
-					break
-				}
-			}
+			hasCarbon := slices.Contains(resp.GetSupportedMetrics(), pb.MetricKind_METRIC_KIND_CARBON_FOOTPRINT)
 
 			if hasCarbon != tt.wantCarbon {
 				t.Errorf("carbon in SupportedMetrics = %v, want %v", hasCarbon, tt.wantCarbon)

--- a/internal/plugin/validation.go
+++ b/internal/plugin/validation.go
@@ -3,6 +3,7 @@ package plugin
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/rshade/finfocus-spec/sdk/go/pluginsdk"
 	pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
@@ -250,7 +251,7 @@ func (p *AWSPublicPlugin) validateProjectedCostRequestWithResolver(
 //  1. req.Arn - Parse AWS ARN and extract region/service (SKU must come from tags)
 //  2. req.ResourceId as JSON - JSON-encoded ResourceDescriptor
 //  3. req.Tags - Extract provider, resource_type, sku, region from tags
-func (p *AWSPublicPlugin) ValidateActualCostRequest(
+func (p *AWSPublicPlugin) ValidateActualCostRequest( //nolint:gocognit,funlen
 	ctx context.Context,
 	req *pbc.GetActualCostRequest,
 ) (*pbc.ResourceDescriptor, *TimestampResolution, error) {
@@ -422,10 +423,8 @@ func (p *AWSPublicPlugin) parseResourceFromARN(req *pbc.GetActualCostRequest) (*
 	// Zero-cost resources (VPC, Subnet, SecurityGroup, IAM, LaunchTemplate, etc.)
 	// don't need a SKU - skip extraction and return immediately with empty SKU.
 	if IsZeroCostService(canonicalService) {
-		tags := make(map[string]string)
-		for k, v := range req.GetTags() {
-			tags[k] = v
-		}
+		tags := make(map[string]string, len(req.GetTags()))
+		maps.Copy(tags, req.GetTags())
 		return &pbc.ResourceDescriptor{
 			Provider:     providerAWS,
 			ResourceType: canonicalService,

--- a/internal/pricing/client.go
+++ b/internal/pricing/client.go
@@ -202,7 +202,7 @@ func NewClient(logger zerolog.Logger) (*Client, error) {
 
 // init parses embedded pricing data exactly once.
 // Parsing is parallelized across services for faster initialization.
-func (c *Client) init() error {
+func (c *Client) init() error { //nolint:gocognit,funlen
 	c.once.Do(func() {
 		// Initialize indexes
 		c.currency = "USD"
@@ -251,9 +251,7 @@ func (c *Client) init() error {
 
 		// 1. Parse EC2 pricing (includes EBS volumes) - largest file, start first
 		// EC2 is CRITICAL - failure to parse means $0 for all compute estimates
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			if region, meta, err := c.parseEC2Pricing(rawEC2JSON); err != nil {
 				parseErrMu.Lock()
 				parseErrs = append(parseErrs, fmt.Errorf("EC2: %w", err))
@@ -266,88 +264,70 @@ func (c *Client) init() error {
 				ec2Metadata = meta
 				regionMu.Unlock()
 			}
-		}()
+		})
 
 		// 2. Parse S3 pricing
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			if _, err := c.parseS3Pricing(rawS3JSON); err != nil {
 				c.logger.Error().Err(err).Msg("failed to parse S3 pricing")
 			}
-		}()
+		})
 
 		// 3. Parse RDS pricing
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			if _, err := c.parseRDSPricing(rawRDSJSON); err != nil {
 				c.logger.Error().Err(err).Msg("failed to parse RDS pricing")
 			}
-		}()
+		})
 
 		// 4. Parse EKS pricing
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			if _, err := c.parseEKSPricing(rawEKSJSON); err != nil {
 				c.logger.Error().Err(err).Msg("failed to parse EKS pricing")
 			}
-		}()
+		})
 
 		// 5. Parse Lambda pricing
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			if _, err := c.parseLambdaPricing(rawLambdaJSON); err != nil {
 				c.logger.Error().Err(err).Msg("failed to parse Lambda pricing")
 			}
-		}()
+		})
 
 		// 6. Parse DynamoDB pricing
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			if _, err := c.parseDynamoDBPricing(rawDynamoDBJSON); err != nil {
 				c.logger.Error().Err(err).Msg("failed to parse DynamoDB pricing")
 			}
-		}()
+		})
 
 		// 7. Parse ELB pricing
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			if _, err := c.parseELBPricing(rawELBJSON); err != nil {
 				c.logger.Error().Err(err).Msg("failed to parse ELB pricing")
 			}
-		}()
+		})
 
 		// 8. Parse NAT Gateway pricing
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			if _, err := c.parseNATGatewayPricing(rawVPCJSON); err != nil {
 				c.logger.Error().Err(err).Msg("failed to parse NAT Gateway pricing")
 			}
-		}()
+		})
 
 		// 9. Parse CloudWatch pricing
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			if _, err := c.parseCloudWatchPricing(rawCloudWatchJSON); err != nil {
 				c.logger.Error().Err(err).Msg("failed to parse CloudWatch pricing")
 			}
-		}()
+		})
 
 		// 10. Parse ElastiCache pricing
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			if _, err := c.parseElastiCachePricing(rawElastiCacheJSON); err != nil {
 				c.logger.Error().Err(err).Msg("failed to parse ElastiCache pricing")
 			}
-		}()
+		})
 
 		// Wait for all parsing to complete
 		wg.Wait()
@@ -530,7 +510,7 @@ func getOnDemandPrice(data *awsPricing, sku string) (float64, string, bool) {
 
 // parseEC2Pricing parses EC2 pricing data including EBS volumes.
 // Returns the detected region, pricing metadata, and any parsing error.
-func (c *Client) parseEC2Pricing(data []byte) (string, *pricingMetadata, error) {
+func (c *Client) parseEC2Pricing(data []byte) (string, *pricingMetadata, error) { //nolint:gocognit
 	var pricing awsPricing
 	if err := json.Unmarshal(data, &pricing); err != nil {
 		return "", nil, fmt.Errorf("failed to parse EC2 JSON: %w", err)
@@ -646,7 +626,7 @@ func (c *Client) parseS3Pricing(data []byte) (string, error) {
 
 // parseRDSPricing parses RDS pricing data.
 // Returns the detected region and any parsing error.
-func (c *Client) parseRDSPricing(data []byte) (string, error) {
+func (c *Client) parseRDSPricing(data []byte) (string, error) { //nolint:gocognit
 	var pricing awsPricing
 	if err := json.Unmarshal(data, &pricing); err != nil {
 		return "", fmt.Errorf("failed to parse RDS JSON: %w", err)
@@ -731,7 +711,7 @@ func (c *Client) parseRDSPricing(data []byte) (string, error) {
 
 // parseEKSPricing parses EKS pricing data.
 // Returns the detected region and any parsing error.
-func (c *Client) parseEKSPricing(data []byte) (string, error) {
+func (c *Client) parseEKSPricing(data []byte) (string, error) { //nolint:gocognit
 	var pricing awsPricing
 	if err := json.Unmarshal(data, &pricing); err != nil {
 		return "", fmt.Errorf("failed to parse EKS JSON: %w", err)
@@ -781,7 +761,7 @@ func (c *Client) parseEKSPricing(data []byte) (string, error) {
 
 // parseLambdaPricing parses Lambda pricing data.
 // Returns the detected region and any parsing error.
-func (c *Client) parseLambdaPricing(data []byte) (string, error) {
+func (c *Client) parseLambdaPricing(data []byte) (string, error) { //nolint:gocognit
 	var pricing awsPricing
 	if err := json.Unmarshal(data, &pricing); err != nil {
 		return "", fmt.Errorf("failed to parse Lambda JSON: %w", err)
@@ -830,7 +810,7 @@ func (c *Client) parseLambdaPricing(data []byte) (string, error) {
 
 // parseDynamoDBPricing parses DynamoDB pricing data.
 // Returns the detected region and any parsing error.
-func (c *Client) parseDynamoDBPricing(data []byte) (string, error) {
+func (c *Client) parseDynamoDBPricing(data []byte) (string, error) { //nolint:gocognit
 	var pricing awsPricing
 	if err := json.Unmarshal(data, &pricing); err != nil {
 		return "", fmt.Errorf("failed to parse DynamoDB JSON: %w", err)
@@ -891,7 +871,7 @@ func (c *Client) parseDynamoDBPricing(data []byte) (string, error) {
 
 // parseELBPricing parses ELB pricing data.
 // Returns the detected region and any parsing error.
-func (c *Client) parseELBPricing(data []byte) (string, error) {
+func (c *Client) parseELBPricing(data []byte) (string, error) { //nolint:gocognit
 	var pricing awsPricing
 	if err := json.Unmarshal(data, &pricing); err != nil {
 		return "", fmt.Errorf("failed to parse ELB JSON: %w", err)
@@ -952,7 +932,7 @@ func (c *Client) parseELBPricing(data []byte) (string, error) {
 
 // parseNATGatewayPricing parses VPC pricing data for NAT Gateways.
 // Returns the detected region and any parsing error.
-func (c *Client) parseNATGatewayPricing(data []byte) (string, error) {
+func (c *Client) parseNATGatewayPricing(data []byte) (string, error) { //nolint:gocognit
 	var pricing awsPricing
 	if err := json.Unmarshal(data, &pricing); err != nil {
 		return "", fmt.Errorf("failed to parse VPC JSON: %w", err)
@@ -1007,7 +987,7 @@ func (c *Client) parseNATGatewayPricing(data []byte) (string, error) {
 //   - Log Storage: productFamily="Storage Snapshot", usagetype contains "TimedStorage-ByteHrs"
 //   - Metrics: productFamily="Metric", group="Metric", usagetype="CW:MetricMonitorUsage"
 //   - Metrics use tiered pricing with beginRange/endRange in priceDimensions
-func (c *Client) parseCloudWatchPricing(data []byte) (string, error) {
+func (c *Client) parseCloudWatchPricing(data []byte) (string, error) { //nolint:gocognit
 	var pricing awsPricing
 	if err := json.Unmarshal(data, &pricing); err != nil {
 		return "", fmt.Errorf("failed to parse CloudWatch JSON: %w", err)

--- a/internal/router/downloader.go
+++ b/internal/router/downloader.go
@@ -189,7 +189,7 @@ func (d *Downloader) fetchChecksums(ctx context.Context) error {
 // Format: <hash>  <filename> (two spaces between hash and filename).
 func parseChecksums(content string) map[string]string {
 	result := make(map[string]string)
-	for _, line := range strings.Split(content, "\n") {
+	for line := range strings.SplitSeq(content, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue

--- a/internal/router/registry_test.go
+++ b/internal/router/registry_test.go
@@ -90,7 +90,7 @@ func TestChildRegistry_ConcurrentGetRegionMutex(t *testing.T) {
 	mutexes := make([]*sync.Mutex, 10)
 
 	// Launch 10 goroutines requesting the same region mutex
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
@@ -114,7 +114,7 @@ func TestChildRegistry_ConcurrentGetOrLaunch_Offline(t *testing.T) {
 	var wg sync.WaitGroup
 	errors := make([]error, 10)
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
@@ -124,7 +124,7 @@ func TestChildRegistry_ConcurrentGetOrLaunch_Offline(t *testing.T) {
 	wg.Wait()
 
 	// All should return an error (no binary in offline mode)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		assert.Error(t, errors[i])
 	}
 }

--- a/test/benchmark/carbon_estimation_bench_test.go
+++ b/test/benchmark/carbon_estimation_bench_test.go
@@ -396,10 +396,8 @@ func TestConcurrentLatency(t *testing.T) {
 	var wg sync.WaitGroup
 	errs := make(chan error, goroutines)
 
-	for i := 0; i < goroutines; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range goroutines {
+		wg.Go(func() {
 			// Run a representative estimator call.
 			start := time.Now()
 			e := carbon.NewEstimator()
@@ -407,7 +405,7 @@ func TestConcurrentLatency(t *testing.T) {
 			if time.Since(start).Milliseconds() > maxLatencyMs {
 				errs <- errors.New("exceeded latency under concurrent load")
 			}
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/test/integration/concurrent_access_test.go
+++ b/test/integration/concurrent_access_test.go
@@ -37,11 +37,9 @@ func TestConcurrentAccess_EC2Estimator(t *testing.T) {
 	errors := make(chan error, numGoroutines*numIterations)
 	results := make(chan float64, numGoroutines*numIterations)
 
-	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for j := 0; j < numIterations; j++ {
+	for range numGoroutines {
+		wg.Go(func() {
+			for range numIterations {
 				carbonGrams, ok := estimator.EstimateCarbonGrams(
 					"m5.large", "us-east-1", 0.5, 730)
 				if !ok {
@@ -50,7 +48,7 @@ func TestConcurrentAccess_EC2Estimator(t *testing.T) {
 				}
 				results <- carbonGrams
 			}
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -85,12 +83,10 @@ func TestConcurrentAccess_EBSEstimator(t *testing.T) {
 	var wg sync.WaitGroup
 	successCount := make(chan int, numGoroutines)
 
-	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range numGoroutines {
+		wg.Go(func() {
 			success := 0
-			for j := 0; j < numIterations; j++ {
+			for range numIterations {
 				_, ok := estimator.EstimateCarbonGrams(carbon.EBSVolumeConfig{
 					VolumeType: "gp3",
 					SizeGB:     100,
@@ -102,7 +98,7 @@ func TestConcurrentAccess_EBSEstimator(t *testing.T) {
 				}
 			}
 			successCount <- success
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -124,12 +120,10 @@ func TestConcurrentAccess_S3Estimator(t *testing.T) {
 	var wg sync.WaitGroup
 	successCount := make(chan int, numGoroutines)
 
-	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range numGoroutines {
+		wg.Go(func() {
 			success := 0
-			for j := 0; j < numIterations; j++ {
+			for range numIterations {
 				_, ok := estimator.EstimateCarbonGrams(carbon.S3StorageConfig{
 					StorageClass: "STANDARD",
 					SizeGB:       100,
@@ -141,7 +135,7 @@ func TestConcurrentAccess_S3Estimator(t *testing.T) {
 				}
 			}
 			successCount <- success
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -163,12 +157,10 @@ func TestConcurrentAccess_LambdaEstimator(t *testing.T) {
 	var wg sync.WaitGroup
 	successCount := make(chan int, numGoroutines)
 
-	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range numGoroutines {
+		wg.Go(func() {
 			success := 0
-			for j := 0; j < numIterations; j++ {
+			for range numIterations {
 				_, ok := estimator.EstimateCarbonGrams(carbon.LambdaFunctionConfig{
 					MemoryMB:     1792,
 					DurationMs:   500,
@@ -181,7 +173,7 @@ func TestConcurrentAccess_LambdaEstimator(t *testing.T) {
 				}
 			}
 			successCount <- success
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -203,12 +195,10 @@ func TestConcurrentAccess_RDSEstimator(t *testing.T) {
 	var wg sync.WaitGroup
 	successCount := make(chan int, numGoroutines)
 
-	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range numGoroutines {
+		wg.Go(func() {
 			success := 0
-			for j := 0; j < numIterations; j++ {
+			for range numIterations {
 				_, ok := estimator.EstimateCarbonGrams(carbon.RDSInstanceConfig{
 					InstanceType:  "db.m5.large",
 					Region:        "us-east-1",
@@ -223,7 +213,7 @@ func TestConcurrentAccess_RDSEstimator(t *testing.T) {
 				}
 			}
 			successCount <- success
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -245,12 +235,10 @@ func TestConcurrentAccess_DynamoDBEstimator(t *testing.T) {
 	var wg sync.WaitGroup
 	successCount := make(chan int, numGoroutines)
 
-	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range numGoroutines {
+		wg.Go(func() {
 			success := 0
-			for j := 0; j < numIterations; j++ {
+			for range numIterations {
 				_, ok := estimator.EstimateCarbonGrams(carbon.DynamoDBTableConfig{
 					SizeGB: 50,
 					Region: "us-east-1",
@@ -261,7 +249,7 @@ func TestConcurrentAccess_DynamoDBEstimator(t *testing.T) {
 				}
 			}
 			successCount <- success
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -283,12 +271,10 @@ func TestConcurrentAccess_EKSEstimator(t *testing.T) {
 	var wg sync.WaitGroup
 	successCount := make(chan int, numGoroutines)
 
-	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range numGoroutines {
+		wg.Go(func() {
 			success := 0
-			for j := 0; j < numIterations; j++ {
+			for range numIterations {
 				_, ok := estimator.EstimateCarbonGrams(carbon.EKSClusterConfig{
 					Region: "us-east-1",
 				})
@@ -297,7 +283,7 @@ func TestConcurrentAccess_EKSEstimator(t *testing.T) {
 				}
 			}
 			successCount <- success
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -319,19 +305,17 @@ func TestConcurrentAccess_EmbodiedCarbonEstimator(t *testing.T) {
 	var wg sync.WaitGroup
 	successCount := make(chan int, numGoroutines)
 
-	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range numGoroutines {
+		wg.Go(func() {
 			success := 0
-			for j := 0; j < numIterations; j++ {
+			for range numIterations {
 				_, ok := estimator.EstimateEmbodiedCarbonKg("m5.large", 1.0)
 				if ok {
 					success++
 				}
 			}
 			successCount <- success
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -362,26 +346,22 @@ func TestConcurrentAccess_MixedEstimators(t *testing.T) {
 	successCount := make(chan int, numGoroutines*8)
 
 	// Launch goroutines for each estimator type
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		// EC2
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			success := 0
-			for j := 0; j < numIterations; j++ {
+			for range numIterations {
 				if _, ok := ec2Estimator.EstimateCarbonGrams("m5.large", "us-east-1", 0.5, 730); ok {
 					success++
 				}
 			}
 			successCount <- success
-		}()
+		})
 
 		// EBS
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			success := 0
-			for j := 0; j < numIterations; j++ {
+			for range numIterations {
 				if _, ok := ebsEstimator.EstimateCarbonGrams(carbon.EBSVolumeConfig{
 					VolumeType: "gp3", SizeGB: 100, Region: "us-east-1", Hours: 730,
 				}); ok {
@@ -389,14 +369,12 @@ func TestConcurrentAccess_MixedEstimators(t *testing.T) {
 				}
 			}
 			successCount <- success
-		}()
+		})
 
 		// S3
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			success := 0
-			for j := 0; j < numIterations; j++ {
+			for range numIterations {
 				if _, ok := s3Estimator.EstimateCarbonGrams(carbon.S3StorageConfig{
 					StorageClass: "STANDARD", SizeGB: 100, Region: "us-east-1", Hours: 730,
 				}); ok {
@@ -404,14 +382,12 @@ func TestConcurrentAccess_MixedEstimators(t *testing.T) {
 				}
 			}
 			successCount <- success
-		}()
+		})
 
 		// Lambda
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			success := 0
-			for j := 0; j < numIterations; j++ {
+			for range numIterations {
 				if _, ok := lambdaEstimator.EstimateCarbonGrams(carbon.LambdaFunctionConfig{
 					MemoryMB: 1792, DurationMs: 500, Invocations: 1000000, Architecture: "x86_64", Region: "us-east-1",
 				}); ok {
@@ -419,14 +395,12 @@ func TestConcurrentAccess_MixedEstimators(t *testing.T) {
 				}
 			}
 			successCount <- success
-		}()
+		})
 
 		// RDS
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			success := 0
-			for j := 0; j < numIterations; j++ {
+			for range numIterations {
 				if _, ok := rdsEstimator.EstimateCarbonGrams(carbon.RDSInstanceConfig{
 					InstanceType: "db.m5.large", Region: "us-east-1", MultiAZ: false,
 					StorageType: "gp3", StorageSizeGB: 100, Utilization: 0.5, Hours: 730,
@@ -435,14 +409,12 @@ func TestConcurrentAccess_MixedEstimators(t *testing.T) {
 				}
 			}
 			successCount <- success
-		}()
+		})
 
 		// DynamoDB
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			success := 0
-			for j := 0; j < numIterations; j++ {
+			for range numIterations {
 				if _, ok := dynamoEstimator.EstimateCarbonGrams(carbon.DynamoDBTableConfig{
 					SizeGB: 50, Region: "us-east-1", Hours: 730,
 				}); ok {
@@ -450,14 +422,12 @@ func TestConcurrentAccess_MixedEstimators(t *testing.T) {
 				}
 			}
 			successCount <- success
-		}()
+		})
 
 		// EKS
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			success := 0
-			for j := 0; j < numIterations; j++ {
+			for range numIterations {
 				if _, ok := eksEstimator.EstimateCarbonGrams(carbon.EKSClusterConfig{
 					Region: "us-east-1",
 				}); ok {
@@ -465,20 +435,18 @@ func TestConcurrentAccess_MixedEstimators(t *testing.T) {
 				}
 			}
 			successCount <- success
-		}()
+		})
 
 		// Embodied
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			success := 0
-			for j := 0; j < numIterations; j++ {
+			for range numIterations {
 				if _, ok := embodiedEstimator.EstimateEmbodiedCarbonKg("m5.large", 1.0); ok {
 					success++
 				}
 			}
 			successCount <- success
-		}()
+		})
 	}
 
 	wg.Wait()
@@ -504,17 +472,15 @@ func TestConcurrentAccess_GridFactorLookup(t *testing.T) {
 	var wg sync.WaitGroup
 	results := make(chan float64, numGoroutines*numIterations*len(regions))
 
-	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for j := 0; j < numIterations; j++ {
+	for range numGoroutines {
+		wg.Go(func() {
+			for range numIterations {
 				for _, region := range regions {
 					factor := carbon.GetGridFactor(region)
 					results <- factor
 				}
 			}
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/tools/generate-pricing/main.go
+++ b/tools/generate-pricing/main.go
@@ -131,13 +131,13 @@ const httpRequestTimeout = 5 * time.Minute
 // awsPricingResponse represents the structure of AWS Price List API response.
 // We use this to filter terms while preserving the raw structure.
 type awsPricingResponse struct {
-	FormatVersion   string                            `json:"formatVersion"`
-	Disclaimer      string                            `json:"disclaimer"`
-	OfferCode       string                            `json:"offerCode"`
-	Version         string                            `json:"version"`
-	PublicationDate string                            `json:"publicationDate"`
-	Products        map[string]json.RawMessage        `json:"products"`
-	Terms           map[string]map[string]interface{} `json:"terms"`
+	FormatVersion   string                     `json:"formatVersion"`
+	Disclaimer      string                     `json:"disclaimer"`
+	OfferCode       string                     `json:"offerCode"`
+	Version         string                     `json:"version"`
+	PublicationDate string                     `json:"publicationDate"`
+	Products        map[string]json.RawMessage `json:"products"`
+	Terms           map[string]map[string]any  `json:"terms"`
 }
 
 // fetchServicePricingRaw retrieves AWS pricing data for the specified service and region.
@@ -212,7 +212,7 @@ func fetchServicePricingRaw(region, service string) ([]byte, error) {
 	//
 	// Why filter? Reduces file size from ~400MB to ~154MB for EC2 alone.
 	// The plugin only supports on-demand pricing for v1.
-	filteredTerms := make(map[string]map[string]interface{})
+	filteredTerms := make(map[string]map[string]any)
 	for termType, skuTerms := range pricing.Terms {
 		if termType == "OnDemand" {
 			filteredTerms[termType] = skuTerms

--- a/tools/update-grid-factors/main.go
+++ b/tools/update-grid-factors/main.go
@@ -147,7 +147,8 @@ func main() {
 		return
 	}
 
-	// Write the file
+	// Write the file (0o644 is intentional: generated Go source needs read permission for go build).
+	//nolint:gosec // G306: generated Go source file needs 0o644 for go build
 	if writeErr := os.WriteFile(*output, []byte(content), 0o644); writeErr != nil {
 		fmt.Fprintf(os.Stderr, "Error writing file: %v\n", writeErr)
 		os.Exit(1)
@@ -181,8 +182,8 @@ func fetchGridFactors() ([]GridFactor, error) {
 	}
 
 	var ccfData []CCFGridData
-	if err := json.NewDecoder(resp.Body).Decode(&ccfData); err != nil {
-		return nil, fmt.Errorf("failed to decode JSON: %w", err)
+	if decodeErr := json.NewDecoder(resp.Body).Decode(&ccfData); decodeErr != nil {
+		return nil, fmt.Errorf("failed to decode JSON: %w", decodeErr)
 	}
 
 	var factors []GridFactor


### PR DESCRIPTION
## Summary

- Restore strict `gocognit` (80→20) and `funlen` (220→100) thresholds, replacing global inflation with 25+ targeted `//nolint` directives on specific complex functions
- Narrow `tools/` linter exclusion by removing blanket `gosec` and `govet` suppression; add targeted `//nolint:gosec` only where needed (1 location)
- Remove `staticcheck` from `test/` exclusion
- Upgrade CI from unpinned `curl | sh` install to `golangci-lint-action@v9` with pinned v2.9.0
- Enable new linters: `modernize`, `zerologlint`, `exhaustruct`, `godox`
- Fix `modernize` violations: `strings.Cut`, `wg.Go()`, `maps.Copy`, `min()`, `strings.FieldsSeq`, `any`
- Fix pre-existing compile error from PR #333 rename (`parsePositiveIntField` → `parsePositiveInt`)

## Test plan

- [x] `make test` — all tests pass
- [x] `make lint` — 0 issues
- [x] `go build -tags region_use1` — compiles successfully
- [x] `go vet ./...` — no issues

## Changes

### Modified files

- `.golangci.yml` — Restore thresholds, remove blanket exclusions, enable new linters, add exhaustruct exclusions, update version to v2.9.0
- `.github/workflows/test.yml` — Replace curl install with golangci-lint-action@v9
- `internal/pricing/client.go` — Add nolint directives (9 functions), refactor `wg.Add/go` → `wg.Go()`
- `internal/plugin/projected.go` — Add nolint directives (9 functions)
- `internal/plugin/plugin.go` — Add nolint, modernize `min()`
- `internal/plugin/supports.go` — Add nolint, reformat signature
- `internal/plugin/ec2_attrs.go` — Add nolint, modernize `FieldsSeq`/`strings.Cut`
- `internal/plugin/ec2_attrs_test.go` — Fix compile error `parsePositiveIntField` → `parsePositiveInt`
- `internal/plugin/instance_type.go` — Refactor `SplitN` → `strings.Cut`
- `internal/plugin/estimate.go` — Refactor `SplitN` → `strings.Cut`
- `internal/plugin/actual.go` — Modernize `maps.Copy`
- `internal/plugin/validation.go` — Add nolint, modernize `maps.Copy`
- `internal/plugin/pricingspec.go` — Add nolint
- `internal/plugin/recommendations.go` — Add nolint
- `cmd/finfocus-plugin-aws-public/config.go` — Add nolint, modernize `SplitSeq`
- `tools/update-grid-factors/main.go` — Add targeted `//nolint:gosec`, fix govet shadow
- Various `*_test.go` files — Modernize `interface{}` → `any`, `range int`, `slices.Contains`, `b.Loop()`
- `tools/generate-pricing/main.go` — Fix goimports formatting, modernize `interface{}` → `any`
- `internal/router/downloader.go` — Modernize `SplitSeq`

Closes #291
Closes #316
Closes #318

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  - Updated CI workflow to use a pinned linting action and extended linter rules/configuration.
  - Strengthened static analysis thresholds and added targeted lint suppressions where appropriate.

* **Refactor**
  - Modernized Go idioms and simplified internal logic without changing runtime behavior.
  - Minor formatting/signature adjustments to satisfy linters.

* **Tests**
  - Modernized test loops and JSON unmarshalling types to current language patterns; preserved test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->