### PR TITLE
chore(plugin): use service constants in ZeroCostServices and ZeroCost…

### DIFF
--- a/internal/plugin/constants.go
+++ b/internal/plugin/constants.go
@@ -94,12 +94,12 @@ const RelationshipManagedBy = "managed_by"
 // 1. Add the canonical service name here
 // 2. Add the Pulumi pattern to ZeroCostPulumiPatterns below, OR implement dedicated prefix matching in normalizeResourceType().
 var ZeroCostServices = map[string]bool{
-	serviceVPC:            true,
-	serviceSecurityGroup:  true,
-	serviceSubnet:         true,
-	"iam":                 true,
-	"launchtemplate":      true,
-	"launchconfiguration": true,
+	serviceVPC:           true,
+	serviceSecurityGroup: true,
+	serviceSubnet:        true,
+	serviceIAM:           true,
+	serviceLaunchTmpl:    true,
+	serviceLaunchConfig:  true,
 }
 
 // ZeroCostPulumiPatterns maps Pulumi resource type path segments to canonical service names.
@@ -109,8 +109,8 @@ var ZeroCostPulumiPatterns = map[string]string{
 	"ec2/vpc":                 serviceVPC,
 	"ec2/securitygroup":       serviceSecurityGroup,
 	"ec2/subnet":              serviceSubnet,
-	"ec2/launchtemplate":      "launchtemplate",
-	"ec2/launchconfiguration": "launchconfiguration",
+	"ec2/launchtemplate":      serviceLaunchTmpl,
+	"ec2/launchconfiguration": serviceLaunchConfig,
 }
 
 // IsZeroCostService returns true if the canonical service name has no direct AWS charges.


### PR DESCRIPTION
…PulumiPatterns maps

## Summary

- Replace 5 string literals with existing `serviceIAM`, `serviceLaunchTmpl`, and `serviceLaunchConfig` constants for consistency with the first three entries that already use constants
- Pure refactor with zero behavioral change — compiled binary is identical since the constants hold the same string values
- Originated from PR #305 CodeRabbit nitpick

## Test plan

- [x] `make test` passes
- [x] `make lint` passes with zero issues
- [x] `goimports` formatting verified

## Changes

### Modified files

- `internal/plugin/constants.go` — Replace string literals `"iam"`, `"launchtemplate"`, `"launchconfiguration"` with `serviceIAM`, `serviceLaunchTmpl`, `serviceLaunchConfig` in both `ZeroCostServices` and `ZeroCostPulumiPatterns` maps

Closes #321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code consistency and maintainability through standardized constant usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->