### PR TITLE
feat(plugin): add ASG cost estimator for aws:autoscaling/group:Group

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,6 +310,7 @@ added to `tools/generate-pricing/main.go` that stripped 85% of pricing data:
 - S3 (Storage per GB-month by storage class)
 - Lambda (Requests + compute GB-seconds, x86_64/arm64 architecture support)
 - RDS (Instance hours + storage, Multi-engine support)
+- Auto Scaling Groups (EC2 pricing × desired capacity, carbon estimation)
 
 ## Directory Structure
 
@@ -450,6 +451,27 @@ go test -tags=integration -run TestIntegration_VerifyPricingEmbedded ./internal/
 - `cost_per_month`: unit_price × 730
 - `billing_detail`: "EKS cluster (<support_type> support), 730 hrs/month (control plane only, excludes worker nodes)"
 
+### Auto Scaling Groups (ASG)
+
+- `resource_type`: "asg", "autoscaling", or "aws:autoscaling/group:Group"
+- `sku`: Instance type (e.g., "m5.large") — optional, resolved from tags
+- Instance type resolution priority: `sku` → `instance_type` tag →
+  `launch_template.instance_type` → `launch_configuration.instance_type`
+- Capacity: Read from `tags["desired_capacity"]` or `tags["desiredCapacity"]`,
+  fallback to `tags["min_size"]` or `tags["minSize"]`, default 1
+- OS: Read from `tags["operating_system"]` or `tags["platform"]`, default
+  "Linux"
+- Assumptions (hardcoded for v1):
+  - `tenancy = "Shared"`
+  - `hoursPerMonth = 730` (24×7 on-demand)
+- `unit_price`: Per-instance EC2 hourly rate from pricing data
+- `cost_per_month`: unit_price × desired_capacity × 730
+- `billing_detail`: "ASG: N× <type> On-demand <OS>, 730 hrs/month"
+- No separate ASG charge — cost is entirely from managed EC2 instances
+- Root EBS volumes are excluded to avoid double-counting
+- Carbon estimation: EC2 carbon × desired_capacity (gCO2e)
+- SKU not required in request (resolved from tags); bypasses SDK SKU validation
+
 ### Elastic Load Balancing (ALB/NLB)
 
 - `resource_type`: "elb", "alb", or "nlb"
@@ -487,6 +509,7 @@ and excluded helps users accurately estimate total infrastructure costs.
 | S3 | Storage per GB-month by storage class | Requests, data transfer, lifecycle | ✅ gCO2e |
 | Lambda | Requests + compute (GB-seconds), x86_64/arm64 | Provisioned concurrency, Lambda@Edge | ✅ gCO2e |
 | DynamoDB | On-Demand/Provisioned throughput, storage | Global tables, streams, DAX, backups | ✅ gCO2e |
+| ASG | EC2 hourly rate × desired_capacity × 730 | Root EBS, spot/reserved, mixed instance policies | ✅ gCO2e |
 
 **Note:** EKS estimates control plane only ($0.10/hr standard, $0.50/hr extended). Estimate worker nodes separately as EC2.
 
@@ -787,6 +810,8 @@ Per CLAUDE.md performance goals: "startup < 1s, PORT < 1s, GetProjectedCost < 10
 ## Active Technologies
 - Go 1.25+ + `finfocus-spec` v0.5.6 (`pluginsdk`, `pbcconnect`), `connectrpc.com/connect` v1.19.1, `zerolog` (036-multi-region-router, 001-correctness-fixes)
 - N/A (in-memory child process registry only) (036-multi-region-router, 001-correctness-fixes)
+- Go 1.25+ + finfocus-spec v0.5.6 (pluginsdk, pbc, pbcconnect), (001-asg-estimator)
+- N/A (in-memory pricing data via `//go:embed`) (001-asg-estimator)
 
 - Go 1.25+ + gRPC (finfocus-spec/sdk/go/pluginsdk), zerolog (001-cache-service-type)
 - N/A (pure in-memory optimization, no persistence) (001-cache-service-type)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -52,9 +52,6 @@ security overhead of cloud credentials.
 
 ## Future Vision [Researching / Planned]
 
-- **[Planned] Service Breadth (New Services):**
-  - **ASG Estimator:** Add estimator for
-    `aws:autoscaling/group:Group` (#295) [L]
 - **[Researching] Memory Optimization:** Implementing lazy-loading or
   memory-mapped access for embedded JSON files to reduce the runtime memory
   footprint without moving to an external database (#84) [L]
@@ -100,6 +97,12 @@ security overhead of cloud credentials.
 
 ### Q1 2026
 
+- **ASG Cost Estimator:** Added cost estimation for
+  `aws:autoscaling/group:Group` resources. Multiplies EC2 on-demand pricing
+  by desired capacity × 730 hours. Includes carbon estimation, service
+  discovery (Supports, GetPricingSpec, GetActualCost), and classification
+  metadata. Supports instance type resolution from SKU, tags, or launch
+  template/configuration properties (#295).
 - **Zero-Cost PricingSpec:** `GetPricingSpec` now returns `BillingMode: "zero_cost"`
   for VPC, Security Groups, Subnets, IAM, Launch Templates, and Launch
   Configurations instead of falling through to "unknown" (#319).

--- a/internal/carbon/asg_estimator.go
+++ b/internal/carbon/asg_estimator.go
@@ -1,0 +1,39 @@
+package carbon
+
+// ASGEstimator estimates carbon footprint for Auto Scaling Groups.
+type ASGEstimator struct{}
+
+// NewASGEstimator creates a new ASG carbon estimator.
+func NewASGEstimator() *ASGEstimator {
+	return &ASGEstimator{}
+}
+
+// EstimateCarbonGrams calculates the carbon footprint for an ASG.
+//
+// ASG carbon is calculated as:
+//
+//	EC2 single-instance carbon × desired_capacity
+//
+// Returns the carbon footprint in grams CO2e and whether the calculation succeeded.
+// Returns (0, false) if the instance type is unknown in the CCF data.
+// Returns (0, true) if desired capacity is zero (valid but no carbon).
+//
+// This method is thread-safe and can be called concurrently.
+func (e *ASGEstimator) EstimateCarbonGrams(config ASGConfig) (float64, bool) {
+	if config.DesiredCapacity <= 0 {
+		return 0, true
+	}
+
+	ec2Estimator := NewEstimator()
+	singleCarbon, ok := ec2Estimator.EstimateCarbonGrams(
+		config.InstanceType,
+		config.Region,
+		config.Utilization,
+		config.Hours,
+	)
+	if !ok {
+		return 0, false
+	}
+
+	return singleCarbon * float64(config.DesiredCapacity), true
+}

--- a/internal/carbon/asg_estimator_test.go
+++ b/internal/carbon/asg_estimator_test.go
@@ -1,0 +1,123 @@
+package carbon
+
+import (
+	"math"
+	"testing"
+)
+
+// TestASGEstimator_SingleInstance verifies that a single-instance ASG
+// produces the same carbon as a direct EC2 estimator call.
+func TestASGEstimator_SingleInstance(t *testing.T) {
+	asgEst := NewASGEstimator()
+	ec2Est := NewEstimator()
+
+	ec2Carbon, ec2OK := ec2Est.EstimateCarbonGrams("m5.large", "us-east-1", 0.5, HoursPerMonth)
+	asgCarbon, asgOK := asgEst.EstimateCarbonGrams(ASGConfig{
+		InstanceType:    "m5.large",
+		Region:          "us-east-1",
+		DesiredCapacity: 1,
+		Utilization:     0.5,
+		Hours:           HoursPerMonth,
+	})
+
+	if !ec2OK || !asgOK {
+		t.Fatal("both estimators should succeed for m5.large")
+	}
+	if math.Abs(asgCarbon-ec2Carbon) > 0.001 {
+		t.Errorf("single-instance ASG carbon (%.2f) should match EC2 carbon (%.2f)", asgCarbon, ec2Carbon)
+	}
+}
+
+// TestASGEstimator_MultiInstance verifies that carbon scales linearly with instance count.
+func TestASGEstimator_MultiInstance(t *testing.T) {
+	asgEst := NewASGEstimator()
+
+	singleCarbon, ok := asgEst.EstimateCarbonGrams(ASGConfig{
+		InstanceType:    "t3.micro",
+		Region:          "us-east-1",
+		DesiredCapacity: 1,
+		Utilization:     0.5,
+		Hours:           HoursPerMonth,
+	})
+	if !ok {
+		t.Fatal("should succeed for t3.micro")
+	}
+
+	tripleCarbon, ok := asgEst.EstimateCarbonGrams(ASGConfig{
+		InstanceType:    "t3.micro",
+		Region:          "us-east-1",
+		DesiredCapacity: 3,
+		Utilization:     0.5,
+		Hours:           HoursPerMonth,
+	})
+	if !ok {
+		t.Fatal("should succeed for t3.micro × 3")
+	}
+
+	expected := singleCarbon * 3
+	if math.Abs(tripleCarbon-expected) > 0.001 {
+		t.Errorf("3-instance carbon (%.2f) should be 3× single (%.2f)", tripleCarbon, expected)
+	}
+}
+
+// TestASGEstimator_UnknownInstanceType verifies that unknown instance types return false.
+func TestASGEstimator_UnknownInstanceType(t *testing.T) {
+	asgEst := NewASGEstimator()
+
+	_, ok := asgEst.EstimateCarbonGrams(ASGConfig{
+		InstanceType:    "x99.nonexistent",
+		Region:          "us-east-1",
+		DesiredCapacity: 1,
+		Utilization:     0.5,
+		Hours:           HoursPerMonth,
+	})
+	if ok {
+		t.Error("should return false for unknown instance type")
+	}
+}
+
+// TestASGEstimator_ZeroCapacity verifies that zero capacity returns 0 carbon.
+func TestASGEstimator_ZeroCapacity(t *testing.T) {
+	asgEst := NewASGEstimator()
+
+	carbonGrams, ok := asgEst.EstimateCarbonGrams(ASGConfig{
+		InstanceType:    "m5.large",
+		Region:          "us-east-1",
+		DesiredCapacity: 0,
+		Utilization:     0.5,
+		Hours:           HoursPerMonth,
+	})
+	if !ok {
+		t.Fatal("zero capacity should succeed")
+	}
+	if carbonGrams != 0 {
+		t.Errorf("zero capacity should produce 0 carbon, got %.2f", carbonGrams)
+	}
+}
+
+// TestASGEstimator_UtilizationPassthrough verifies that utilization is passed to the EC2 estimator.
+func TestASGEstimator_UtilizationPassthrough(t *testing.T) {
+	asgEst := NewASGEstimator()
+
+	lowUtil, ok1 := asgEst.EstimateCarbonGrams(ASGConfig{
+		InstanceType:    "m5.large",
+		Region:          "us-east-1",
+		DesiredCapacity: 1,
+		Utilization:     0.1,
+		Hours:           HoursPerMonth,
+	})
+	highUtil, ok2 := asgEst.EstimateCarbonGrams(ASGConfig{
+		InstanceType:    "m5.large",
+		Region:          "us-east-1",
+		DesiredCapacity: 1,
+		Utilization:     0.9,
+		Hours:           HoursPerMonth,
+	})
+
+	if !ok1 || !ok2 {
+		t.Fatal("both utilization levels should succeed")
+	}
+	if highUtil <= lowUtil {
+		t.Errorf("higher utilization (%.2f) should produce more carbon than lower (%.2f)", highUtil, lowUtil)
+	}
+}

--- a/internal/carbon/types.go
+++ b/internal/carbon/types.go
@@ -162,6 +162,24 @@ type EKSClusterConfig struct {
 	Region string
 }
 
+// ASGConfig contains configuration for ASG carbon estimation.
+type ASGConfig struct {
+	// InstanceType is the EC2 instance type (e.g., "m5.large").
+	InstanceType string
+
+	// Region is the AWS region for grid emission factor lookup.
+	Region string
+
+	// DesiredCapacity is the number of instances in the ASG.
+	DesiredCapacity int
+
+	// Utilization is the CPU utilization (0.0 to 1.0, default: 0.50).
+	Utilization float64
+
+	// Hours is the operating hours per month.
+	Hours float64
+}
+
 // ElastiCacheConfig contains configuration for ElastiCache carbon estimation.
 type ElastiCacheConfig struct {
 	// NodeType is the ElastiCache node type (EC2-equivalent, e.g., "cache.m5.large").

--- a/internal/plugin/actual.go
+++ b/internal/plugin/actual.go
@@ -259,6 +259,8 @@ func (p *AWSPublicPlugin) getProjectedForResource(
 		return p.estimateCloudWatch(traceID, resource)
 	case serviceElastiCache:
 		return p.estimateElastiCache(traceID, resource)
+	case serviceASG:
+		return p.estimateASG(traceID, resource)
 	case serviceS3:
 		return p.estimateS3(traceID, resource)
 	case serviceLambda:

--- a/internal/plugin/actual_test.go
+++ b/internal/plugin/actual_test.go
@@ -1695,6 +1695,13 @@ func TestGetActualCost_ASG_Routes(t *testing.T) {
 		t.Fatal("GetActualCost returned nil response")
 	}
 	if len(resp.GetResults()) == 0 {
-		t.Error("expected at least one cost result for ASG")
+		t.Fatal("expected at least one cost result for ASG")
+	}
+	result := resp.GetResults()[0]
+	if result.GetCost() <= 0 {
+		t.Errorf("expected positive cost for ASG, got %v", result.GetCost())
+	}
+	if result.GetSource() == "" {
+		t.Error("expected non-empty source for ASG result")
 	}
 }

--- a/internal/plugin/actual_test.go
+++ b/internal/plugin/actual_test.go
@@ -1670,3 +1670,31 @@ func TestGetActualCost_MixedBatch(t *testing.T) {
 		})
 	}
 }
+
+// TestGetActualCost_ASG_Routes verifies that GetActualCost routes ASG resources
+// through the ASG estimator (dual-path coverage per CLAUDE.md convention).
+func TestGetActualCost_ASG_Routes(t *testing.T) {
+	plugin := newTestPluginForActual()
+
+	now := time.Now()
+	start := timestamppb.New(now.Add(-24 * time.Hour))
+	end := timestamppb.New(now)
+
+	resourceJSON := makeResourceJSON("aws", "aws:autoscaling/group:Group", "t3.micro", "us-east-1",
+		map[string]string{"desired_capacity": "2"})
+
+	resp, err := plugin.GetActualCost(context.Background(), &pbc.GetActualCostRequest{
+		ResourceId: resourceJSON,
+		Start:      start,
+		End:        end,
+	})
+	if err != nil {
+		t.Fatalf("GetActualCost returned error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("GetActualCost returned nil response")
+	}
+	if len(resp.GetResults()) == 0 {
+		t.Error("expected at least one cost result for ASG")
+	}
+}

--- a/internal/plugin/arn.go
+++ b/internal/plugin/arn.go
@@ -151,11 +151,14 @@ func (a *ARNComponents) ToPulumiResourceType() string {
 	case serviceIAM:
 		return serviceIAM
 	case "autoscaling":
-		// LaunchConfigurations are under autoscaling service
-		if a.ResourceType == "launchConfiguration" || a.ResourceType == "launch-configuration" {
+		switch a.ResourceType {
+		case "launchConfiguration", "launch-configuration":
 			return serviceLaunchConfig
+		case "autoScalingGroup", "auto-scaling-group":
+			return serviceASG
+		default:
+			return a.Service
 		}
-		return a.Service
 	default:
 		// Return the service name as-is for unsupported services
 		return a.Service

--- a/internal/plugin/asg_attrs.go
+++ b/internal/plugin/asg_attrs.go
@@ -1,0 +1,112 @@
+package plugin
+
+import (
+	"strconv"
+
+	pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
+)
+
+// ASGAttributes contains extracted ASG configuration for cost estimation.
+type ASGAttributes struct {
+	InstanceType    string
+	DesiredCapacity int
+	OS              string
+}
+
+// ExtractASGAttributes extracts ASG configuration from a ResourceDescriptor.
+//
+// Instance type resolution priority (highest to lowest):
+//  1. resource.Sku field
+//  2. "instance_type" tag
+//  3. "launch_template.instance_type" tag
+//  4. "launch_configuration.instance_type" tag
+//
+// Capacity resolution priority:
+//  1. "desired_capacity" or "desiredCapacity" tag
+//  2. "min_size" or "minSize" tag
+//  3. Default: 1
+//
+// OS resolution: "operating_system" or "platform" tag, default "Linux".
+//
+// Returns the extracted attributes and a DefaultsTracker recording any defaults applied.
+// Returns an error if no instance type can be resolved.
+func ExtractASGAttributes(resource *pbc.ResourceDescriptor) (ASGAttributes, *DefaultsTracker, error) {
+	var dt DefaultsTracker
+	tags := resource.GetTags()
+	if tags == nil {
+		tags = map[string]string{}
+	}
+
+	instanceType := resolveInstanceType(resource.GetSku(), tags)
+	if instanceType == "" {
+		return ASGAttributes{}, &dt, &PricingUnavailableError{
+			Service:       "ASG",
+			SKU:           "",
+			BillingDetail: "cannot determine instance type for ASG: set 'sku' field or 'instance_type' tag",
+		}
+	}
+
+	capacity, capacityDefaulted := resolveDesiredCapacity(tags)
+	if capacityDefaulted {
+		dt.Add("desired_capacity", "1", KindConfig)
+	}
+
+	os := resolveASGOS(tags)
+	if os == defaultOS && tags["operating_system"] == "" && tags["platform"] == "" {
+		dt.Add("operating_system", defaultOS, KindConfig)
+	}
+
+	return ASGAttributes{
+		InstanceType:    instanceType,
+		DesiredCapacity: capacity,
+		OS:              os,
+	}, &dt, nil
+}
+
+// resolveInstanceType resolves the EC2 instance type using priority-based lookup.
+func resolveInstanceType(sku string, tags map[string]string) string {
+	if sku != "" {
+		return sku
+	}
+	if v := tags["instance_type"]; v != "" {
+		return v
+	}
+	if v := tags["launch_template.instance_type"]; v != "" {
+		return v
+	}
+	if v := tags["launch_configuration.instance_type"]; v != "" {
+		return v
+	}
+	return ""
+}
+
+// resolveDesiredCapacity resolves the desired capacity from tags.
+// Returns the capacity value and whether the default was used.
+// Priority: desired_capacity → desiredCapacity → min_size → minSize → default 1.
+func resolveDesiredCapacity(tags map[string]string) (int, bool) {
+	for _, key := range [...]string{
+		"desired_capacity", "desiredCapacity",
+		"min_size", "minSize",
+	} {
+		if v := tags[key]; v != "" {
+			if n, err := strconv.Atoi(v); err == nil {
+				if n < 0 {
+					return 0, false
+				}
+				return n, false
+			}
+		}
+	}
+	return 1, true
+}
+
+// resolveASGOS resolves the operating system from tags.
+func resolveASGOS(tags map[string]string) string {
+	if v := tags["operating_system"]; v != "" {
+		return normalizePlatform(v)
+	}
+	if v := tags["platform"]; v != "" {
+		return normalizePlatform(v)
+	}
+	return defaultOS
+}

--- a/internal/plugin/asg_attrs.go
+++ b/internal/plugin/asg_attrs.go
@@ -18,8 +18,10 @@ type ASGAttributes struct {
 // Instance type resolution priority (highest to lowest):
 //  1. resource.Sku field
 //  2. "instance_type" tag
-//  3. "launch_template.instance_type" tag
-//  4. "launch_configuration.instance_type" tag
+//  3. "launch_template.instance_type" tag (dot-notation)
+//  4. "launch_configuration.instance_type" tag (dot-notation)
+//  5. "launch_template" tag parsed as Go map string
+//  6. "launch_configuration" tag parsed as Go map string
 //
 // Capacity resolution priority:
 //  1. "desired_capacity" or "desiredCapacity" tag
@@ -64,6 +66,14 @@ func ExtractASGAttributes(resource *pbc.ResourceDescriptor) (ASGAttributes, *Def
 }
 
 // resolveInstanceType resolves the EC2 instance type using priority-based lookup.
+//
+// Resolution priority (highest to lowest):
+//  1. SKU field (resource.Sku)
+//  2. "instance_type" tag (flat tag)
+//  3. "launch_template.instance_type" tag (dot-notation from Pulumi flattening)
+//  4. "launch_configuration.instance_type" tag (dot-notation)
+//  5. "launch_template" tag parsed as Go map string (e.g., "map[instance_type:m5.large]")
+//  6. "launch_configuration" tag parsed as Go map string
 func resolveInstanceType(sku string, tags map[string]string) string {
 	if sku != "" {
 		return sku
@@ -77,6 +87,21 @@ func resolveInstanceType(sku string, tags map[string]string) string {
 	if v := tags["launch_configuration.instance_type"]; v != "" {
 		return v
 	}
+
+	// Pulumi may serialize nested objects as Go map strings (e.g., "map[instance_type:m5.large]").
+	// This mirrors how EC2's rootBlockDevice is parsed via parseGoMapString.
+	for _, key := range [...]string{"launch_template", "launch_configuration"} {
+		if raw := tags[key]; raw != "" {
+			m := parseGoMapString(raw)
+			if v := m["instance_type"]; v != "" {
+				return v
+			}
+			if v := m["instanceType"]; v != "" {
+				return v
+			}
+		}
+	}
+
 	return ""
 }
 
@@ -91,7 +116,7 @@ func resolveDesiredCapacity(tags map[string]string) (int, bool) {
 		if v := tags[key]; v != "" {
 			if n, err := strconv.Atoi(v); err == nil {
 				if n < 0 {
-					return 0, false
+					return 0, true
 				}
 				return n, false
 			}

--- a/internal/plugin/asg_attrs_test.go
+++ b/internal/plugin/asg_attrs_test.go
@@ -1,0 +1,188 @@
+package plugin
+
+import (
+	"testing"
+
+	pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
+)
+
+// TestExtractASGAttributes_InstanceType verifies the priority-based instance type resolution
+// for ASG resources. The resolution order is: sku → instance_type tag → launch_template →
+// launch_configuration. An error is returned when no instance type is found.
+func TestExtractASGAttributes_InstanceType(t *testing.T) {
+	tests := []struct {
+		name             string
+		sku              string
+		tags             map[string]string
+		wantInstanceType string
+		wantErr          bool
+	}{
+		{
+			name:             "sku takes priority over tags",
+			sku:              "m5.large",
+			tags:             map[string]string{"instance_type": "t3.micro"},
+			wantInstanceType: "m5.large",
+		},
+		{
+			name:             "instance_type tag fallback",
+			tags:             map[string]string{"instance_type": "t3.medium"},
+			wantInstanceType: "t3.medium",
+		},
+		{
+			name:             "launch_template.instance_type fallback",
+			tags:             map[string]string{"launch_template.instance_type": "c5.xlarge"},
+			wantInstanceType: "c5.xlarge",
+		},
+		{
+			name:             "launch_configuration.instance_type fallback",
+			tags:             map[string]string{"launch_configuration.instance_type": "r5.2xlarge"},
+			wantInstanceType: "r5.2xlarge",
+		},
+		{
+			name:    "no instance type returns error",
+			tags:    map[string]string{"desired_capacity": "3"},
+			wantErr: true,
+		},
+		{
+			name:    "nil tags and empty sku returns error",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := &pbc.ResourceDescriptor{
+				Sku:  tt.sku,
+				Tags: tt.tags,
+			}
+			attrs, _, err := ExtractASGAttributes(resource)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if attrs.InstanceType != tt.wantInstanceType {
+				t.Errorf("InstanceType = %q, want %q", attrs.InstanceType, tt.wantInstanceType)
+			}
+		})
+	}
+}
+
+// TestExtractASGAttributes_DesiredCapacity verifies capacity resolution from tags.
+// Priority: desired_capacity → desiredCapacity → min_size → minSize → default 1.
+func TestExtractASGAttributes_DesiredCapacity(t *testing.T) {
+	tests := []struct {
+		name         string
+		tags         map[string]string
+		wantCapacity int
+		wantDefault  bool
+	}{
+		{
+			name:         "desired_capacity tag",
+			tags:         map[string]string{"instance_type": "t3.micro", "desired_capacity": "5"},
+			wantCapacity: 5,
+		},
+		{
+			name:         "desiredCapacity camelCase",
+			tags:         map[string]string{"instance_type": "t3.micro", "desiredCapacity": "3"},
+			wantCapacity: 3,
+		},
+		{
+			name:         "min_size fallback",
+			tags:         map[string]string{"instance_type": "t3.micro", "min_size": "2"},
+			wantCapacity: 2,
+		},
+		{
+			name:         "minSize camelCase fallback",
+			tags:         map[string]string{"instance_type": "t3.micro", "minSize": "4"},
+			wantCapacity: 4,
+		},
+		{
+			name:         "default capacity of 1",
+			tags:         map[string]string{"instance_type": "t3.micro"},
+			wantCapacity: 1,
+			wantDefault:  true,
+		},
+		{
+			name:         "zero capacity",
+			tags:         map[string]string{"instance_type": "t3.micro", "desired_capacity": "0"},
+			wantCapacity: 0,
+		},
+		{
+			name:         "negative capacity treated as zero",
+			tags:         map[string]string{"instance_type": "t3.micro", "desired_capacity": "-1"},
+			wantCapacity: 0,
+		},
+		{
+			name:         "non-numeric capacity falls through to default",
+			tags:         map[string]string{"instance_type": "t3.micro", "desired_capacity": "abc"},
+			wantCapacity: 1,
+			wantDefault:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := &pbc.ResourceDescriptor{
+				Tags: tt.tags,
+			}
+			attrs, dt, err := ExtractASGAttributes(resource)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if attrs.DesiredCapacity != tt.wantCapacity {
+				t.Errorf("DesiredCapacity = %d, want %d", attrs.DesiredCapacity, tt.wantCapacity)
+			}
+			if tt.wantDefault {
+				if dt.Quality() == qualityHigh {
+					t.Error("expected defaults to be tracked when using default capacity")
+				}
+			}
+		})
+	}
+}
+
+// TestExtractASGAttributes_OS verifies OS resolution from tags.
+// Checks operating_system tag, platform tag, and default Linux behavior.
+func TestExtractASGAttributes_OS(t *testing.T) {
+	tests := []struct {
+		name   string
+		tags   map[string]string
+		wantOS string
+	}{
+		{
+			name:   "operating_system tag",
+			tags:   map[string]string{"instance_type": "t3.micro", "operating_system": "Windows"},
+			wantOS: "Windows",
+		},
+		{
+			name:   "platform tag fallback",
+			tags:   map[string]string{"instance_type": "t3.micro", "platform": "rhel"},
+			wantOS: "RHEL",
+		},
+		{
+			name:   "default OS is Linux",
+			tags:   map[string]string{"instance_type": "t3.micro"},
+			wantOS: "Linux",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource := &pbc.ResourceDescriptor{
+				Tags: tt.tags,
+			}
+			attrs, _, err := ExtractASGAttributes(resource)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if attrs.OS != tt.wantOS {
+				t.Errorf("OS = %q, want %q", attrs.OS, tt.wantOS)
+			}
+		})
+	}
+}

--- a/internal/plugin/asg_attrs_test.go
+++ b/internal/plugin/asg_attrs_test.go
@@ -39,6 +39,29 @@ func TestExtractASGAttributes_InstanceType(t *testing.T) {
 			wantInstanceType: "r5.2xlarge",
 		},
 		{
+			name:             "launch_template Go map string with instance_type",
+			tags:             map[string]string{"launch_template": "map[instance_type:m5.xlarge]"},
+			wantInstanceType: "m5.xlarge",
+		},
+		{
+			name:             "launch_template Go map string with instanceType (camelCase)",
+			tags:             map[string]string{"launch_template": "map[instanceType:c5.2xlarge]"},
+			wantInstanceType: "c5.2xlarge",
+		},
+		{
+			name:             "launch_configuration Go map string",
+			tags:             map[string]string{"launch_configuration": "map[instance_type:t3.large]"},
+			wantInstanceType: "t3.large",
+		},
+		{
+			name: "dot-notation takes priority over Go map string",
+			tags: map[string]string{
+				"launch_template.instance_type": "c5.xlarge",
+				"launch_template":               "map[instance_type:m5.large]",
+			},
+			wantInstanceType: "c5.xlarge",
+		},
+		{
 			name:    "no instance type returns error",
 			tags:    map[string]string{"desired_capacity": "3"},
 			wantErr: true,
@@ -116,6 +139,7 @@ func TestExtractASGAttributes_DesiredCapacity(t *testing.T) {
 			name:         "negative capacity treated as zero",
 			tags:         map[string]string{"instance_type": "t3.micro", "desired_capacity": "-1"},
 			wantCapacity: 0,
+			wantDefault:  true,
 		},
 		{
 			name:         "non-numeric capacity falls through to default",

--- a/internal/plugin/classification.go
+++ b/internal/plugin/classification.go
@@ -94,6 +94,13 @@ var serviceClassifications = map[string]ServiceClassification{
 		ParentType:        "aws:ec2:vpc:Vpc",
 		Relationship:      RelationshipWithin,
 	},
+	"aws:autoscaling/group:Group": {
+		GrowthType:        pbc.GrowthType_GROWTH_TYPE_NONE,
+		AffectedByDevMode: true, // Instance hours
+		ParentTagKeys:     []string{"vpc_id"},
+		ParentType:        "aws:ec2:vpc:Vpc",
+		Relationship:      RelationshipWithin,
+	},
 }
 
 // GetServiceClassification retrieves the classification metadata for a service type.

--- a/internal/plugin/classification.go
+++ b/internal/plugin/classification.go
@@ -87,6 +87,13 @@ var serviceClassifications = map[string]ServiceClassification{
 		ParentType:        "aws:ec2:vpc:Vpc",
 		Relationship:      RelationshipWithin,
 	},
+	"aws:autoscaling:autoScalingGroup": {
+		GrowthType:        pbc.GrowthType_GROWTH_TYPE_NONE,
+		AffectedByDevMode: true, // Instance hours
+		ParentTagKeys:     []string{"vpc_id"},
+		ParentType:        "aws:ec2:vpc:Vpc",
+		Relationship:      RelationshipWithin,
+	},
 }
 
 // GetServiceClassification retrieves the classification metadata for a service type.

--- a/internal/plugin/classification_test.go
+++ b/internal/plugin/classification_test.go
@@ -1,0 +1,24 @@
+package plugin
+
+import (
+	"testing"
+
+	pbc "github.com/rshade/finfocus-spec/sdk/go/proto/finfocus/v1"
+)
+
+// TestClassification_ASG verifies the ASG classification entry exists with correct growth type.
+func TestClassification_ASG(t *testing.T) {
+	classification, ok := GetServiceClassification("aws:autoscaling:autoScalingGroup")
+	if !ok {
+		t.Fatal("ASG classification entry not found")
+	}
+	if classification.GrowthType != pbc.GrowthType_GROWTH_TYPE_NONE {
+		t.Errorf("GrowthType = %v, want GROWTH_TYPE_NONE", classification.GrowthType)
+	}
+	if !classification.AffectedByDevMode {
+		t.Error("AffectedByDevMode should be true for ASG")
+	}
+	if classification.Relationship != RelationshipWithin {
+		t.Errorf("Relationship = %q, want %q", classification.Relationship, RelationshipWithin)
+	}
+}

--- a/internal/plugin/classification_test.go
+++ b/internal/plugin/classification_test.go
@@ -21,4 +21,30 @@ func TestClassification_ASG(t *testing.T) {
 	if classification.Relationship != RelationshipWithin {
 		t.Errorf("Relationship = %q, want %q", classification.Relationship, RelationshipWithin)
 	}
+	if classification.ParentType != "aws:ec2:vpc:Vpc" {
+		t.Errorf("ParentType = %q, want %q", classification.ParentType, "aws:ec2:vpc:Vpc")
+	}
+	expectedTagKeys := []string{"vpc_id"}
+	if len(classification.ParentTagKeys) != len(expectedTagKeys) {
+		t.Fatalf("ParentTagKeys length = %d, want %d", len(classification.ParentTagKeys), len(expectedTagKeys))
+	}
+	for i, key := range expectedTagKeys {
+		if classification.ParentTagKeys[i] != key {
+			t.Errorf("ParentTagKeys[%d] = %q, want %q", i, classification.ParentTagKeys[i], key)
+		}
+	}
+}
+
+// TestClassification_ASG_PulumiFormat verifies the Pulumi-format alias resolves to the same classification.
+func TestClassification_ASG_PulumiFormat(t *testing.T) {
+	classification, ok := GetServiceClassification("aws:autoscaling/group:Group")
+	if !ok {
+		t.Fatal("ASG classification entry not found for Pulumi format key")
+	}
+	if classification.GrowthType != pbc.GrowthType_GROWTH_TYPE_NONE {
+		t.Errorf("GrowthType = %v, want GROWTH_TYPE_NONE", classification.GrowthType)
+	}
+	if !classification.AffectedByDevMode {
+		t.Error("AffectedByDevMode should be true for ASG (Pulumi format)")
+	}
 }

--- a/internal/plugin/constants.go
+++ b/internal/plugin/constants.go
@@ -22,6 +22,7 @@ const (
 	serviceIAM          = "iam"
 	serviceLaunchTmpl   = "launchtemplate"
 	serviceLaunchConfig = "launchconfiguration"
+	serviceASG          = "asg"
 )
 
 // Default values for EC2 attributes.

--- a/internal/plugin/pricingspec.go
+++ b/internal/plugin/pricingspec.go
@@ -60,6 +60,8 @@ func (p *AWSPublicPlugin) GetPricingSpec(
 		spec = p.natGatewayPricingSpec(resource)
 	case serviceCloudWatch:
 		spec = p.cloudWatchPricingSpec(resource)
+	case serviceASG:
+		spec = p.asgPricingSpec(resource)
 	case serviceVPC, serviceSecurityGroup, serviceSubnet, serviceIAM, serviceLaunchTmpl, serviceLaunchConfig:
 		spec = p.zeroCostPricingSpec(resource, serviceType)
 	default:
@@ -712,5 +714,66 @@ func (p *AWSPublicPlugin) zeroCostPricingSpec(
 		Description:  description,
 		Source:       "aws-public",
 		Assumptions:  []string{"No direct AWS charges for this resource type"},
+	}
+}
+
+// asgPricingSpec returns the pricing specification for Auto Scaling Groups.
+// ASGs delegate to EC2 instance pricing; the total cost is the per-instance rate × desired capacity.
+func (p *AWSPublicPlugin) asgPricingSpec(resource *pbc.ResourceDescriptor) *pbc.PricingSpec {
+	instanceType := resource.GetSku()
+	if instanceType == "" {
+		if tags := resource.GetTags(); tags != nil {
+			instanceType = resolveInstanceType("", tags)
+		}
+	}
+
+	if instanceType == "" {
+		return &pbc.PricingSpec{
+			Provider:     resource.GetProvider(),
+			ResourceType: resource.GetResourceType(),
+			Region:       resource.GetRegion(),
+			BillingMode:  "on_demand",
+			RatePerUnit:  0,
+			Currency:     "USD",
+			Unit:         "per-instance-hour",
+			Description:  "ASG instance type not specified: set 'sku' field or 'instance_type' tag",
+			Source:       "aws-public",
+		}
+	}
+
+	hourlyRate, found := p.pricing.EC2OnDemandPricePerHour(instanceType, defaultOS, defaultTenancy)
+	if !found {
+		return &pbc.PricingSpec{
+			Provider:     resource.GetProvider(),
+			ResourceType: resource.GetResourceType(),
+			Sku:          instanceType,
+			Region:       resource.GetRegion(),
+			BillingMode:  "on_demand",
+			RatePerUnit:  0,
+			Currency:     "USD",
+			Unit:         "per-instance-hour",
+			Description:  fmt.Sprintf(PricingNotFoundTemplate, "EC2 instance type", instanceType),
+			Source:       "aws-public",
+			Assumptions:  []string{"Instance type not found in embedded pricing data"},
+		}
+	}
+
+	return &pbc.PricingSpec{
+		Provider:     resource.GetProvider(),
+		ResourceType: resource.GetResourceType(),
+		Sku:          instanceType,
+		Region:       resource.GetRegion(),
+		BillingMode:  "on_demand",
+		RatePerUnit:  hourlyRate,
+		Currency:     "USD",
+		Unit:         "per-instance-hour",
+		Description:  fmt.Sprintf("ASG cost = %s hourly rate × desired_capacity × 730 hrs/month", instanceType),
+		Source:       "aws-public",
+		Assumptions: []string{
+			fmt.Sprintf("Instance type: %s", instanceType),
+			"On-demand Linux, shared tenancy",
+			"Cost = per-instance hourly rate × desired_capacity × 730",
+			"Worker instance costs only (ASG has no separate charge)",
+		},
 	}
 }

--- a/internal/plugin/pricingspec.go
+++ b/internal/plugin/pricingspec.go
@@ -741,7 +741,9 @@ func (p *AWSPublicPlugin) asgPricingSpec(resource *pbc.ResourceDescriptor) *pbc.
 		}
 	}
 
-	hourlyRate, found := p.pricing.EC2OnDemandPricePerHour(instanceType, defaultOS, defaultTenancy)
+	os := resolveASGOS(resource.GetTags())
+
+	hourlyRate, found := p.pricing.EC2OnDemandPricePerHour(instanceType, os, defaultTenancy)
 	if !found {
 		return &pbc.PricingSpec{
 			Provider:     resource.GetProvider(),
@@ -771,7 +773,7 @@ func (p *AWSPublicPlugin) asgPricingSpec(resource *pbc.ResourceDescriptor) *pbc.
 		Source:       "aws-public",
 		Assumptions: []string{
 			fmt.Sprintf("Instance type: %s", instanceType),
-			"On-demand Linux, shared tenancy",
+			fmt.Sprintf("On-demand %s, shared tenancy", os),
 			"Cost = per-instance hourly rate × desired_capacity × 730",
 			"Worker instance costs only (ASG has no separate charge)",
 		},

--- a/internal/plugin/pricingspec_test.go
+++ b/internal/plugin/pricingspec_test.go
@@ -704,3 +704,29 @@ func TestGetPricingSpec_ZeroCostResources(t *testing.T) {
 		})
 	}
 }
+
+// TestGetPricingSpec_ASG verifies the ASG pricing spec response format.
+func TestGetPricingSpec_ASG(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	mock.ec2Prices["m5.large/Linux/Shared"] = 0.096
+	plugin := NewAWSPublicPlugin("us-east-1", "test-version", mock, logger)
+
+	resp, err := plugin.GetPricingSpec(context.Background(), &pbc.GetPricingSpecRequest{
+		Resource: &pbc.ResourceDescriptor{
+			Provider:     "aws",
+			ResourceType: "aws:autoscaling/group:Group",
+			Sku:          "m5.large",
+			Region:       "us-east-1",
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp.GetSpec())
+	assert.Equal(t, "on_demand", resp.GetSpec().GetBillingMode())
+	assert.Equal(t, "per-instance-hour", resp.GetSpec().GetUnit())
+	assert.Equal(t, 0.096, resp.GetSpec().GetRatePerUnit())
+	assert.Equal(t, "USD", resp.GetSpec().GetCurrency())
+	assert.Equal(t, "aws-public", resp.GetSpec().GetSource())
+	assert.Contains(t, resp.GetSpec().GetDescription(), "m5.large")
+}

--- a/internal/plugin/pricingspec_test.go
+++ b/internal/plugin/pricingspec_test.go
@@ -730,3 +730,30 @@ func TestGetPricingSpec_ASG(t *testing.T) {
 	assert.Equal(t, "aws-public", resp.GetSpec().GetSource())
 	assert.Contains(t, resp.GetSpec().GetDescription(), "m5.large")
 }
+
+// TestGetPricingSpec_ASG_TagResolution verifies ASG pricing spec when Sku is empty
+// and instance type is resolved from tags, exercising the SDK-validation-bypass path.
+func TestGetPricingSpec_ASG_TagResolution(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	mock.ec2Prices["m5.large/Linux/Shared"] = 0.096
+	plugin := NewAWSPublicPlugin("us-east-1", "test-version", mock, logger)
+
+	resp, err := plugin.GetPricingSpec(context.Background(), &pbc.GetPricingSpecRequest{
+		Resource: &pbc.ResourceDescriptor{
+			Provider:     "aws",
+			ResourceType: "aws:autoscaling/group:Group",
+			Region:       "us-east-1",
+			Tags:         map[string]string{"instance_type": "m5.large"},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp.GetSpec())
+	assert.Equal(t, "on_demand", resp.GetSpec().GetBillingMode())
+	assert.Equal(t, "per-instance-hour", resp.GetSpec().GetUnit())
+	assert.Equal(t, 0.096, resp.GetSpec().GetRatePerUnit())
+	assert.Equal(t, "USD", resp.GetSpec().GetCurrency())
+	assert.Equal(t, "aws-public", resp.GetSpec().GetSource())
+	assert.Contains(t, resp.GetSpec().GetDescription(), "m5.large")
+}

--- a/internal/plugin/projected.go
+++ b/internal/plugin/projected.go
@@ -53,6 +53,11 @@ func normalizeResourceType(resourceType string) string { //nolint:gocognit
 			return serviceIAM
 		}
 
+		// ASG: aws:autoscaling/group:Group
+		if strings.Contains(rt, "autoscaling/group") {
+			return serviceASG
+		}
+
 		// Zero-cost EC2 networking resources (centralized in ZeroCostPulumiPatterns)
 		// Use token-aware matching to avoid false positives (e.g., "ec2/vpc" matching "ec2/vpcEndpoint")
 		awsSuffix := rt[4:] // Remove "aws:" prefix (already verified above)
@@ -218,6 +223,8 @@ func (p *AWSPublicPlugin) GetProjectedCost( //nolint:funlen
 		resp, err = p.estimateCloudWatch(traceID, resource)
 	case serviceElastiCache:
 		resp, err = p.estimateElastiCache(traceID, resource)
+	case serviceASG:
+		resp, err = p.estimateASG(traceID, resource)
 	case serviceVPC, serviceSecurityGroup, serviceSubnet, serviceIAM, serviceLaunchTmpl, serviceLaunchConfig:
 		// Zero-cost AWS networking, IAM, and configuration-only resources - no direct charges
 		resp = p.estimateZeroCostResource(traceID, resource, serviceType)
@@ -1226,6 +1233,81 @@ func (p *AWSPublicPlugin) estimateRDS( //nolint:gocognit,funlen
 	return resp, nil
 }
 
+// estimateASG calculates projected monthly cost for an Auto Scaling Group.
+// ASGs have no direct AWS charge; cost is the aggregate of managed EC2 instances:
+// cost = EC2 hourly rate × desired_capacity × 730 hours/month.
+func (p *AWSPublicPlugin) estimateASG(
+	traceID string,
+	resource *pbc.ResourceDescriptor,
+) (*pbc.GetProjectedCostResponse, error) {
+	attrs, dt, err := ExtractASGAttributes(resource)
+	if err != nil {
+		return nil, err
+	}
+
+	hourlyRate, found := p.pricing.EC2OnDemandPricePerHour(attrs.InstanceType, attrs.OS, defaultTenancy)
+	if !found {
+		return nil, &PricingUnavailableError{
+			Service:       "ASG",
+			SKU:           attrs.InstanceType,
+			BillingDetail: fmt.Sprintf(PricingNotFoundTemplate, "EC2 instance type", attrs.InstanceType),
+		}
+	}
+
+	monthlyCost := hourlyRate * float64(attrs.DesiredCapacity) * HoursPerMonthProd
+
+	billingDetail := fmt.Sprintf("ASG: %d× %s On-demand %s, 730 hrs/month",
+		attrs.DesiredCapacity, attrs.InstanceType, attrs.OS)
+	if attrs.DesiredCapacity == 0 {
+		billingDetail += " (zero instances)"
+	}
+
+	tags := resource.GetTags()
+	if tags != nil {
+		if _, hasMixed := tags["mixed_instances_policy"]; hasMixed {
+			billingDetail += " (mixed instance policies not yet supported, using primary instance type)"
+		}
+	}
+
+	resp := &pbc.GetProjectedCostResponse{
+		CostPerMonth:  monthlyCost,
+		UnitPrice:     hourlyRate,
+		Currency:      "USD",
+		BillingDetail: billingDetail,
+		Metadata:      dt.Metadata(),
+	}
+
+	asgEstimator := carbon.NewASGEstimator()
+	totalCarbon, carbonOK := asgEstimator.EstimateCarbonGrams(carbon.ASGConfig{
+		InstanceType:    attrs.InstanceType,
+		Region:          resource.GetRegion(),
+		DesiredCapacity: attrs.DesiredCapacity,
+		Utilization:     carbon.DefaultUtilization,
+		Hours:           carbon.HoursPerMonth,
+	})
+	if carbonOK && totalCarbon > 0 {
+		resp.ImpactMetrics = []*pbc.ImpactMetric{
+			{
+				Kind:  pbc.MetricKind_METRIC_KIND_CARBON_FOOTPRINT,
+				Value: totalCarbon,
+				Unit:  "gCO2e",
+			},
+		}
+		p.traceLogger(traceID, "estimateASG").Debug().
+			Float64("carbon_grams", totalCarbon).
+			Int("instance_count", attrs.DesiredCapacity).
+			Msg("ASG carbon estimation successful")
+	}
+
+	setGrowthHint(
+		p.logger.With().Str(pluginsdk.FieldTraceID, traceID).Logger(),
+		"aws:autoscaling:autoScalingGroup",
+		resp,
+	)
+
+	return resp, nil
+}
+
 // detectService maps a provider resource type string to a normalized service identifier.
 // The input resourceType is expected to be normalized by normalizeResourceType().
 func detectService(resourceType string) string {
@@ -1243,6 +1325,8 @@ func detectService(resourceType string) string {
 		serviceCloudWatch,
 		serviceElastiCache:
 		return resourceType
+	case serviceASG, "autoscaling":
+		return serviceASG
 	case serviceALB, serviceNLB:
 		return serviceELB
 	case "nat_gateway", "nat-gateway", "natgateway":
@@ -1297,6 +1381,9 @@ func detectService(resourceType string) string {
 	}
 	if strings.Contains(resourceTypeLower, "iam/") {
 		return serviceIAM
+	}
+	if strings.Contains(resourceTypeLower, "autoscaling/group") {
+		return serviceASG
 	}
 
 	return resourceType

--- a/internal/plugin/projected.go
+++ b/internal/plugin/projected.go
@@ -1293,7 +1293,7 @@ func (p *AWSPublicPlugin) estimateASG(
 				Unit:  "gCO2e",
 			},
 		}
-		p.traceLogger(traceID, "estimateASG").Debug().
+		p.traceLogger(traceID, "GetProjectedCost").Debug().
 			Float64("carbon_grams", totalCarbon).
 			Int("instance_count", attrs.DesiredCapacity).
 			Msg("ASG carbon estimation successful")

--- a/internal/plugin/projected_test.go
+++ b/internal/plugin/projected_test.go
@@ -5105,13 +5105,14 @@ func TestEstimateASG_ZeroCapacity(t *testing.T) {
 	}
 }
 
-// TestEstimateASG_MissingInstanceType verifies that ASG without instance type returns error.
+// TestEstimateASG_MissingInstanceType verifies that ASG without instance type returns
+// a $0 response with a soft-failure billing detail (PricingUnavailableError is caught).
 func TestEstimateASG_MissingInstanceType(t *testing.T) {
 	mock := newMockPricingClient("us-east-1", "USD")
 	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
 	plugin := NewAWSPublicPlugin("us-east-1", "test-version", mock, logger)
 
-	_, err := plugin.GetProjectedCost(context.Background(), &pbc.GetProjectedCostRequest{
+	resp, err := plugin.GetProjectedCost(context.Background(), &pbc.GetProjectedCostRequest{
 		Resource: &pbc.ResourceDescriptor{
 			Provider:     "aws",
 			ResourceType: "aws:autoscaling/group:Group",
@@ -5122,6 +5123,16 @@ func TestEstimateASG_MissingInstanceType(t *testing.T) {
 	// PricingUnavailableError is caught and returns $0 response (not gRPC error)
 	if err != nil {
 		t.Fatalf("expected PricingUnavailableError to be caught, got gRPC error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response for missing instance type")
+	}
+	if resp.GetCostPerMonth() != 0 {
+		t.Errorf("CostPerMonth should be 0 for missing instance type, got %.2f", resp.GetCostPerMonth())
+	}
+	if !strings.Contains(resp.GetBillingDetail(), "cannot determine instance type") &&
+		!strings.Contains(resp.GetBillingDetail(), "not found") {
+		t.Errorf("BillingDetail should contain soft-failure message, got %q", resp.GetBillingDetail())
 	}
 }
 
@@ -5179,6 +5190,38 @@ func TestEstimateASG_DefaultCapacity(t *testing.T) {
 	}
 	if resp.GetMetadata()["estimate_quality"] != "medium" {
 		t.Errorf("estimate_quality = %q, want 'medium'", resp.GetMetadata()["estimate_quality"])
+	}
+}
+
+// TestEstimateASG_TagBasedInstanceTypeResolution verifies that ASG resolves instance type from tags
+// when Sku is empty, exercising the tag-resolution path through SDK validation bypass.
+func TestEstimateASG_TagBasedInstanceTypeResolution(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	mock.ec2Prices["t3.micro/Linux/Shared"] = 0.0104
+	plugin := NewAWSPublicPlugin("us-east-1", "test-version", mock, logger)
+
+	resp, err := plugin.GetProjectedCost(context.Background(), &pbc.GetProjectedCostRequest{
+		Resource: &pbc.ResourceDescriptor{
+			Provider:     "aws",
+			ResourceType: "aws:autoscaling/group:Group",
+			Region:       "us-east-1",
+			Tags: map[string]string{
+				"instance_type":    "t3.micro",
+				"desired_capacity": "2",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedCost := 0.0104 * 2 * 730
+	if math.Abs(resp.GetCostPerMonth()-expectedCost) > 0.01 {
+		t.Errorf("CostPerMonth = %.2f, want %.2f", resp.GetCostPerMonth(), expectedCost)
+	}
+	if !strings.Contains(resp.GetBillingDetail(), "t3.micro") {
+		t.Errorf("BillingDetail should contain resolved instance type: %q", resp.GetBillingDetail())
 	}
 }
 

--- a/internal/plugin/projected_test.go
+++ b/internal/plugin/projected_test.go
@@ -5038,3 +5038,185 @@ func TestGetProjectedCost_Metadata_BackwardCompat(t *testing.T) {
 	// EC2 with no root volume → no defaults → nil metadata
 	assertMetadata(t, resp, "", true)
 }
+
+// TestEstimateASG_BasicCostCalculation verifies that ASG cost estimation
+// correctly multiplies EC2 hourly rate × desired_capacity × 730 hours.
+func TestEstimateASG_BasicCostCalculation(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	mock.ec2Prices["t3.medium/Linux/Shared"] = 0.0416
+	plugin := NewAWSPublicPlugin("us-east-1", "test-version", mock, logger)
+
+	resp, err := plugin.GetProjectedCost(context.Background(), &pbc.GetProjectedCostRequest{
+		Resource: &pbc.ResourceDescriptor{
+			Provider:     "aws",
+			ResourceType: "aws:autoscaling/group:Group",
+			Sku:          "t3.medium",
+			Region:       "us-east-1",
+			Tags:         map[string]string{"desired_capacity": "3"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedCost := 0.0416 * 3 * 730
+	if math.Abs(resp.GetCostPerMonth()-expectedCost) > 0.01 {
+		t.Errorf("CostPerMonth = %.2f, want %.2f", resp.GetCostPerMonth(), expectedCost)
+	}
+	if math.Abs(resp.GetUnitPrice()-0.0416) > 0.0001 {
+		t.Errorf("UnitPrice = %.4f, want 0.0416", resp.GetUnitPrice())
+	}
+	if resp.GetCurrency() != "USD" {
+		t.Errorf("Currency = %q, want USD", resp.GetCurrency())
+	}
+	if !strings.Contains(resp.GetBillingDetail(), "ASG: 3×") {
+		t.Errorf("BillingDetail should contain instance count: %q", resp.GetBillingDetail())
+	}
+	if !strings.Contains(resp.GetBillingDetail(), "t3.medium") {
+		t.Errorf("BillingDetail should contain instance type: %q", resp.GetBillingDetail())
+	}
+}
+
+// TestEstimateASG_ZeroCapacity verifies that an ASG with zero desired capacity returns $0.
+func TestEstimateASG_ZeroCapacity(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	mock.ec2Prices["m5.large/Linux/Shared"] = 0.096
+	plugin := NewAWSPublicPlugin("us-east-1", "test-version", mock, logger)
+
+	resp, err := plugin.GetProjectedCost(context.Background(), &pbc.GetProjectedCostRequest{
+		Resource: &pbc.ResourceDescriptor{
+			Provider:     "aws",
+			ResourceType: "asg",
+			Sku:          "m5.large",
+			Region:       "us-east-1",
+			Tags:         map[string]string{"desired_capacity": "0"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.GetCostPerMonth() != 0 {
+		t.Errorf("CostPerMonth = %.2f, want 0", resp.GetCostPerMonth())
+	}
+	if !strings.Contains(resp.GetBillingDetail(), "zero instances") {
+		t.Errorf("BillingDetail should note zero instances: %q", resp.GetBillingDetail())
+	}
+}
+
+// TestEstimateASG_MissingInstanceType verifies that ASG without instance type returns error.
+func TestEstimateASG_MissingInstanceType(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	plugin := NewAWSPublicPlugin("us-east-1", "test-version", mock, logger)
+
+	_, err := plugin.GetProjectedCost(context.Background(), &pbc.GetProjectedCostRequest{
+		Resource: &pbc.ResourceDescriptor{
+			Provider:     "aws",
+			ResourceType: "aws:autoscaling/group:Group",
+			Region:       "us-east-1",
+			Tags:         map[string]string{"desired_capacity": "3"},
+		},
+	})
+	// PricingUnavailableError is caught and returns $0 response (not gRPC error)
+	if err != nil {
+		t.Fatalf("expected PricingUnavailableError to be caught, got gRPC error: %v", err)
+	}
+}
+
+// TestEstimateASG_UnknownInstanceType verifies that unknown instance type returns PricingUnavailableError.
+func TestEstimateASG_UnknownInstanceType(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	// No pricing added for "x9.mega"
+	plugin := NewAWSPublicPlugin("us-east-1", "test-version", mock, logger)
+
+	resp, err := plugin.GetProjectedCost(context.Background(), &pbc.GetProjectedCostRequest{
+		Resource: &pbc.ResourceDescriptor{
+			Provider:     "aws",
+			ResourceType: "aws:autoscaling/group:Group",
+			Sku:          "x9.mega",
+			Region:       "us-east-1",
+			Tags:         map[string]string{"desired_capacity": "2"},
+		},
+	})
+	// PricingUnavailableError is caught and returns $0 with billing detail
+	if err != nil {
+		t.Fatalf("expected PricingUnavailableError to be caught, got gRPC error: %v", err)
+	}
+	if resp.GetCostPerMonth() != 0 {
+		t.Errorf("CostPerMonth should be 0 for unknown instance type, got %.2f", resp.GetCostPerMonth())
+	}
+}
+
+// TestEstimateASG_DefaultCapacity verifies metadata tracking when capacity defaults to 1.
+func TestEstimateASG_DefaultCapacity(t *testing.T) {
+	mock := newMockPricingClient("us-east-1", "USD")
+	logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+	mock.ec2Prices["t3.micro/Linux/Shared"] = 0.0104
+	plugin := NewAWSPublicPlugin("us-east-1", "test-version", mock, logger)
+
+	resp, err := plugin.GetProjectedCost(context.Background(), &pbc.GetProjectedCostRequest{
+		Resource: &pbc.ResourceDescriptor{
+			Provider:     "aws",
+			ResourceType: "aws:autoscaling/group:Group",
+			Sku:          "t3.micro",
+			Region:       "us-east-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should default to 1 instance with metadata tracking
+	expectedCost := 0.0104 * 1 * 730
+	if math.Abs(resp.GetCostPerMonth()-expectedCost) > 0.01 {
+		t.Errorf("CostPerMonth = %.2f, want %.2f", resp.GetCostPerMonth(), expectedCost)
+	}
+	if resp.GetMetadata() == nil {
+		t.Fatal("expected metadata to be set when defaults are applied")
+	}
+	if resp.GetMetadata()["estimate_quality"] != "medium" {
+		t.Errorf("estimate_quality = %q, want 'medium'", resp.GetMetadata()["estimate_quality"])
+	}
+}
+
+// TestEstimateASG_AllResourceTypeFormats verifies consistent results across all resource type formats.
+func TestEstimateASG_AllResourceTypeFormats(t *testing.T) {
+	resourceTypes := []string{
+		"aws:autoscaling/group:Group",
+		"asg",
+		"autoscaling",
+	}
+
+	for _, rt := range resourceTypes {
+		t.Run(rt, func(t *testing.T) {
+			mock := newMockPricingClient("us-east-1", "USD")
+			logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+			mock.ec2Prices["t3.micro/Linux/Shared"] = 0.0104
+			plugin := NewAWSPublicPlugin("us-east-1", "test-version", mock, logger)
+
+			resp, err := plugin.GetProjectedCost(context.Background(), &pbc.GetProjectedCostRequest{
+				Resource: &pbc.ResourceDescriptor{
+					Provider:     "aws",
+					ResourceType: rt,
+					Sku:          "t3.micro",
+					Region:       "us-east-1",
+					Tags:         map[string]string{"desired_capacity": "2"},
+				},
+			})
+			if err != nil {
+				t.Fatalf("unexpected error for resource type %q: %v", rt, err)
+			}
+
+			expectedCost := 0.0104 * 2 * 730
+			if math.Abs(resp.GetCostPerMonth()-expectedCost) > 0.01 {
+				t.Errorf(
+					"CostPerMonth = %.2f, want %.2f for resource type %q",
+					resp.GetCostPerMonth(), expectedCost, rt,
+				)
+			}
+		})
+	}
+}

--- a/internal/plugin/supports.go
+++ b/internal/plugin/supports.go
@@ -84,7 +84,8 @@ func (p *AWSPublicPlugin) Supports( //nolint:funlen
 
 	// Check resource type
 	switch serviceType {
-	case serviceEC2, serviceRDS, serviceLambda, serviceS3, serviceEBS, serviceEKS, serviceDynamoDB, serviceElastiCache:
+	case serviceEC2, serviceRDS, serviceLambda, serviceS3, serviceEBS,
+		serviceEKS, serviceDynamoDB, serviceElastiCache, serviceASG:
 		// These services support cost estimation
 		// EC2 also supports carbon footprint estimation
 		supportedMetrics := getSupportedMetrics(serviceType)
@@ -179,6 +180,9 @@ func getSupportedMetrics(resourceType string) []pbc.MetricKind {
 		return []pbc.MetricKind{pbc.MetricKind_METRIC_KIND_CARBON_FOOTPRINT}
 	case serviceElastiCache:
 		// ElastiCache clusters: EC2-equivalent node carbon × cluster size
+		return []pbc.MetricKind{pbc.MetricKind_METRIC_KIND_CARBON_FOOTPRINT}
+	case serviceASG:
+		// ASG: EC2-equivalent carbon × desired capacity
 		return []pbc.MetricKind{pbc.MetricKind_METRIC_KIND_CARBON_FOOTPRINT}
 	default:
 		// ELB, NAT Gateway, CloudWatch: No carbon estimation yet

--- a/internal/plugin/supports_test.go
+++ b/internal/plugin/supports_test.go
@@ -1153,3 +1153,39 @@ func TestSupports_IAM(t *testing.T) {
 		})
 	}
 }
+
+// TestSupports_ASG verifies that ASG resource types are supported with carbon metrics.
+// Tests all three resource type formats: Pulumi full format, short form, and autoscaling alias.
+func TestSupports_ASG(t *testing.T) {
+	resourceTypes := []string{
+		"aws:autoscaling/group:Group",
+		"asg",
+		"autoscaling",
+	}
+
+	for _, rt := range resourceTypes {
+		t.Run(rt, func(t *testing.T) {
+			mock := newMockPricingClient("us-east-1", "USD")
+			logger := zerolog.New(nil).Level(zerolog.InfoLevel)
+			plugin := NewAWSPublicPlugin("us-east-1", "test-version", mock, logger)
+
+			resp, err := plugin.Supports(context.Background(), &pb.SupportsRequest{
+				Resource: &pb.ResourceDescriptor{
+					Provider:     "aws",
+					ResourceType: rt,
+					Region:       "us-east-1",
+				},
+			})
+
+			if err != nil {
+				t.Fatalf("Supports() returned error: %v", err)
+			}
+			if !resp.GetSupported() {
+				t.Errorf("ASG with resource type %q should be supported", rt)
+			}
+			if !slices.Contains(resp.GetSupportedMetrics(), pb.MetricKind_METRIC_KIND_CARBON_FOOTPRINT) {
+				t.Errorf("ASG should advertise carbon footprint metric, got %v", resp.GetSupportedMetrics())
+			}
+		})
+	}
+}

--- a/internal/plugin/validation.go
+++ b/internal/plugin/validation.go
@@ -39,22 +39,10 @@ func (p *AWSPublicPlugin) validateProvider(traceID string, provider string) erro
 	return nil
 }
 
-// isZeroCostResource checks if a resource type maps to a zero-cost resource.
-// Returns false for empty, malformed, or unrecognized resource types by design,
-// since normalizeResourceType() and detectService() will return empty strings
-// or the original input, which won't match any ZeroCostServices keys.
-//
-// Note: Zero-cost services are defined centrally in ZeroCostServices (constants.go).
-func isZeroCostResource(resourceType string) bool {
-	normalized := normalizeResourceType(resourceType)
-	service := detectService(normalized)
-	return IsZeroCostService(service)
-}
-
-// isZeroCostResourceWithResolver checks if a resource type maps to a zero-cost resource
-// using a pre-computed serviceResolver. This avoids redundant normalization and detection.
-func isZeroCostResourceWithResolver(resolver *serviceResolver) bool {
-	return IsZeroCostService(resolver.ServiceType())
+// allowsEmptySKU returns true for services that resolve their primary identifier from tags
+// rather than requiring it in the SKU field. These services bypass SDK SKU validation.
+func allowsEmptySKU(service string) bool {
+	return service == serviceASG
 }
 
 // ValidateProjectedCostRequest validates the request using SDK helpers and custom region checks.
@@ -77,24 +65,21 @@ func (p *AWSPublicPlugin) ValidateProjectedCostRequest(
 
 	resource := req.GetResource()
 
-	// Check if this is a zero-cost resource BEFORE SDK validation.
+	// Check if this is a zero-cost resource or tag-resolved service BEFORE SDK validation.
 	// Zero-cost resources (VPC, Security Groups, Subnets) don't require a SKU
 	// since they always return $0 cost estimates.
-	// Note: isZeroCostResource() guarantees a non-empty, known type via
-	// normalizeResourceType() and detectService(), so no separate empty check needed.
-	if isZeroCostResource(resource.GetResourceType()) {
+	// Tag-resolved services (ASG) resolve their primary identifier from tags.
+	normalizedRT := normalizeResourceType(resource.GetResourceType())
+	detectedSvc := detectService(normalizedRT)
+	if IsZeroCostService(detectedSvc) || allowsEmptySKU(detectedSvc) {
 		// Validate provider and region manually (skip SDK's SKU requirement)
 		if err := p.validateProvider(traceID, resource.GetProvider()); err != nil {
 			return nil, err
 		}
 
-		// Region check for zero-cost resources
+		// Region check
 		effectiveRegion := resource.GetRegion()
 		if effectiveRegion == "" {
-			// Zero-cost networking resources (VPC, SecurityGroup, Subnet) are technically regional,
-			// but since their cost is always $0 regardless of region, we can safely default to the
-			// plugin's current region to allow processing. This aligns with how we handle global
-			// services like S3 and IAM.
 			effectiveRegion = p.region
 		}
 		if effectiveRegion != p.region {
@@ -174,15 +159,16 @@ func (p *AWSPublicPlugin) validateProjectedCostRequestWithResolver(
 
 	resource := req.GetResource()
 
-	// Check if this is a zero-cost resource BEFORE SDK validation.
+	// Check if this is a zero-cost resource or tag-resolved service BEFORE SDK validation.
 	// Use resolver to avoid redundant detectService() calls.
-	if isZeroCostResourceWithResolver(resolver) {
+	svcType := resolver.ServiceType()
+	if IsZeroCostService(svcType) || allowsEmptySKU(svcType) {
 		// Validate provider and region manually (skip SDK's SKU requirement)
 		if err := p.validateProvider(traceID, resource.GetProvider()); err != nil {
 			return nil, err
 		}
 
-		// Region check for zero-cost resources
+		// Region check
 		effectiveRegion := resource.GetRegion()
 		if effectiveRegion == "" {
 			effectiveRegion = p.region

--- a/internal/plugin/validation.go
+++ b/internal/plugin/validation.go
@@ -77,8 +77,17 @@ func (p *AWSPublicPlugin) ValidateProjectedCostRequest(
 			return nil, err
 		}
 
-		// Region check
+		// Region check: tag-resolved services must provide an explicit region
+		// to prevent silently defaulting to the plugin's region.
 		effectiveRegion := resource.GetRegion()
+		if effectiveRegion == "" && allowsEmptySKU(detectedSvc) {
+			return nil, p.newErrorWithID(
+				traceID,
+				codes.InvalidArgument,
+				"region is required for tag-resolved services",
+				pbc.ErrorCode_ERROR_CODE_INVALID_RESOURCE,
+			)
+		}
 		if effectiveRegion == "" {
 			effectiveRegion = p.region
 		}
@@ -168,8 +177,17 @@ func (p *AWSPublicPlugin) validateProjectedCostRequestWithResolver(
 			return nil, err
 		}
 
-		// Region check
+		// Region check: tag-resolved services must provide an explicit region
+		// to prevent silently defaulting to the plugin's region.
 		effectiveRegion := resource.GetRegion()
+		if effectiveRegion == "" && allowsEmptySKU(svcType) {
+			return nil, p.newErrorWithID(
+				traceID,
+				codes.InvalidArgument,
+				"region is required for tag-resolved services",
+				pbc.ErrorCode_ERROR_CODE_INVALID_RESOURCE,
+			)
+		}
 		if effectiveRegion == "" {
 			effectiveRegion = p.region
 		}
@@ -409,6 +427,21 @@ func (p *AWSPublicPlugin) parseResourceFromARN(req *pbc.GetActualCostRequest) (*
 	// Zero-cost resources (VPC, Subnet, SecurityGroup, IAM, LaunchTemplate, etc.)
 	// don't need a SKU - skip extraction and return immediately with empty SKU.
 	if IsZeroCostService(canonicalService) {
+		tags := make(map[string]string, len(req.GetTags()))
+		maps.Copy(tags, req.GetTags())
+		return &pbc.ResourceDescriptor{
+			Provider:     providerAWS,
+			ResourceType: canonicalService,
+			Sku:          "",
+			Region:       arn.Region,
+			Tags:         tags,
+		}, nil
+	}
+
+	// Tag-resolved services (ASG) resolve their SKU from tags during estimation,
+	// not during validation. Pass all tags through with empty SKU so the estimator
+	// (e.g., ExtractASGAttributes) can resolve the instance type from tags.
+	if allowsEmptySKU(canonicalService) {
 		tags := make(map[string]string, len(req.GetTags()))
 		maps.Copy(tags, req.GetTags())
 		return &pbc.ResourceDescriptor{

--- a/internal/plugin/validation_test.go
+++ b/internal/plugin/validation_test.go
@@ -316,6 +316,29 @@ func TestValidateActualCostRequest_ARN(t *testing.T) {
 			pbcCode:   pbc.ErrorCode_ERROR_CODE_INVALID_RESOURCE,
 		},
 		{
+			name: "ASG ARN with instance_type in tags (no SKU required)",
+			req: &pbc.GetActualCostRequest{
+				Arn:   "arn:aws:autoscaling:us-east-1:123456789012:autoScalingGroup:uuid:autoScalingGroupName/my-asg",
+				Start: timestamppb.New(now.Add(-1 * time.Hour)),
+				End:   timestamppb.New(now),
+				Tags: map[string]string{
+					"instance_type":    "m5.large",
+					"desired_capacity": "3",
+				},
+			},
+			wantError: false,
+			wantResource: &pbc.ResourceDescriptor{
+				Provider:     "aws",
+				ResourceType: "asg",
+				Sku:          "",
+				Region:       "us-east-1",
+				Tags: map[string]string{
+					"instance_type":    "m5.large",
+					"desired_capacity": "3",
+				},
+			},
+		},
+		{
 			name: "S3 global ARN (empty region) uses plugin region",
 			req: &pbc.GetActualCostRequest{
 				Arn:   "arn:aws:s3:::my-bucket",

--- a/specs/001-asg-estimator/checklists/requirements.md
+++ b/specs/001-asg-estimator/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: ASG Cost Estimator
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-26
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- The spec references existing codebase patterns (DefaultsTracker, PricingUnavailableError,
+  serviceResolver) by name for precision — these are domain concepts, not implementation
+  prescriptions.
+- A-006 (no root EBS in ASG estimates) is a deliberate scope decision to avoid
+  double-counting with separate EBS volume resources.

--- a/specs/001-asg-estimator/contracts/asg-rpc.md
+++ b/specs/001-asg-estimator/contracts/asg-rpc.md
@@ -1,0 +1,103 @@
+# API Contract: ASG Cost Estimation RPCs
+
+**Feature**: 001-asg-estimator | **Date**: 2026-03-26
+
+## Supports RPC
+
+### Request
+
+```text
+ResourceDescriptor:
+  provider: "aws"
+  resource_type: "aws:autoscaling/group:Group" | "asg" | "autoscaling"
+  region: "<must match plugin binary region>"
+```
+
+### Response
+
+```text
+SupportsResponse:
+  supported: true
+  reason: ""
+  supported_metrics: [METRIC_KIND_CARBON_FOOTPRINT]
+```
+
+### Error Cases
+
+| Condition | Response |
+| --------- | -------- |
+| Region mismatch | supported: false, reason: "Region not supported by this binary" |
+
+## GetProjectedCost RPC
+
+### Request
+
+```text
+ResourceDescriptor:
+  provider: "aws"
+  resource_type: "aws:autoscaling/group:Group"
+  sku: "<instance_type>"            # Optional, highest priority
+  region: "us-east-1"
+  tags:
+    instance_type: "m5.large"       # Fallback 1
+    desired_capacity: "3"           # Instance count (default: 1)
+    min_size: "1"                   # Fallback for capacity
+    operating_system: "Linux"       # OS for pricing (default: Linux)
+    launch_template.instance_type: "m5.large"  # Fallback 2
+    launch_configuration.instance_type: "m5.large"  # Fallback 3
+```
+
+### Response (Success)
+
+```text
+GetProjectedCostResponse:
+  unit_price: 0.096                 # Per-instance hourly rate
+  currency: "USD"
+  cost_per_month: 210.24            # 0.096 × 3 × 730
+  billing_detail: "ASG: 3× m5.large On-demand Linux, 730 hrs/month"
+  metadata:
+    estimate_quality: "high"        # or "medium" if defaults applied
+  impact_metrics:
+    - kind: METRIC_KIND_CARBON_FOOTPRINT
+      value: 45678.9                # gCO2e (per-instance carbon × 3)
+      unit: "gCO2e"
+```
+
+### Response (Zero Capacity)
+
+```text
+GetProjectedCostResponse:
+  unit_price: 0.096
+  currency: "USD"
+  cost_per_month: 0.0
+  billing_detail: "ASG: 0× m5.large On-demand Linux, 730 hrs/month (zero instances)"
+  metadata:
+    estimate_quality: "high"
+```
+
+### Error Cases
+
+| Condition | Error |
+| --------- | ----- |
+| No instance type resolvable | PricingUnavailableError: "cannot determine instance type for ASG" |
+| Instance type not in pricing data | PricingUnavailableError: "no pricing for instance type X in region Y" |
+| Region mismatch | gRPC error with ERROR_CODE_UNSUPPORTED_REGION |
+
+## GetPricingSpec RPC
+
+### Response
+
+```text
+GetPricingSpecResponse:
+  billing_mode: "on_demand"
+  rate_per_unit: 0.096              # Per-instance hourly rate
+  rate_unit: "per-instance-hour"
+  currency: "USD"
+  notes: "ASG cost = instance hourly rate × desired_capacity × 730 hrs/month"
+```
+
+## GetActualCost RPC
+
+Delegates to GetProjectedCost via `getProjectedForResource`. Same pricing
+logic applies. Actual cost calculation uses runtime hours when available:
+`projected_monthly_cost × runtime_hours / 730`.

--- a/specs/001-asg-estimator/data-model.md
+++ b/specs/001-asg-estimator/data-model.md
@@ -1,0 +1,62 @@
+# Data Model: ASG Cost Estimator
+
+**Feature**: 001-asg-estimator | **Date**: 2026-03-26
+
+## Entities
+
+### ASGAttributes
+
+Extracted from ResourceDescriptor tags for cost calculation.
+
+| Field | Type | Source Priority | Default | Validation |
+| ----- | ---- | --------------- | ------- | ---------- |
+| InstanceType | string | sku → instance_type → launch_template.instance_type → launch_configuration.instance_type | (none — error) | Must be non-empty |
+| DesiredCapacity | int | desired_capacity → desiredCapacity → min_size → minSize | 1 | Must be ≥ 0 |
+| OS | string | operating_system → platform | "Linux" | "Linux", "Windows", "RHEL", "SUSE" |
+
+### ASGConfig (Carbon)
+
+Input to the ASG carbon estimator.
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| InstanceType | string | EC2 instance type (e.g., "m5.large") |
+| Region | string | AWS region for grid emission factor lookup |
+| DesiredCapacity | int | Number of instances |
+| Utilization | float64 | CPU utilization (0.0-1.0), default 0.5 |
+| Hours | float64 | Hours per month (730 production, 160 dev) |
+
+## Relationships
+
+```text
+AutoScalingGroup ──manages──▶ EC2 Instances (desiredCapacity count)
+       │
+       └──references──▶ LaunchTemplate OR LaunchConfiguration (instance type source)
+```
+
+- ASG → EC2: One-to-many. Cost = per-instance × count.
+- ASG → LaunchTemplate: One-to-one. Configuration reference only (zero-cost
+  resource). Instance type extracted from template properties in tags.
+
+## Tag Key Mapping
+
+Maps Pulumi state property names to canonical tag keys used in extraction.
+
+| Pulumi Property | Tag Key (snake_case) | Tag Key (camelCase) |
+| --------------- | -------------------- | ------------------- |
+| desiredCapacity | desired_capacity | desiredCapacity |
+| minSize | min_size | minSize |
+| maxSize | max_size | maxSize |
+| launchTemplate.instanceType | launch_template.instance_type | N/A |
+| launchConfiguration.instanceType | launch_configuration.instance_type | N/A |
+
+## Service Classification Entry
+
+```text
+Key: "aws:autoscaling:autoScalingGroup"
+GrowthType: GROWTH_TYPE_STATIC (fixed cost)
+AffectedByDevMode: true (160 hrs/month in dev)
+ParentTagKeys: ["vpc_id"]
+ParentType: "aws:ec2:vpc:Vpc"
+Relationship: RelationshipWithin
+```

--- a/specs/001-asg-estimator/plan.md
+++ b/specs/001-asg-estimator/plan.md
@@ -1,0 +1,85 @@
+# Implementation Plan: ASG Cost Estimator
+
+**Branch**: `001-asg-estimator` | **Date**: 2026-03-26 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/001-asg-estimator/spec.md`
+
+## Summary
+
+Add a cost estimator for `aws:autoscaling/group:Group` resources that
+delegates to existing EC2 pricing data. The ASG estimator multiplies the
+per-instance on-demand EC2 hourly rate by desired capacity × 730 hours/month.
+No new pricing data is needed — ASGs have no direct AWS charge; cost is
+the aggregate of managed instances. Carbon estimation delegates to the
+existing EC2 carbon estimator, scaled by instance count.
+
+## Technical Context
+
+**Language/Version**: Go 1.25+
+**Primary Dependencies**: finfocus-spec v0.5.6 (pluginsdk, pbc, pbcconnect),
+connectrpc.com/connect v1.19.1, zerolog
+**Storage**: N/A (in-memory pricing data via `//go:embed`)
+**Testing**: Go testing with table-driven tests, integration tests with
+`-tags=integration`
+**Target Platform**: Linux server (gRPC service on 127.0.0.1)
+**Project Type**: Single Go module
+**Performance Goals**: GetProjectedCost RPC < 100ms, Supports < 10ms, startup
+< 500ms
+**Constraints**: No runtime network calls (air-gapped), binary < 250MB,
+memory < 400MB
+**Scale/Scope**: ~200 lines of new estimator code, ~400 lines of tests,
+updates to ~10 existing files, 2 new files
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+| --------- | ------ | ----- |
+| I. Code Quality & Simplicity | PASS | Single-purpose estimator function, no new abstractions. Reuses existing EC2 pricing lookup — no new data structures. |
+| II. Testing Discipline | PASS | Table-driven unit tests for cost calculation, tag extraction, normalization. Integration test for full RPC path. |
+| III. Protocol & Interface Consistency | PASS | Uses proto-defined types only. No stdout logging. gRPC error codes from proto enum. Thread-safe (read-only pricing data). |
+| IV. Performance & Reliability | PASS | No new pricing data parsing. ASG estimate is a map lookup + multiplication — well under 100ms. No binary size increase. |
+| V. Build & Release Quality | PASS | No new build tags. No new embed files. Existing `make lint` and `make test` cover new code. |
+| Security | PASS | No new inputs beyond existing ResourceDescriptor. No network calls. Input validation via existing helpers. |
+
+No violations. No complexity tracking needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-asg-estimator/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 research findings
+├── data-model.md        # Phase 1 data model
+├── quickstart.md        # Phase 1 quickstart guide
+├── contracts/           # Phase 1 API contracts
+│   └── asg-rpc.md       # gRPC contract for ASG RPCs
+└── checklists/
+    └── requirements.md  # Spec quality checklist
+```
+
+### Source Code (repository root)
+
+```text
+internal/
+  plugin/
+    constants.go          # ADD: serviceASG constant
+    projected.go          # ADD: case serviceASG in switch, estimateASG() method
+    supports.go           # ADD: case serviceASG in switch, getSupportedMetrics update
+    pricingspec.go        # ADD: case serviceASG in switch, asgPricingSpec() method
+    actual.go             # ADD: case serviceASG in getProjectedForResource switch
+    classification.go     # ADD: ASG entry in serviceClassifications map
+    arn.go                # UPDATE: autoscaling case to detect ASG vs LaunchConfig
+    asg_attrs.go          # NEW: ASG-specific tag extraction helpers
+  carbon/
+    asg_estimator.go      # NEW: ASG carbon estimator (delegates to EC2)
+    types.go              # ADD: ASGConfig struct
+```
+
+**Structure Decision**: All new code fits within existing package structure.
+One new file in `internal/plugin/` for ASG tag extraction (follows pattern of
+`ec2_attrs.go`). One new file in `internal/carbon/` for ASG carbon estimator
+(follows pattern of `elasticache_estimator.go`). No new packages needed.

--- a/specs/001-asg-estimator/quickstart.md
+++ b/specs/001-asg-estimator/quickstart.md
@@ -1,0 +1,75 @@
+# Quickstart: ASG Cost Estimator
+
+**Feature**: 001-asg-estimator | **Date**: 2026-03-26
+
+## Prerequisites
+
+```bash
+make develop  # Install deps + generate pricing + carbon data
+```
+
+## Build & Test
+
+```bash
+# Build with real pricing (us-east-1)
+make build-default-region
+
+# Run all tests
+make test
+
+# Run ASG-specific tests
+go test -v ./internal/plugin/... -run TestASG
+go test -v ./internal/carbon/... -run TestASG
+
+# Run with region tag for pricing verification
+go test -tags=region_use1 -v ./internal/plugin/... -run TestASG
+
+# Lint
+make lint
+```
+
+## Manual Verification
+
+After building with `make build-default-region`:
+
+```bash
+# Start the plugin
+./bin/finfocus-plugin-aws-public-us-east-1 &
+
+# Test ASG support (via grpcurl)
+grpcurl -plaintext -d '{
+  "resource": {
+    "provider": "aws",
+    "resource_type": "aws:autoscaling/group:Group",
+    "region": "us-east-1"
+  }
+}' localhost:<PORT> finfocus.v1.CostSourceService/Supports
+
+# Test ASG cost estimation
+grpcurl -plaintext -d '{
+  "resource": {
+    "provider": "aws",
+    "resource_type": "aws:autoscaling/group:Group",
+    "sku": "m5.large",
+    "region": "us-east-1",
+    "tags": {
+      "desired_capacity": "3"
+    }
+  }
+}' localhost:<PORT> finfocus.v1.CostSourceService/GetProjectedCost
+```
+
+## Key Files to Modify
+
+| File | Change |
+| ---- | ------ |
+| `internal/plugin/constants.go` | Add `serviceASG` constant |
+| `internal/plugin/projected.go` | Add switch case + `estimateASG()` |
+| `internal/plugin/supports.go` | Add switch case + metrics |
+| `internal/plugin/pricingspec.go` | Add switch case + `asgPricingSpec()` |
+| `internal/plugin/actual.go` | Add switch case in `getProjectedForResource` |
+| `internal/plugin/classification.go` | Add classification entry |
+| `internal/plugin/arn.go` | Update autoscaling ARN case |
+| `internal/plugin/asg_attrs.go` | NEW: Tag extraction helpers |
+| `internal/carbon/asg_estimator.go` | NEW: Carbon estimator |
+| `internal/carbon/types.go` | Add `ASGConfig` struct |

--- a/specs/001-asg-estimator/research.md
+++ b/specs/001-asg-estimator/research.md
@@ -1,0 +1,119 @@
+# Research: ASG Cost Estimator
+
+**Feature**: 001-asg-estimator | **Date**: 2026-03-26
+
+## R1: ASG Pricing Model
+
+**Decision**: ASG cost = EC2 on-demand hourly rate × desired_capacity × 730
+hours/month. No separate ASG pricing data needed.
+
+**Rationale**: AWS Auto Scaling Groups have no direct charge. The cost is
+entirely from the EC2 instances the ASG manages. The plugin already embeds
+full EC2 pricing data, so the ASG estimator simply performs a lookup in the
+existing EC2 price index and multiplies by instance count.
+
+**Alternatives considered**:
+- Fetch separate ASG pricing from AWS API: Rejected — ASGs have no separate
+  pricing SKU in the AWS Price List API.
+- Include EBS root volume cost per instance: Rejected — risks double-counting
+  with separately tracked EBS volumes. The EC2 estimator already has
+  optional root EBS support via tags, but for ASGs this should be
+  opt-in via the individual EC2 resource estimates.
+
+## R2: Instance Type Resolution Strategy
+
+**Decision**: Priority-based resolution: `sku` → `instance_type` tag →
+`launch_template.instance_type` → `launch_configuration.instance_type`.
+Error if none found.
+
+**Rationale**: In real Pulumi stacks, the ASG resource's properties are
+flattened into the tags map. The instance type may appear in several forms:
+- Direct `instance_type` tag (when Pulumi serializes the ASG's
+  `mixedInstancesPolicy.launchTemplate.overrides[0].instanceType`)
+- Nested `launch_template.instance_type` (when the launch template
+  properties are flattened with dot notation)
+- The `sku` field on ResourceDescriptor (when FinFocus Core pre-resolves
+  the instance type)
+
+No reasonable default exists for instance type (unlike capacity, where 1
+is a safe default). A `t3.micro` default would massively underestimate
+costs for production ASGs.
+
+**Alternatives considered**:
+- Default to `t3.micro` when unknown: Rejected — silently wrong is worse
+  than explicit error.
+- Require `sku` field only: Rejected — Pulumi state exports don't
+  populate `sku` for ASG resources.
+
+## R3: Capacity Extraction
+
+**Decision**: `desired_capacity` → `desiredCapacity` (camelCase variant) →
+`min_size` → `minSize` → default 1.
+
+**Rationale**: Pulumi state exports use camelCase (`desiredCapacity`), while
+manual/CLI usage may use snake_case (`desired_capacity`). The fallback to
+`min_size` is reasonable because when `desired_capacity` is absent, `min_size`
+represents the minimum guaranteed fleet size. Default of 1 is the safest
+assumption when no capacity information is available — it represents the
+smallest possible ASG.
+
+**Alternatives considered**:
+- Use `max_size` as fallback: Rejected — would overestimate costs.
+- Error when no capacity: Rejected — unlike instance type, a capacity
+  default of 1 is reasonable and doesn't silently mislead users.
+
+## R4: Carbon Estimation Approach
+
+**Decision**: Delegate to existing EC2 `Estimator.EstimateCarbonGrams()`,
+multiply result by `desired_capacity`. Create an `ASGEstimator` struct
+following the ElastiCache delegation pattern.
+
+**Rationale**: ASG-managed instances are standard EC2 instances. The
+ElastiCache carbon estimator already demonstrates this delegation pattern
+(mapping `cache.m5.large` → `m5.large`, then delegating to EC2). The ASG
+case is even simpler — the instance type is already in EC2 format, so no
+type mapping is needed.
+
+**Alternatives considered**:
+- Inline carbon calculation in the estimator: Rejected — would duplicate
+  the EC2 carbon logic and risk drift.
+- Skip carbon for v1: Rejected — the delegation is trivial and carbon is
+  a differentiating feature.
+
+## R5: Service Normalization and ARN Handling
+
+**Decision**: Add `serviceASG = "asg"` constant. Normalize
+`aws:autoscaling/group:Group` → `"asg"` in `normalizeResourceType()`. Update
+ARN parsing to distinguish ASG from LaunchConfiguration under the
+`autoscaling` service.
+
+**Rationale**: The existing ARN parser already handles the `autoscaling`
+service but only distinguishes LaunchConfigurations. ASG ARNs have
+`resourceType: "autoScalingGroup"`, which currently falls through to
+returning the raw service name `"autoscaling"`. This needs to map to the
+new `serviceASG` constant.
+
+**Alternatives considered**:
+- Reuse `"autoscaling"` as the service constant: Rejected — ambiguous with
+  LaunchConfigurations which are also under the autoscaling service.
+
+## R6: GetPricingSpec Response
+
+**Decision**: Return a PricingSpec response showing the per-instance EC2
+rate with `BillingMode: "on_demand"`, `RateUnit: "per-instance-hour"`,
+and a `notes` field describing the multiplication by desired capacity.
+
+**Rationale**: Follows the pattern of other estimators (EKS, ELB) that
+return the base unit rate in PricingSpec and describe the total calculation
+in notes. This gives consumers enough information to understand how the
+cost was derived without reimplementing the calculation.
+
+## R7: Classification and Growth Type
+
+**Decision**: `GROWTH_TYPE_STATIC` with `AffectedByDevMode: true`.
+Parent tag keys: `["vpc_id"]` with relationship `RelationshipWithin`.
+
+**Rationale**: ASG costs are fixed based on desired capacity (not
+accumulating like S3). Dev mode should apply the 160-hour reduction since
+ASG instances can be scaled down in non-production environments. The VPC
+parent relationship matches the ElastiCache and RDS patterns.

--- a/specs/001-asg-estimator/spec.md
+++ b/specs/001-asg-estimator/spec.md
@@ -1,0 +1,277 @@
+# Feature Specification: ASG Cost Estimator
+
+**Feature Branch**: `001-asg-estimator`
+**Created**: 2026-03-26
+**Status**: Draft
+**Input**: GitHub Issue #295 — feat: Add ASG estimator for aws:autoscaling/group:Group
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Basic ASG Cost Estimation (Priority: P1)
+
+A FinFocus user has an AWS stack containing Auto Scaling Groups. When they run
+cost estimation, the plugin should return a meaningful cost for each ASG based
+on the desired number of instances and the instance type configured in the
+associated launch template or launch configuration. Currently, ASGs return
+"no cost data available," leaving a significant gap in total infrastructure
+cost visibility — especially for EKS-managed node groups that are backed by
+ASGs.
+
+**Why this priority**: ASGs are where real EC2 compute costs live. Without this
+estimator, users undercount their infrastructure costs by the entire compute
+spend of their auto-scaled workloads.
+
+**Independent Test**: Can be fully tested by sending a `GetProjectedCost` RPC
+with `resource_type: "aws:autoscaling/group:Group"`, an instance type in
+tags, and verifying the response contains a non-zero `cost_per_month` equal
+to (EC2 hourly rate × desired capacity × 730 hours).
+
+**Acceptance Scenarios**:
+
+1. **Given** a ResourceDescriptor with `resource_type:
+   "aws:autoscaling/group:Group"` and tags `instance_type: "t3.medium"`,
+   `desired_capacity: "3"`, **When** `GetProjectedCost` is called, **Then**
+   the response returns `cost_per_month` equal to the t3.medium hourly rate ×
+   3 × 730, with `billing_detail` describing the assumptions.
+2. **Given** a ResourceDescriptor with `resource_type: "asg"` and `sku:
+   "m5.large"` and no capacity tags, **When** `GetProjectedCost` is called,
+   **Then** the response defaults `desired_capacity` to 1 and returns the
+   cost for a single m5.large instance, with metadata indicating the default
+   was applied.
+3. **Given** a ResourceDescriptor with `resource_type:
+   "aws:autoscaling/group:Group"` and a region that does not match the
+   plugin binary's embedded region, **When** `Supports` is called, **Then**
+   the response returns `supported: false` with reason "Region not supported
+   by this binary."
+
+---
+
+### User Story 2 — Tag-Based Instance Type Resolution (Priority: P2)
+
+When Pulumi state is used as input, the ASG resource's tags may contain
+instance type information in several forms: directly as `instance_type`, or
+nested within `launch_template` or `launch_configuration` properties
+(serialized as tag map entries). The estimator should resolve the instance
+type from these sources using a priority-based lookup.
+
+**Why this priority**: Real-world Pulumi stacks express instance types through
+launch template references, not directly on the ASG. Without this resolution
+logic, the estimator would fail on most real stacks.
+
+**Independent Test**: Can be tested by sending `GetProjectedCost` with various
+tag configurations (direct `instance_type`, `launch_template.instance_type`,
+`sku` field) and verifying the correct instance type is resolved in each case.
+
+**Acceptance Scenarios**:
+
+1. **Given** tags containing `instance_type: "c5.xlarge"`, **When**
+   `GetProjectedCost` is called, **Then** the instance type "c5.xlarge" is
+   used for pricing lookup.
+2. **Given** tags containing `launch_template.instance_type: "r5.2xlarge"` but
+   no direct `instance_type` tag, **When** `GetProjectedCost` is called,
+   **Then** the instance type "r5.2xlarge" is used for pricing lookup.
+3. **Given** `sku: "t3.small"` on the ResourceDescriptor and no instance type
+   tags, **When** `GetProjectedCost` is called, **Then** "t3.small" is used
+   for pricing lookup.
+4. **Given** no instance type in `sku` or tags, **When** `GetProjectedCost`
+   is called, **Then** the response returns an appropriate error indicating
+   that instance type could not be determined.
+
+---
+
+### User Story 3 — Capacity Tag Extraction with Fallback (Priority: P2)
+
+The estimator should extract the number of instances from `desired_capacity`
+(preferred), falling back to `min_size` if `desired_capacity` is absent. This
+accommodates both Pulumi state exports (which may include `desiredCapacity`
+or `desired_capacity`) and manual ResourceDescriptor construction.
+
+**Why this priority**: Accurate instance count is critical for cost accuracy.
+The fallback chain ensures reasonable estimates even with incomplete data.
+
+**Independent Test**: Can be tested by varying capacity tags and verifying
+the correct multiplier is applied to the per-instance cost.
+
+**Acceptance Scenarios**:
+
+1. **Given** tags `desired_capacity: "5"`, **When** `GetProjectedCost` is
+   called, **Then** the cost is calculated for 5 instances.
+2. **Given** tags `min_size: "2"` with no `desired_capacity`, **When**
+   `GetProjectedCost` is called, **Then** the cost is calculated for 2
+   instances with metadata indicating `desired_capacity` was defaulted from
+   `min_size`.
+3. **Given** no capacity tags at all, **When** `GetProjectedCost` is called,
+   **Then** the cost is calculated for 1 instance with metadata indicating
+   the default was applied.
+
+---
+
+### User Story 4 — Carbon Footprint Estimation (Priority: P3)
+
+The ASG estimator should provide carbon footprint estimates by delegating
+to the existing EC2 carbon estimator, multiplied by the number of instances.
+This follows the same delegation pattern used by ElastiCache.
+
+**Why this priority**: Carbon estimation is a differentiating feature of
+FinFocus. Since ASGs manage EC2 instances, the carbon calculation is
+straightforward — delegate to EC2 carbon per instance × count.
+
+**Independent Test**: Can be tested by verifying that `ImpactMetrics` in the
+response contains a `METRIC_KIND_CARBON_FOOTPRINT` entry with a value equal
+to (single-instance carbon × desired capacity).
+
+**Acceptance Scenarios**:
+
+1. **Given** a ResourceDescriptor for an ASG with `instance_type: "m5.large"`
+   and `desired_capacity: "3"` in a region with known grid emission factors,
+   **When** `GetProjectedCost` is called, **Then** the response includes
+   `ImpactMetrics` with carbon footprint equal to 3× the m5.large carbon
+   estimate.
+2. **Given** an ASG in a region without grid emission data, **When**
+   `GetProjectedCost` is called, **Then** the response omits carbon metrics
+   gracefully (no error).
+
+---
+
+### User Story 5 — Supports and Service Discovery (Priority: P2)
+
+The plugin should correctly advertise support for ASG resources through the
+`Supports` RPC, including both Pulumi-format
+(`aws:autoscaling/group:Group`) and short-form (`asg`, `autoscaling`)
+resource types.
+
+**Why this priority**: Without proper `Supports` registration, FinFocus Core
+will not route ASG resources to this plugin.
+
+**Independent Test**: Can be tested by calling `Supports` with various ASG
+resource type formats and verifying `supported: true` with appropriate
+metrics advertisement.
+
+**Acceptance Scenarios**:
+
+1. **Given** `resource_type: "aws:autoscaling/group:Group"` with a matching
+   region, **When** `Supports` is called, **Then** the response returns
+   `supported: true` with carbon footprint in `supported_metrics`.
+2. **Given** `resource_type: "asg"` with a matching region, **When**
+   `Supports` is called, **Then** the response returns `supported: true`.
+
+---
+
+### Edge Cases
+
+- What happens when `desired_capacity` is 0? The estimator returns $0 cost
+  with billing detail noting zero instances.
+- What happens when the instance type is not found in embedded pricing data?
+  The estimator returns a `PricingUnavailableError` with a clear message.
+- What happens when `desired_capacity` is negative or non-numeric? The
+  estimator uses the validation helper pattern to log a warning and default
+  to 1.
+- What happens when both `sku` and `instance_type` tag are present but
+  differ? The `sku` field takes priority (consistent with EC2 estimator
+  behavior).
+- What happens when `mixed_instances_policy` tags are present? For v1, the
+  estimator uses the primary instance type only and notes in `billing_detail`
+  that mixed instance policies are not yet supported.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST estimate ASG costs by multiplying per-instance EC2
+  on-demand pricing by the desired instance count.
+- **FR-002**: System MUST resolve instance type from ResourceDescriptor using
+  priority: `sku` field → `instance_type` tag → `launch_template.instance_type`
+  tag → `launch_configuration.instance_type` tag.
+- **FR-003**: System MUST resolve instance count from tags using priority:
+  `desired_capacity`/`desiredCapacity` → `min_size`/`minSize` → default of 1.
+- **FR-004**: System MUST support Pulumi-format resource type
+  `aws:autoscaling/group:Group` and short-form types `asg` and `autoscaling`.
+- **FR-005**: System MUST return `PricingUnavailableError` when instance type
+  cannot be determined from any source.
+- **FR-006**: System MUST track all applied defaults (capacity, instance type
+  source) in response `Metadata` using the `DefaultsTracker` pattern.
+- **FR-007**: System MUST include carbon footprint estimation in
+  `ImpactMetrics` by delegating to the EC2 carbon estimator, scaled by
+  instance count.
+- **FR-008**: System MUST advertise `METRIC_KIND_CARBON_FOOTPRINT` in
+  `Supports` response for ASG resources.
+- **FR-009**: System MUST classify ASG with `GROWTH_TYPE_STATIC` growth hint
+  and `AffectedByDevMode: true` in service classifications.
+- **FR-010**: System MUST handle zero `desired_capacity` gracefully, returning
+  $0 cost without error.
+- **FR-011**: System MUST include `billing_detail` describing assumptions:
+  instance type, count, on-demand pricing, 730 hours/month.
+- **FR-012**: System MUST handle ASG resources in `GetActualCost`,
+  `GetPricingSpec`, and `Supports` RPCs consistently (two-step normalization
+  pattern).
+
+### Key Entities
+
+- **Auto Scaling Group**: A resource that manages a fleet of EC2 instances.
+  Key attributes: desired capacity, min/max size, instance type (via launch
+  template/configuration reference). Has no direct AWS charge — cost is
+  represented by the aggregate of managed instances.
+- **Launch Template / Launch Configuration**: Configuration-only resources
+  (already handled as zero-cost) that define the instance type, AMI, and
+  other parameters for instances launched by an ASG.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: ASG resources return accurate cost estimates matching the
+  formula: EC2 on-demand hourly rate × desired capacity × 730, with less
+  than 1% deviation from manual calculation.
+- **SC-002**: All supported resource type formats
+  (`aws:autoscaling/group:Group`, `asg`, `autoscaling`) produce identical
+  cost estimates for the same configuration.
+- **SC-003**: Users see ASG costs reflected in total infrastructure estimates
+  instead of "no cost data available."
+- **SC-004**: Carbon footprint estimates for ASGs are proportional to instance
+  count and consistent with standalone EC2 carbon estimates for the same
+  instance type.
+- **SC-005**: Default tracking metadata enables downstream consumers to
+  distinguish "real configuration" from "estimated defaults" for cost diff
+  accuracy.
+- **SC-006**: Plugin initialization and ASG cost estimation complete within
+  existing performance budgets (startup < 1s, RPC < 100ms).
+
+## Assumptions
+
+- **A-001**: ASG costs are estimated using on-demand pricing only. Spot
+  instances, mixed instance policies, and capacity reservations are out of
+  scope for v1.
+- **A-002**: The ASG estimator does not need separate pricing data from AWS.
+  It reuses the existing EC2 pricing data already embedded in the binary.
+- **A-003**: When no instance type can be resolved, the estimator returns an
+  error rather than guessing a default instance type — there is no
+  reasonable universal default.
+- **A-004**: `desiredCapacity` represents the steady-state instance count for
+  cost estimation purposes, even though actual ASG scaling may vary.
+- **A-005**: The `operating_system` tag (if present) is passed through to
+  EC2 pricing lookup; otherwise defaults to Linux (consistent with EC2
+  estimator).
+- **A-006**: Root EBS volume costs are NOT included in ASG estimates to avoid
+  double-counting — users should estimate EBS volumes separately if needed.
+
+## Scope Boundaries
+
+### In Scope
+
+- ASG cost estimation via EC2 pricing delegation
+- Instance type resolution from multiple tag sources
+- Capacity extraction with fallback chain
+- Carbon footprint estimation
+- Service registration (Supports, normalization, classification)
+- DefaultsTracker metadata for applied defaults
+- All RPC paths (GetProjectedCost, GetActualCost, GetPricingSpec, Supports)
+
+### Out of Scope
+
+- Spot instance pricing or mixed instance policies
+- Auto-scaling behavior simulation (scaling policies, scheduled actions)
+- Correlation with CloudWatch metrics for actual utilization
+- EBS volume costs for ASG-managed instances (separate resource)
+- Network costs (data transfer, NAT Gateway) for ASG instances
+- GetRecommendations RPC path (ASG-specific recommendations are out of scope
+  for v1; batch processing logic does not require ASG awareness)

--- a/specs/001-asg-estimator/tasks.md
+++ b/specs/001-asg-estimator/tasks.md
@@ -1,0 +1,280 @@
+# Tasks: ASG Cost Estimator
+
+**Input**: Design documents from `/specs/001-asg-estimator/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md,
+data-model.md, contracts/
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No project initialization needed — existing Go module. This
+phase verifies the development environment is ready.
+
+- [x] T001 Verify development environment with `make develop` and
+  `make build-default-region`
+
+---
+
+## Phase 2: Foundational (Service Registration)
+
+**Purpose**: Register ASG as a recognized service type across all
+normalization and detection paths. MUST complete before any estimator work.
+
+- [x] T002 Add `serviceASG = "asg"` constant in
+  `internal/plugin/constants.go` alongside existing service constants
+  (after `serviceLaunchConfig`)
+- [x] T003 Add ASG normalization in `normalizeResourceType()` in
+  `internal/plugin/projected.go` to map
+  `aws:autoscaling/group:Group` → `serviceASG`
+- [x] T004 Add ASG detection in `detectService()` in
+  `internal/plugin/projected.go` to map `"asg"` and `"autoscaling"`
+  short-forms → `serviceASG`
+- [x] T005 [P] Update autoscaling ARN case in `ToPulumiResourceType()` in
+  `internal/plugin/arn.go` to return `serviceASG` for
+  `resourceType: "autoScalingGroup"` (existing code only handles
+  `launchConfiguration`)
+
+**Checkpoint**: `normalizeResourceType("aws:autoscaling/group:Group")`
+returns `"asg"` and `detectService("asg")` returns `serviceASG`
+
+---
+
+## Phase 3: User Story 1 — Basic ASG Cost Estimation (Priority: P1) MVP
+
+**Goal**: ASG resources return cost estimates based on EC2 pricing ×
+desired capacity
+
+**Independent Test**: Send `GetProjectedCost` with
+`resource_type: "aws:autoscaling/group:Group"`, `sku: "t3.medium"`,
+`desired_capacity: "3"` and verify `cost_per_month` equals t3.medium
+hourly rate × 3 × 730
+
+### Implementation for User Story 1
+
+- [x] T006 [P] [US1] [US2] [US3] Create `internal/plugin/asg_attrs.go` with
+  `ExtractASGAttributes()` function that returns `ASGAttributes` struct
+  containing: `InstanceType` (string), `DesiredCapacity` (int), `OS`
+  (string). Implement instance type resolution priority (US2): `sku` →
+  `instance_type` tag → `launch_template.instance_type` tag →
+  `launch_configuration.instance_type` tag. Implement capacity resolution
+  (US3): `desired_capacity` → `desiredCapacity` → `min_size` → `minSize` →
+  default 1. Track defaults via `DefaultsTracker`. Return error when no
+  instance type found.
+- [x] T007 [P] [US1] [US2] [US3] Add unit tests for
+  `ExtractASGAttributes()` in `internal/plugin/asg_attrs_test.go` with
+  table-driven tests covering: sku priority over tags, launch_template
+  fallback, launch_configuration fallback, no instance type error (US2),
+  desired_capacity extraction, min_size fallback, camelCase variants
+  (desiredCapacity, minSize), default capacity of 1, zero capacity,
+  negative/non-numeric capacity (US3), operating_system tag passthrough,
+  default OS Linux
+- [x] T008 [US1] Add `estimateASG()` method on `AWSPublicPlugin` in
+  `internal/plugin/projected.go`. Function signature:
+  `func (p *AWSPublicPlugin) estimateASG(traceID string, resource *pbc.ResourceDescriptor, req *pbc.GetProjectedCostRequest) (*pbc.GetProjectedCostResponse, error)`.
+  Call `ExtractASGAttributes()`, look up EC2 pricing with
+  `p.pricing.EC2OnDemandPricePerHour()`, calculate
+  `cost = hourlyRate × desiredCapacity × 730`, build `billing_detail`
+  string: `"ASG: N× <type> On-demand <OS>, 730 hrs/month"`, return
+  `PricingUnavailableError` when instance type not found or not in pricing
+  data. Handle zero capacity returning $0 gracefully. Include
+  `DefaultsTracker` metadata in response. Call `setGrowthHint()` on
+  response to apply growth type metadata (FR-009). If
+  `mixed_instances_policy` tags are detected, note in `billing_detail`
+  that mixed instance policies are not yet supported.
+- [x] T009 [US1] Add `case serviceASG:` to the `GetProjectedCost` switch
+  in `internal/plugin/projected.go` routing to
+  `p.estimateASG(traceID, resource, req)`
+- [x] T010 [US1] Add unit tests for `estimateASG()` in
+  `internal/plugin/projected_test.go` with table-driven tests covering:
+  basic cost calculation (verify rate × count × 730), zero capacity
+  returns $0, missing instance type returns error, unknown instance type
+  returns PricingUnavailableError, billing_detail format verification,
+  metadata defaults tracking, all resource type formats produce same
+  result
+
+**Checkpoint**: `GetProjectedCost` with ASG resource type returns correct
+cost. Run `go test ./internal/plugin/... -run TestASG` — all pass.
+
+---
+
+## Phase 4: User Story 5 — Supports and Service Discovery (Priority: P2)
+
+**Goal**: Plugin advertises ASG support through Supports RPC, handles ASG
+in GetPricingSpec, GetActualCost, and classification
+
+**Independent Test**: Call `Supports` with
+`resource_type: "aws:autoscaling/group:Group"` and verify
+`supported: true` with carbon footprint in `supported_metrics`
+
+### Implementation for User Story 5
+
+- [x] T011 [P] [US5] Add ASG entry to `serviceClassifications` map in
+  `internal/plugin/classification.go` with key
+  `"aws:autoscaling:autoScalingGroup"`, `GrowthType:
+  GROWTH_TYPE_STATIC`, `AffectedByDevMode: true`, `ParentTagKeys:
+  ["vpc_id"]`, `ParentType: "aws:ec2:vpc:Vpc"`, `Relationship:
+  RelationshipWithin`
+- [x] T012 [P] [US5] Add `case serviceASG:` to the `Supports` switch in
+  `internal/plugin/supports.go` routing to return `supported: true` with
+  `getSupportedMetrics(serviceASG)`. Add `serviceASG` to the
+  carbon-capable services case in `getSupportedMetrics()`
+- [x] T013 [P] [US5] Add `asgPricingSpec()` method and `case serviceASG:`
+  to the `GetPricingSpec` switch in `internal/plugin/pricingspec.go`.
+  Return `BillingMode: "on_demand"`, `RateUnit: "per-instance-hour"`,
+  with notes describing the ASG cost formula
+- [x] T014 [P] [US5] Add `case serviceASG:` to the
+  `getProjectedForResource` switch in `internal/plugin/actual.go`
+  routing to the ASG estimator
+- [x] T015 [US5] Add unit tests for ASG service discovery in
+  `internal/plugin/supports_test.go`: verify Supports returns true for
+  `"aws:autoscaling/group:Group"`, `"asg"`, and `"autoscaling"` with
+  carbon metric advertised. Add test in `internal/plugin/pricingspec_test.go`
+  for ASG PricingSpec response format. Add test in
+  `internal/plugin/classification_test.go` verifying ASG classification
+  entry exists with correct growth type. Add test in
+  `internal/plugin/actual_test.go` verifying `getProjectedForResource`
+  routes ASG resources correctly through GetActualCost (dual-path coverage
+  per CLAUDE.md convention)
+
+**Checkpoint**: All 4 RPC paths (Supports, GetProjectedCost, GetPricingSpec,
+GetActualCost) handle ASG resources consistently.
+
+---
+
+## Phase 5: User Story 4 — Carbon Footprint Estimation (Priority: P3)
+
+**Goal**: ASG responses include carbon footprint metrics by delegating to
+EC2 carbon estimator × instance count
+
+**Independent Test**: Send `GetProjectedCost` for ASG with
+`instance_type: "m5.large"`, `desired_capacity: "3"` and verify
+`ImpactMetrics` contains `METRIC_KIND_CARBON_FOOTPRINT` with value
+equal to 3× the m5.large single-instance carbon
+
+### Implementation for User Story 4
+
+- [x] T016 [P] [US4] Add `ASGConfig` struct to `internal/carbon/types.go`
+  with fields: `InstanceType string`, `Region string`,
+  `DesiredCapacity int`, `Utilization float64`, `Hours float64`
+- [x] T017 [P] [US4] Create `internal/carbon/asg_estimator.go` with
+  `ASGEstimator` struct and `EstimateCarbonGrams(config ASGConfig)
+  (float64, bool)` method. Delegate to `NewEstimator()` for single-instance
+  carbon, multiply by `DesiredCapacity`. Return `(0, false)` when EC2
+  estimator returns false. Follow ElastiCache delegation pattern.
+- [x] T018 [US4] Add carbon estimation call to `estimateASG()` in
+  `internal/plugin/projected.go`. After cost calculation, create
+  `ASGConfig`, call `ASGEstimator.EstimateCarbonGrams()`, and if
+  successful, append `ImpactMetric` with
+  `METRIC_KIND_CARBON_FOOTPRINT` to response
+- [x] T019 [US4] Add unit tests for ASG carbon estimation in
+  `internal/carbon/asg_estimator_test.go` with table-driven tests:
+  single instance carbon matches EC2 estimator, multi-instance carbon
+  scales linearly, unknown instance type returns false, zero capacity
+  returns 0 carbon, utilization parameter is passed through correctly
+
+**Checkpoint**: `GetProjectedCost` for ASG includes `ImpactMetrics` with
+carbon footprint proportional to instance count.
+
+---
+
+## Phase 6: Polish and Cross-Cutting Concerns
+
+**Purpose**: Validation, documentation, and quality gates
+
+- [x] T020 Run `make test` to verify all existing and new tests pass
+- [x] T021 Run `make lint` to verify no linting issues (use extended
+  timeout)
+- [x] T022 Run `go test -tags=region_use1 ./internal/plugin/... -run
+  TestASG` to verify ASG estimation with real pricing data
+- [x] T023 Update CLAUDE.md estimation logic section to document ASG
+  estimator (resource_type, sku, tags, formula, billing_detail format)
+- [x] T024 Update ROADMAP.md to move ASG Estimator (#295) from Future
+  Vision to Completed Milestones Q1 2026
+
+---
+
+## Dependencies and Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — verify environment
+- **Foundational (Phase 2)**: Depends on Phase 1 — registers ASG as a
+  known service type. BLOCKS all user story phases.
+- **US1 (Phase 3)**: Depends on Phase 2 — core estimation logic
+- **US5 (Phase 4)**: Depends on Phase 2 — can run in parallel with US1
+  (different files) but T014 depends on T008 (estimateASG must exist
+  for actual.go routing)
+- **US4 (Phase 5)**: Depends on Phase 3 (T008 — estimateASG must exist
+  to add carbon call) and Phase 4 (T012 — carbon metric must be
+  advertised in Supports)
+- **Polish (Phase 6)**: Depends on all user stories complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Requires Phase 2 only — MVP
+- **US5 (P2)**: Requires Phase 2 + T008 from US1 (for actual.go routing)
+- **US4 (P3)**: Requires T008 (estimateASG) + T012 (carbon in Supports)
+
+### Within Each Phase
+
+- Tasks marked [P] can run in parallel (different files)
+- T006 and T007 can run in parallel (implementation + tests in separate files)
+- T011, T012, T013, T014 can ALL run in parallel (4 different files)
+- T016 and T017 can run in parallel (types.go + estimator in separate files)
+
+### Parallel Opportunities
+
+```text
+# Phase 2: All foundational tasks are sequential (same files: projected.go, constants.go)
+# Except T005 (arn.go) can run in parallel with T002-T004
+
+# Phase 3: Tag extraction and tests in parallel
+Parallel: T006 (asg_attrs.go) + T007 (asg_attrs_test.go)
+Sequential: T008 (estimateASG) → T009 (switch case) → T010 (tests)
+
+# Phase 4: All 4 registration tasks in parallel (different files)
+Parallel: T011 (classification.go) + T012 (supports.go) + T013 (pricingspec.go) + T014 (actual.go)
+Sequential: T015 (tests after all registrations)
+
+# Phase 5: Type + estimator in parallel, then integration
+Parallel: T016 (types.go) + T017 (asg_estimator.go)
+Sequential: T018 (integrate into projected.go) → T019 (tests)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Verify environment
+2. Complete Phase 2: Register ASG service type (T002-T005)
+3. Complete Phase 3: Core ASG estimation (T006-T010)
+4. **STOP and VALIDATE**: Run `go test ./internal/plugin/... -run TestASG`
+5. ASG resources now return cost estimates — MVP complete
+
+### Incremental Delivery
+
+1. Phase 2 → Foundation ready (ASG recognized as service)
+2. Phase 3 (US1) → Core estimation works → MVP
+3. Phase 4 (US5) → Full RPC coverage (Supports, PricingSpec, ActualCost)
+4. Phase 5 (US4) → Carbon estimation added
+5. Phase 6 → Polish, docs, validation
+
+---
+
+## Notes
+
+- No new embed files or pricing data needed — ASG reuses EC2 pricing
+- No binary size increase — this feature adds only Go source code
+- The `estimateASG` function signature includes `req` parameter for future
+  dev mode support (utilization percentage)
+- All tag key lookups should check both snake_case and camelCase variants
+- Follow the two-step normalization pattern (CLAUDE.md) in ALL code paths


### PR DESCRIPTION
## Summary

- Estimates ASG monthly cost by multiplying EC2 on-demand hourly rate by desired capacity and 730 hours/month
- No new pricing data needed; ASGs delegate entirely to existing EC2 pricing lookups
- Instance type resolved from priority chain: sku field, instance_type tag, launch_template, launch_configuration
- Desired capacity resolved from tags with snake_case and camelCase variants, defaulting to 1
- Carbon footprint estimation delegates to EC2 carbon estimator scaled by instance count
- SKU validation bypassed for ASG since instance type is resolved from tags (new `allowsEmptySKU` pattern)
- DefaultsTracker metadata reports estimate quality when capacity or OS defaults are applied

## Test plan

- [x] `go test ./...` passes (all packages)
- [x] `make lint` passes (only pre-existing router issues)
- [x] `go test -tags=region_use1 ./internal/plugin/... -run TestASG` passes with real pricing data
- [x] All resource type formats produce consistent results: `aws:autoscaling/group:Group`, `asg`, `autoscaling`
- [x] Dual-path coverage: GetProjectedCost and GetActualCost both route ASG resources correctly
- [x] Carbon estimation scales linearly with instance count
- [x] Zero capacity returns $0 with appropriate billing detail
- [x] Missing instance type returns PricingUnavailableError

## Changes

### New files

- `internal/plugin/asg_attrs.go` - ASG tag extraction with priority-based instance type and capacity resolution
- `internal/plugin/asg_attrs_test.go` - 17 table-driven tests for tag extraction
- `internal/carbon/asg_estimator.go` - Carbon estimator delegating to EC2 estimator scaled by desired capacity
- `internal/carbon/asg_estimator_test.go` - 5 tests for carbon scaling, unknown types, and utilization passthrough
- `internal/plugin/classification_test.go` - Classification entry verification for ASG growth type and relationships

### Modified files

- `internal/plugin/constants.go` - Added `serviceASG` constant
- `internal/plugin/projected.go` - Added `estimateASG()`, normalization in `normalizeResourceType()`, detection in `detectService()`, and switch case routing
- `internal/plugin/supports.go` - Added ASG to supported services with carbon metrics advertisement
- `internal/plugin/pricingspec.go` - Added `asgPricingSpec()` returning on_demand billing mode with per-instance-hour unit
- `internal/plugin/actual.go` - Added ASG routing in `getProjectedForResource` switch
- `internal/plugin/classification.go` - Added ASG entry with GROWTH_TYPE_STATIC, dev mode affected, VPC parent
- `internal/plugin/arn.go` - Updated autoscaling ARN case to distinguish autoScalingGroup from launchConfiguration
- `internal/plugin/validation.go` - Added `allowsEmptySKU()` for services resolving identifiers from tags; removed unused `isZeroCostResource` and `isZeroCostResourceWithResolver`

### Housekeeping

- `CLAUDE.md` - Documented ASG estimator in service support list, estimation logic, and cost estimation scope table
- `ROADMAP.md` - Moved ASG estimator from Future Vision to Completed Milestones Q1 2026

Closes #295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ASG cost estimation: monthly = EC2 on‑demand hourly rate × desired_capacity × 730; carbon = per‑instance carbon × desired_capacity. ASG is now a supported service with carbon metric support. Billing details summarize count, resolved instance type and OS; zero‑capacity and mixed‑instances notes are included. Instance type/capacity/OS resolved from sku, tags or launch configuration. Tag‑resolved ASG requests require a region.

* **Documentation**
  * Docs and roadmap updated with ASG pricing semantics, defaults, exclusions, billing template and carbon guidance.

* **Tests**
  * Added comprehensive tests covering ASG pricing, carbon, attribute resolution, routing, support and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->